### PR TITLE
Remove optional add-ons

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -389,7 +389,6 @@
     "previewSubtitle": "This is how your document will generally look. Specific clauses and details will be customized by your answers.",
     "pricingTitle": "Transparent Pricing",
     "competitivePrice": "Compare to typical attorney fees of ${{competitorPrice}}+",
-    "optionalAddons": "Optional Add-ons",
     "aiAssistance": "AI Assistance"
   },
   "announcement.offerTitle": "Limited Time Offer:",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -388,7 +388,6 @@
     "previewSubtitle": "Así es como se verá generalmente tu documento. Las cláusulas y detalles específicos se personalizarán según tus respuestas.",
     "pricingTitle": "Precios Transparentes",
     "competitivePrice": "Compara con los honorarios típicos de abogados de ${{competitorPrice}}+",
-    "optionalAddons": "Complementos Opcionales",
     "aiAssistance": "Asistencia de IA"
   },
   "announcement.offerTitle": "Oferta por Tiempo Limitado:",

--- a/src/lib/document-library-additions.ts
+++ b/src/lib/document-library-additions.ts
@@ -29,10 +29,7 @@ export const documentLibraryAdditions: LegalDocument[] = [
       confidentialInfoDescription: z.string().optional(),
       termYears: z.number().int().min(0).optional(),
     }),
-    upsellClauses: [
-      { id: 'extendedTerm', description: 'Extend NDA duration beyond 1 year', description_es: 'Extender la duración del NDA más allá de 1 año', price: 1 },
-      { id: 'mutualProtection', description: 'Make NDA mutual instead of one-sided', description_es: 'Hacer que el NDA sea mutuo en lugar de unilateral', price: 2 }
-    ],
+    upsellClauses: [],
     questions: [
        { id: "party1Name", label: "Party 1 Full Name/Company", type: "text", required: true },
        { id: "party1Address", label: "Party 1 Address", type: "textarea", required: true },
@@ -164,10 +161,7 @@ export const documentLibraryAdditions: LegalDocument[] = [
         { id: 'late_fee_policy', label: 'Late Fee Policy (Optional)', type: 'textarea', placeholder: 'e.g., $50 fee if rent is more than 5 days late.', required: false },
         { id: 'state', label: 'State Governing Lease', type: 'select', required: true, options: [{value: 'CA', label: 'California'}, {value: 'NY', label: 'New York'}, {value: 'TX', label: 'Texas'}, {value: 'FL', label: 'Florida'}, {value: 'Other', label: 'Other'}] }
     ],
-    upsellClauses: [
-        { id: "lateFeeClause", description: "Add detailed late rent fee clause", description_es: "Añadir cláusula detallada de cargo por pago tardío", price: 1 },
-        { id: "petPolicy", description: "Include a specific pet policy addendum", description_es: "Incluir un anexo específico de política de mascotas", price: 1 }
-    ]
+    upsellClauses: []
   },
   {
     id: 'commercial-lease-agreement-add', 

--- a/src/lib/documents/ca/promissory-note.ts
+++ b/src/lib/documents/ca/promissory-note.ts
@@ -46,14 +46,5 @@ export const promissoryNoteCA: LegalDocument = {
     { id: 'repaymentTerms', label: 'documents.ca.promissory-note-ca.repaymentTerms.label', type: 'textarea', required: true, placeholder: 'e.g., Monthly payments of $100 for 12 months.' }, 
     { id: 'province', label: 'documents.ca.promissory-note-ca.province.label', type: 'select', required: true, options: caProvinces } 
   ],
-  upsellClauses: [
-    {
-      id: 'bilingualClause',
-      price: 2,
-      translations: {
-         en: { description: 'Include French and English bilingual version' },
-         fr: { description: 'Inclure une version bilingue en français et en anglais' }
-      }
-    }
-  ]
+  upsellClauses: []
 };

