### PR TITLE
Enable SSR and preload dynamic modules

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -24,28 +24,23 @@ const LoadingSpinner = () => (
 
 // Dynamically import components
 const HowItWorks = dynamic(() => import('@/components/landing/HowItWorks'), {
-  loading: () => <LoadingSpinner />,
-  ssr: false
+  loading: () => <LoadingSpinner />
 });
 
 const TrustAndTestimonialsSection = dynamic(() => import('@/components/landing/TrustAndTestimonialsSection'), {
-  loading: () => <LoadingSpinner />,
-  ssr: false
+  loading: () => <LoadingSpinner />
 });
 
 const GuaranteeBadge = dynamic(() => import('@/components/landing/GuaranteeBadge').then(mod => mod.GuaranteeBadge), {
-  loading: () => <LoadingSpinner />,
-  ssr: false
+  loading: () => <LoadingSpinner />
 });
 
 const TopDocsChips = dynamic(() => import('@/components/TopDocsChips'), {
-  loading: () => <LoadingSpinner />,
-  ssr: false
+  loading: () => <LoadingSpinner />
 });
 
 const StickyFilterBar = dynamic(() => import('@/components/StickyFilterBar'), {
-  loading: () => <div className="h-16 bg-muted" />, // Placeholder for filter bar height
-  ssr: false
+  loading: () => <div className="h-16 bg-muted" /> // Placeholder for filter bar height
 });
 
 export default function HomePageClient() {
@@ -65,6 +60,15 @@ export default function HomePageClient() {
 
   useEffect(() => {
     setIsHydrated(true);
+  }, []);
+
+  // Preload dynamically imported sections once on the client
+  useEffect(() => {
+    HowItWorks.preload();
+    TrustAndTestimonialsSection.preload();
+    GuaranteeBadge.preload();
+    TopDocsChips.preload();
+    StickyFilterBar.preload();
   }, []);
 
   const workflowSectionId = "workflow-start";

--- a/src/app/[locale]/docs/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/DocPageClient.tsx
@@ -15,7 +15,6 @@ import { Separator } from '@/components/ui/separator';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const DocumentDetail = dynamic(() => import('@/components/DocumentDetail'), {
-  ssr: false,
   loading: () => (
     <div className="flex items-center justify-center border rounded-lg bg-muted p-4 aspect-[8.5/11] max-h-[500px] md:max-h-[700px] w-full shadow-lg">
       <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -58,6 +57,14 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
   useEffect(() => {
     setIsHydrated(true);
   }, []);
+
+  // Preload detail component and next step route for quicker interactions
+  useEffect(() => {
+    DocumentDetail.preload();
+    if (docId && currentLocale) {
+      router.prefetch(`/${currentLocale}/docs/${docId}/start`);
+    }
+  }, [router, docId, currentLocale]);
 
   useEffect(() => {
     if (isHydrated) { // Ensure this runs only after hydration

--- a/src/components/providers/ClientProviders.tsx
+++ b/src/components/providers/ClientProviders.tsx
@@ -23,12 +23,10 @@ const FooterSkeleton = () => <div className="h-40 bg-muted animate-pulse"></div>
 // Dynamically import Header and Footer
 const DynamicHeader = dynamic(() => import('@/components/layout/Header'), {
   loading: () => <HeaderSkeleton />,
-  ssr: false, 
 });
 
 const DynamicFooter = dynamic(() => import('@/components/layout/Footer').then(mod => mod.Footer), {
   loading: () => <FooterSkeleton />,
-  ssr: false, 
 });
 
 


### PR DESCRIPTION
## Summary
- remove `ssr: false` from dynamic imports so components render on the server
- preload heavy dynamic sections in `HomePageClient`
- preload `DocumentDetail` and prefetch the wizard route in `DocPageClient`

## Testing
- `npm test`