### PR TITLE
Make Live Preview background white

### DIFF
--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -210,7 +210,7 @@ export default function StartWizardPageClient() {
               <h3 className="text-xl font-semibold mb-4 text-center text-card-foreground shrink-0 hidden lg:block">
                 {t('Live Preview')}
               </h3>
-              <div className="flex-grow overflow-hidden rounded-lg shadow-md border border-border bg-background">
+              <div className="flex-grow overflow-hidden rounded-lg shadow-md border border-border bg-card">
                  <PreviewPane docId={docIdFromPath} locale={locale} />
               </div>
             </div>

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -157,10 +157,10 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
       <div
         id="live-preview"
         data-watermark={watermarkText}
-        className="relative w-full h-full bg-background rounded-lg overflow-hidden"
+        className="relative w-full h-full bg-card text-card-foreground rounded-lg overflow-hidden"
         style={{ userSelect: 'none' }}
       >
-        <div className={cn("prose prose-sm dark:prose-invert max-w-none w-full h-full overflow-y-auto overflow-x-hidden p-4 md:p-6 scrollbar-hide bg-background text-foreground")}>
+        <div className={cn("prose prose-sm max-w-none w-full h-full overflow-y-auto overflow-x-hidden p-4 md:p-6 scrollbar-hide bg-card text-card-foreground")}>
           <ReactMarkdown 
               remarkPlugins={[remarkGfm]}
               components={{ 
@@ -180,7 +180,7 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
       <div
         id="live-preview"
         data-watermark={watermarkText}
-        className="relative w-full h-full bg-background rounded-lg overflow-hidden"
+        className="relative w-full h-full bg-card text-card-foreground rounded-lg overflow-hidden"
         style={{ userSelect: 'none' }}
       >
         <Image


### PR DESCRIPTION
## Summary
- adjust Start Wizard page preview container to use white background
- update PreviewPane component background classes to show document on white

## Testing
- `npm test`