--- a/src/lib/documents/divorce-settlement-agreement.ts
+++ b/src/lib/documents/divorce-settlement-agreement.ts
@@ -38,8 +38,5 @@ export const divorceSettlementAgreement: LegalDocument = {
     { id: 'spousalSupport', label: 'Spousal Support (Alimony) Details', type: 'textarea', placeholder: 'e.g., Spouse 1 pays $500/month for 36 months, or waived' },
     { id: 'state', label: 'State Governing Divorce', type: 'select', required: true, options: usStates.map(s => ({ value: s.value, label: s.label })) }
   ],
-  upsellClauses: [
-    { id: "spousalSupportWaiver", description: "Include waiver of spousal support", description_es: "Incluir renuncia a la manutención conyugal", price: 2 },
-    { id: "retirementSplit", description: "Specify division of retirement accounts", description_es: "Especificar división de cuentas de jubilación", price: 2 },
-  ]
+  upsellClauses: []
 };

--- a/src/lib/documents/lease-agreement.ts
+++ b/src/lib/documents/lease-agreement.ts
@@ -49,8 +49,5 @@ export const leaseAgreement: LegalDocument = {
     { id: "late_fee_policy", label: "Late Fee Policy (Optional)", type: "textarea", placeholder: "e.g., $50 fee if rent is more than 5 days late.", required: false },
     { id: "state", label: "State Governing Lease", type: "select", required: true, options: usStates.map(s => ({ value: s.value, label: s.label })) }
   ],
-  upsellClauses: [
-    { id: "lateFeeClause", description: "Add detailed late rent fee clause", description_es: "Añadir cláusula detallada de cargo por pago tardío", price: 1 },
-    { id: "petPolicy", description: "Include a specific pet policy addendum", description_es: "Incluir un anexo específico de política de mascotas", price: 1 }
-  ]
+  upsellClauses: []
 };

--- a/src/lib/documents/nda.ts
+++ b/src/lib/documents/nda.ts
@@ -37,8 +37,5 @@ export const nda: LegalDocument = {
     { id: "confidentialInfoDescription", label: "Brief Description of Confidential Information", type: "textarea", placeholder: "e.g., Business plans, customer lists, source code" },
     { id: "termYears", label: "Term of Agreement (Years, 0 for indefinite)", type: "number", placeholder: "e.g., 3" },
   ],
-  upsellClauses: [
-    { id: "extendedTerm", description: "Extend NDA duration beyond 1 year", description_es: "Extender la duración del NDA más allá de 1 año", price: 1 },
-    { id: "mutualProtection", description: "Make NDA mutual instead of one-sided", description_es: "Hacer que el NDA sea mutuo en lugar de unilateral", price: 2 }
-  ]
+  upsellClauses: []
 };

--- a/src/lib/documents/power-of-attorney.ts
+++ b/src/lib/documents/power-of-attorney.ts
@@ -38,8 +38,5 @@ export const powerOfAttorney: LegalDocument = {
     { id: "isDurable", label: "Is this a Durable POA (remains effective after incapacity)?", type: "select", options: [{ value: "yes", label: "Yes (Durable)" }, { value: "no", label: "No (Terminates on incapacity)" }], required: true },
     { id: "state", label: "State Governing the POA", type: "select", required: true, options: usStates.map(s => ({ value: s.value, label: s.label })) }
   ],
-  upsellClauses: [
-    { id: "specificPowers", description: "Grant only specific listed powers", description_es: "Otorgar solo poderes específicos listados", price: 1 },
-    { id: "addWitnessClause", description: "Add witness clause for extra validation", description_es: "Añadir cláusula de testigo para validación adicional", price: 2 }
-  ]
+  upsellClauses: []
 };

--- a/src/lib/documents/promissory-note.ts
+++ b/src/lib/documents/promissory-note.ts
@@ -32,7 +32,5 @@ export const promissoryNote: LegalDocument = {
     { id: 'interestRate', label: 'Interest Rate (%)', type: 'number', tooltip: "Annual interest rate. Leave blank or 0 if no interest." },
     { id: 'repaymentTerms', label: 'Repayment Terms', type: 'textarea', required: true, tooltip: "Describe how the loan will be repaid (e.g., monthly installments, lump sum)." },
   ],
