### PR TITLE
Fix TypeScript errors in testing1 document

### DIFF
--- a/src/lib/documents/us/testing1/index.ts
+++ b/src/lib/documents/us/testing1/index.ts
@@ -1,4 +1,4 @@
-// src/lib/documents/us/"first-second-third-fourth"/index.ts
-export { "firstSecondThirdFourth"Meta as "firstSecondThirdFourth" } from './metadata';
+// src/lib/documents/us/testing1/index.ts
+export { firstSecondMeta as testing1 } from './metadata';
 export * from './schema';
 export * from './questions';

--- a/src/lib/documents/us/testing1/metadata.ts
+++ b/src/lib/documents/us/testing1/metadata.ts
@@ -1,6 +1,25 @@
-// src/lib/documents/us/first-second/metadata.ts
+// src/lib/documents/us/testing1/metadata.ts
 import type { LegalDocument } from '@/types/documents';
 import { FirstSecondSchema } from './schema';
 import { firstSecondQuestions } from './questions';
 
 export const firstSecondMeta: LegalDocument = {
+  id: 'testing1',
+  jurisdiction: 'US',
+  category: 'General',
+  languageSupport: ['en', 'es'],
+  basePrice: 0,
+  requiresNotarization: false,
+  canBeRecorded: false,
+  offerNotarization: false,
+  offerRecordingHelp: false,
+  states: 'all',
+  templatePath: '/templates/en/testing1.md',
+  templatePath_es: '/templates/es/testing1.md',
+  schema: FirstSecondSchema,
+  questions: firstSecondQuestions,
+  translations: {
+    en: { name: 'Testing1', description: 'Placeholder document', aliases: [] },
+    es: { name: 'Testing1', description: 'Documento de prueba', aliases: [] }
+  }
+};

--- a/src/lib/documents/us/testing1/questions.ts
+++ b/src/lib/documents/us/testing1/questions.ts
@@ -1,3 +1,12 @@
 import { usStates } from '@/lib/usStates';
 
 export const firstSecondQuestions = [
+  { id: 'fullName', label: 'Full Name', type: 'text', required: true },
+  {
+    id: 'state',
+    label: 'State',
+    type: 'select',
+    required: true,
+    options: usStates.map((s) => ({ value: s.value, label: s.label }))
+  }
+];

--- a/src/lib/documents/us/testing1/schema.ts
+++ b/src/lib/documents/us/testing1/schema.ts
@@ -1,10 +1,9 @@
-// src/lib/documents/us/first-second/schema.ts
+// src/lib/documents/us/testing1/schema.ts
 import { z } from 'zod';
-// Assuming your main schema is in src/schemas/
-import { FirstSecondNoteSchema as MainFirstSecondSchema } from '@/schemas/first-second'; 
 
-// Re-export the schema to ensure it's a ZodObject for LegalDocument type compatibility
-export const FirstSecondSchema: z.ZodObject<any, any, any> = MainFirstSecondSchema;
+export const FirstSecondSchema = z.object({
+  fullName: z.string().min(1),
+  state: z.string().length(2)
+});
 
-// Export the inferred type if needed elsewhere, though WizardForm infers directly
 export type FirstSecondData = z.infer<typeof FirstSecondSchema>;


### PR DESCRIPTION
## Summary
- complete the `testing1` document files to resolve syntax errors
- include simple schema, metadata and question setup

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*