### PR TITLE
Improve page navigation speed

### DIFF
--- a/src/components/BundlesCarousel.tsx
+++ b/src/components/BundlesCarousel.tsx
@@ -69,7 +69,7 @@ export default function BundlesCarousel({ max = 6 }: Props) {
                 <span className="text-muted-foreground"> · {b.docIds.length} docs</span>
               </p>
 
-              <Link href={`/bundle/${b.id}`} prefetch={false}>
+              <Link href={`/bundle/${b.id}`}> 
                 <Button size="sm" className="w-full">View bundle</Button>
               </Link>
               </CardContent>

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -36,14 +36,22 @@ const TopDocsChips = React.memo(function TopDocsChips() {
 
   useEffect(() => {
     if (!isHydrated) return;
-    
+
     const resolvedTopDocs = staticTopDocIds
       .map(id => documentLibrary.find(doc => doc.id === id))
       .filter((doc): doc is LegalDocument => doc !== undefined);
-    
+
     setTopDocs(resolvedTopDocs);
     setIsLoading(false);
   }, [isHydrated]);
+
+  // Prefetch document pages for snappier navigation
+  useEffect(() => {
+    if (!isHydrated || topDocs.length === 0) return;
+    topDocs.forEach(doc => {
+      router.prefetch(`/${locale}/docs/${doc.id}`);
+    });
+  }, [isHydrated, topDocs, router, locale]);
 
   const handleChipClick = (docId: string) => {
     router.push(`/${locale}/docs/${docId}`);


### PR DESCRIPTION
## Summary
- enable Next.js prefetch on bundle detail links
- prefetch popular document links in TopDocsChips for quicker navigation

## Testing
- `npm test`