-  upsellClauses: [
-    { id: 'securedClause', description: 'Add collateral details (secured note)', description_es: 'Añadir detalles de garantía (pagaré garantizado)', price: 2 }
-  ]
+  upsellClauses: []
 };

--- a/src/lib/documents/us/bill-of-sale-vehicle.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle.ts
@@ -77,14 +77,5 @@ export const billOfSaleVehicle: LegalDocument = {
     { id: 'state', label: 'documents.us.bill-of-sale-vehicle.state.label', type: 'select', required: true, options: usStates.map(s => ({ value: s.value, label: s.label })), tooltip: 'documents.us.bill-of-sale-vehicle.state.tooltip' }, 
     { id: 'county', label: 'documents.us.bill-of-sale-vehicle.county.label', type: 'text', required: false, tooltip: 'documents.us.bill-of-sale-vehicle.county.tooltip' }
   ],
-  upsellClauses: [
-    {
-      id: 'includeNotaryLanguage',
-      price: 2.00,
-      translations: {
-        en: { description: 'Include formal Notary Acknowledgment block' },
-        es: { description: 'Incluir bloque formal de Reconocimiento Notarial' }
-      }
-    }
-  ]
+  upsellClauses: []
 };

--- a/src/lib/documents/us/divorce-settlement-agreement.ts
+++ b/src/lib/documents/us/divorce-settlement-agreement.ts
@@ -39,8 +39,5 @@ export const divorceSettlementAgreement: LegalDocument = {
     { id: 'spousalSupport', label: 'Spousal Support (Alimony) Details', type: 'textarea', placeholder: 'e.g., Spouse 1 pays $500/month for 36 months, or waived' },
     { id: 'state', label: 'State Governing Divorce', type: 'select', required: true, options: usStates.map(s => ({ value: s.value, label: s.label })) }
   ],
-  upsellClauses: [
-    { id: "spousalSupportWaiver", description: "Include waiver of spousal support", description_es: "Incluir renuncia a la manutención conyugal", price: 2 },
-    { id: "retirementSplit", description: "Specify division of retirement accounts", description_es: "Especificar división de cuentas de jubilación", price: 2 },
-  ]
+  upsellClauses: []
 };

--- a/src/lib/documents/us/lease-agreement.ts
+++ b/src/lib/documents/us/lease-agreement.ts
@@ -119,24 +119,7 @@ export const leaseAgreement: LegalDocument = {
       options: usStates.map((s) => ({ value: s.value, label: s.label })),
     },
   ],
