### PR TITLE
Implement dashboard data fetching

### DIFF
--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -9,7 +9,8 @@ import { Label } from '@/components/ui/label';
 import { FileText, CreditCard, UserCircle, Settings, LogOut, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { useAuth } from '@/hooks/useAuth';
-import { useRouter } from 'next/navigation'; 
+import { useRouter } from 'next/navigation';
+import { getUserDocuments, getUserPayments } from '@/lib/firestore/dashboardData';
 
 // Define a more specific type for Firestore Timestamps if that's what you use
 interface FirestoreTimestamp {
@@ -38,30 +39,9 @@ interface DashboardClientContentProps {
   locale: 'en' | 'es';
 }
 
-// --- Placeholder Firestore Data Fetching Functions ---
-// You MUST replace these with your actual Firestore implementation.
-
-async function getRecentDocsForUser(userId: string): Promise<DocumentData[]> {
-  console.log(`[Firestore MOCK] Fetching recent documents for user ${userId}...`);
-  await new Promise(resolve => setTimeout(resolve, 500)); // Simulate network delay
-  // Example structure - ensure your actual function returns this structure
-  // return [
-  //   { id: 'mockDoc1', name: 'Mock Lease Agreement', date: new Date().toISOString(), status: 'Draft', docType: 'lease-agreement' },
-  //   { id: 'mockDoc2', name: 'Mock NDA', date: new Date(Date.now() - 86400000 * 5).toISOString(), status: 'Signed', docType: 'nda' },
-  // ];
-  return []; // Default to empty for now
-}
-
-async function getPaymentHistoryForUser(userId: string): Promise<PaymentData[]> {
-  console.log(`[Firestore MOCK] Fetching payment history for user ${userId}...`);
-  await new Promise(resolve => setTimeout(resolve, 700)); // Simulate network delay
-  // Example structure - ensure your actual function returns this structure
-  // return [
-  //   { id: 'mockPay1', documentName: 'Mock Lease Agreement', documentId: 'mockDoc1', date: new Date().toISOString(), amount: '$35.00' },
-  // ];
-  return []; // Default to empty for now
-}
-// --- End Placeholder Functions ---
+// Firestore data helpers
+const getRecentDocsForUser = getUserDocuments;
+const getPaymentHistoryForUser = getUserPayments;
 
 export default function DashboardClientContent({ locale }: DashboardClientContentProps) {
   const { t, i18n } = useTranslation("common");

--- a/src/lib/firestore/dashboardData.ts
+++ b/src/lib/firestore/dashboardData.ts
@@ -1,0 +1,57 @@
+import { db } from '@/lib/firebase';
+import {
+  collection,
+  getDocs,
+  query,
+  orderBy,
+  limit,
+  type Timestamp,
+} from 'firebase/firestore';
+import { documentLibrary } from '@/lib/document-library';
+
+export interface DashboardDocument {
+  id: string;
+  name: string;
+  date: Timestamp | Date | string;
+  status: string;
+  docType: string;
+}
+
+export async function getUserDocuments(
+  userId: string,
+  max = 20
+): Promise<DashboardDocument[]> {
+  const col = collection(db, 'users', userId, 'documents');
+  const q = query(col, orderBy('createdAt', 'desc'), limit(max));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => {
+    const data = d.data() as any;
+    const docType = data.originalDocId || data.docType || d.id;
+    const docConfig = documentLibrary.find((doc) => doc.id === docType);
+    return {
+      id: d.id,
+      name: docConfig ? docConfig.name : docType,
+      date: data.createdAt,
+      status: data.status || 'Draft',
+      docType,
+    };
+  });
+}
+
+export interface DashboardPayment {
+  id: string;
+  date: Timestamp | Date | string;
+  amount: string;
+  documentName: string;
+  documentId?: string;
+}
+
+export async function getUserPayments(
+  userId: string,
+  max = 20
+): Promise<DashboardPayment[]> {
+  const col = collection(db, 'users', userId, 'payments');
+  const q = query(col, orderBy('date', 'desc'), limit(max));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => d.data() as DashboardPayment);
+}


### PR DESCRIPTION
## Summary
- add Firestore helpers for dashboard data
- wire dashboard page to fetch documents and payments from Firestore

## Testing
- `npm test`
