### PR TITLE
Add missing breadcrumb translations

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -325,6 +325,8 @@
   "Authentication Required": "Authentication Required",
   "Please sign in or create an account to save your document and proceed to payment.": "Please sign in or create an account to save your document and proceed to payment.",
   "Home": "Home",
+  "breadcrumb.home": "Home",
+  "breadcrumb.start": "Start",
   "Create": "Create",
   "What do you want to accomplish?": "What do you want to accomplish?",
   "stepOne.categoryDescription": "Select a category to find the document you need, or use the search bar.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -324,6 +324,8 @@
   "Authentication Required": "Autenticación Requerida",
   "Please sign in or create an account to save your document and proceed to payment.": "Por favor, inicia sesión o crea una cuenta para guardar tu documento y proceder al pago.",
   "Home": "Inicio",
+  "breadcrumb.home": "Inicio",
+  "breadcrumb.start": "Empezar",
   "Create": "Crear",
   "What do you want to accomplish?": "¿Qué quieres lograr?",
   "stepOne.categoryDescription": "Selecciona una categoría para encontrar el documento que necesitas, o usa la barra de búsqueda.",


### PR DESCRIPTION
## Summary
- add `breadcrumb.home` and `breadcrumb.start` translations in EN and ES locales

## Testing
- `npm test`