-  upsellClauses: [
-    {
-      id: 'lateFeeClause',
-      price: 1,
-      translations: {
-        en: { description: 'Add detailed late rent fee clause' },
-        es: { description: 'Añadir cláusula detallada de cargo por pago tardío' },
-      },
-    },
-    {
-      id: 'petPolicy',
-      price: 1,
-      translations: {
-        en: { description: 'Include a specific pet policy addendum' },
-        es: { description: 'Incluir un anexo específico de política de mascotas' },
-      },
-    },
-  ],
+  upsellClauses: [],
   translations: {
     en: {
       name: 'Residential Lease Agreement',

--- a/src/lib/documents/us/nda.ts
+++ b/src/lib/documents/us/nda.ts
@@ -32,24 +32,7 @@ export const nda: LegalDocument = {
     { id: "confidentialInfoDescription", label: "Brief Description of Confidential Information", type: "textarea", placeholder: "e.g., Business plans, customer lists, source code" },
     { id: "termYears", label: "Term of Agreement (Years, 0 for indefinite)", type: "number", placeholder: "e.g., 3" },
   ],
-  upsellClauses: [
-    {
-      id: "extendedTerm",
-      price: 1,
-      translations: {
-        en: { description: "Extend NDA duration beyond 1 year" },
-        es: { description: "Extender la duración del NDA más allá de 1 año" }
-      }
-    },
-    {
-      id: "mutualProtection",
-      price: 2,
-      translations: {
-        en: { description: "Make NDA mutual instead of one-sided" },
-        es: { description: "Hacer que el NDA sea mutuo en lugar de unilateral" }
-      }
-    }
-  ],
+  upsellClauses: [],
   // Added translations object
   translations: {
     en: {

--- a/src/lib/documents/us/power-of-attorney.ts
+++ b/src/lib/documents/us/power-of-attorney.ts
@@ -58,24 +58,7 @@ export const powerOfAttorney: LegalDocument = {
       options: usStates.map(s => ({ value: s.value, label: s.label }))
     }
   ],
-  upsellClauses: [
-    {
-      id: "specificPowers",
-      price: 1,
-      translations: {
-        en: { description: "Grant only specific listed powers" },
-        es: { description: "Otorgar solo poderes específicos listados" }
-      }
-    },
-    {
-      id: "addWitnessClause",
-      price: 2,
-      translations: {
-        en: { description: "Add witness clause for extra validation" },
-        es: { description: "Añadir cláusula de testigo para validación adicional" }
-      }
-    }
-  ],
+  upsellClauses: [],
   translations: {
     en: {
       name: "General Power of Attorney",

--- a/src/lib/documents/us/promissory-note.ts
+++ b/src/lib/documents/us/promissory-note.ts
@@ -33,16 +33,7 @@ export const promissoryNote: LegalDocument = {
     { id: 'interestRate', label: 'documents.us.promissory-note.interestRate.label', type: 'number', tooltip: 'documents.us.promissory-note.interestRate.tooltip' },
     { id: 'repaymentTerms', label: 'documents.us.promissory-note.repaymentTerms.label', type: 'textarea', required: true, tooltip: 'documents.us.promissory-note.repaymentTerms.tooltip' },
   ],
-  upsellClauses: [
-    {
-      id: 'securedClause',
-      price: 2,
-      translations: {
-        en: { description: 'Add collateral details (secured note)' },
-        es: { description: 'Añadir detalles de garantía (pagaré garantizado)' }
-      }
-    }
-  ],
+  upsellClauses: [],
   translations: {
     en: {
       name: 'Promissory Note',

--- a/src/lib/documents/us/promissory-note/metadata.ts
+++ b/src/lib/documents/us/promissory-note/metadata.ts
@@ -18,24 +18,7 @@ export const promissoryNoteMeta: LegalDocument = {
   templatePath_es: '/templates/es/promissory-note.md', // Path relative to public folder
   schema: PromissoryNoteSchema,
   questions: promissoryNoteQuestions,
-  upsellClauses: [
-    { 
-      id: 'lateFee', 
-      translations: {
-        en: { description: 'Late-payment fee clause' },
-        es: { description: 'Cláusula de cargo por pago atrasado' }
-      },
-      price: 1 
-    },
-    { 
-      id: 'securedClause', 
-      translations: {
-        en: { description: 'Add collateral details (secured note)' },
-        es: { description: 'Añadir detalles de garantía (pagaré garantizado)' }
-      },
-      price: 2 
-    }
-  ],
+  upsellClauses: [],
   translations: { 
     en: {
       name: 'Promissory Note',

--- a/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
@@ -20,14 +20,7 @@ export const vehicleBillOfSaleMeta: LegalDocument = {
   requiresNotarizationStates: ['AZ','KY','LA','MT','NV','OH','OK','PA','WV','WY'], // States where notarization is mandatory
   schema: BillOfSaleSchema,
   questions: vehicleBillOfSaleQuestions,
-  upsellClauses: [
-    { 
-      id: 'includeNotaryLanguage', 
-      description: 'Include formal Notary Acknowledgment block', 
-      description_es: 'Incluir bloque formal de Reconocimiento Notarial', 
-      price: 2 
-    }
-  ],
+  upsellClauses: [],
   // Direct name/description for fallbacks or non-i18n contexts
   name: "Vehicle Bill of Sale",
   name_es: "Contrato de Compraventa de Vehículo",


### PR DESCRIPTION
## Summary
- drop `optionalAddons` translations
- remove all upsell clauses from document metadata and configs

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: TypeScript errors in existing files)*