### PR TITLE
Integrate SignWell eSignature API

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -291,6 +291,7 @@
   "pdfPreview.signButton": "Sign Document",
   "pdfPreview.signingButton": "Signing...",
   "pdfPreview.signedButton": "Document Signed",
+  "pdfPreview.openSigningLink": "Open Signing Link",
   "shareDownloadStep.stepTitle": "Step 4: Download & Share",
   "shareDownloadStep.disabledDescription": "Please complete the previous steps to enable download and share options.",
   "shareDownloadStep.description": "Your document is ready! You can download it or share it securely.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -290,6 +290,7 @@
   "pdfPreview.signButton": "Firmar Documento",
   "pdfPreview.signingButton": "Firmando...",
   "pdfPreview.signedButton": "Documento Firmado",
+  "pdfPreview.openSigningLink": "Abrir enlace de firma",
   "shareDownloadStep.stepTitle": "Paso 4: Descargar y Compartir",
   "shareDownloadStep.disabledDescription": "Por favor, completa los pasos anteriores para habilitar las opciones de descarga y compartir.",
   "shareDownloadStep.description": "¡Tu documento está listo! Puedes descargarlo o compartirlo de forma segura.",

--- a/src/app/api/signwell/[id]/route.ts
+++ b/src/app/api/signwell/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const { id } = params;
+  const apiKey = process.env.SIGNWELL_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'SIGNWELL_API_KEY not configured' }, { status: 500 });
+  }
+  try {
+    const res = await fetch(`https://api.signwell.com/v1/documents/${id}`, {
+      headers: { 'Authorization': `Bearer ${apiKey}` },
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      return NextResponse.json({ error: 'SignWell API error', details: data }, { status: res.status });
+    }
+    return NextResponse.json({ status: data.status, raw: data });
+  } catch (err: any) {
+    console.error('SignWell status check failed', err);
+    return NextResponse.json({ error: err.message || 'Unknown error' }, { status: 500 });
+  }
+}

--- a/src/app/api/signwell/route.ts
+++ b/src/app/api/signwell/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { pdfBase64, fileName } = await req.json();
+  if (!pdfBase64) {
+    return NextResponse.json({ error: 'Missing pdfBase64' }, { status: 400 });
+  }
+
+  const apiKey = process.env.SIGNWELL_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'SIGNWELL_API_KEY not configured' }, { status: 500 });
+  }
+
+  try {
+    const res = await fetch('https://api.signwell.com/v1/documents', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        test_mode: true,
+        files: [{ file_base64: pdfBase64, file_name: fileName || 'document.pdf' }],
+        signers: [{ name: 'Signer', email: 'signer@example.com' }],
+      }),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'SignWell API error', details: data }, { status: res.status });
+    }
+
+    return NextResponse.json({ documentId: data.id, signingUrl: data.signing_links?.[0]?.url, raw: data });
+  } catch (err: any) {
+    console.error('SignWell API call failed', err);
+    return NextResponse.json({ error: err.message || 'Unknown error' }, { status: 500 });
+  }
+}

--- a/src/components/pdf-preview.tsx
+++ b/src/components/pdf-preview.tsx
@@ -115,6 +115,16 @@ const PdfPreview = React.memo(function PdfPreview({ documentDataUrl, documentNam
                  <CheckCircle className="h-5 w-5" />
                  <span>{t('pdfPreview.signingSuccessDescription')}</span>
                </div>
+               {signatureResult.signingUrl && (
+                 <a
+                   href={signatureResult.signingUrl}
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   className="underline text-primary text-xs"
+                 >
+                   {t('pdfPreview.openSigningLink')}
+                 </a>
+               )}
             </div>
         )}
          {signatureResult && !signatureResult.success && !isSigning && (

--- a/src/services/digital-signature.ts
+++ b/src/services/digital-signature.ts
@@ -1,100 +1,41 @@
-/**
- * Represents the result of a digital signature operation.
- */
 export interface DigitalSignatureResult {
-  /**
-   * Indicates whether the document was successfully signed.
-   */
   success: boolean;
-  /**
-   * A message providing details about the signature operation.
-   */
   message: string;
-  /**
-   * The signed PDF document as a byte array (or URL if stored remotely).
-   * Using Uint8Array for local simulation, but a URL might be better in production.
-   */
-  signedPdf: Uint8Array | null; // Changed to allow null in case of failure
+  signedPdf: Uint8Array | null;
+  signingUrl?: string;
+  documentId?: string;
 }
 
 /**
- * Asynchronously signs a PDF document using a digital signature.
- * **Note:** This is a placeholder implementation. In a real application,
- * this function would likely make an API call to a backend service
- * (e.g., a Firebase Function or dedicated microservice) that integrates
- * with a digital signature provider (like DocuSign, Adobe Sign, etc.).
- * The backend would handle the secure signing process.
- *
- * @param pdfData The PDF document data as a byte array.
- * @param signatureOptions Options for the digital signature, potentially including signer info, signature placement, etc.
- * @returns A promise that resolves to a DigitalSignatureResult object.
+ * Sends the PDF data to our SignWell integration API route.
  */
-export async function signPdfDocument(
-  pdfData: Uint8Array,
-  signatureOptions: any // Define a more specific type for options in a real app
-): Promise<DigitalSignatureResult> {
-  console.log('[digital-signature] Attempting to sign PDF. Data length:', pdfData.length);
-  console.log('[digital-signature] Signature options:', signatureOptions);
-
-  // --- Start Placeholder Logic ---
-  // Simulate an API call delay
-  await new Promise(resolve => setTimeout(resolve, 1500));
-
-  // Simulate a potential failure (e.g., 10% chance)
-  if (Math.random() < 0.1) {
-    console.warn('[digital-signature] Simulated signing failure.');
-    return {
-      success: false,
-      message: 'Failed to sign document (simulated error).',
-      signedPdf: null,
-    };
-  }
-
-  // Simulate successful signing by simply returning the original data
-  // In a real implementation, this `signedPdfData` would be the modified
-  // byte array received from the signature service/library.
-  const signedPdfData = pdfData;
-
-  console.log('[digital-signature] Simulated signing successful.');
-  return {
-    success: true,
-    message: 'Document successfully signed (simulation).',
-    signedPdf: signedPdfData,
-  };
-  // --- End Placeholder Logic ---
-
-  /*
-  // --- Example of potential real API call structure ---
+export async function signPdfDocument(pdfData: Uint8Array, options: any): Promise<DigitalSignatureResult> {
   try {
-    const response = await fetch('/api/sign-document', { // Your backend API endpoint
+    const binary = Array.from(pdfData)
+      .map((b) => String.fromCharCode(b))
+      .join('');
+    const pdfBase64 = typeof btoa === 'function' ? btoa(binary) : Buffer.from(binary, 'binary').toString('base64');
+    const res = await fetch('/api/signwell', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        pdfData: Buffer.from(pdfData).toString('base64'), // Send base64 encoded PDF
-        options: signatureOptions,
-      }),
+      body: JSON.stringify({ pdfBase64, fileName: options?.fileName }),
     });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.message || `API Error: ${response.status}`);
+    if (!res.ok) {
+      const err = await res.json();
+      return { success: false, message: err.error || 'Failed to create SignWell document', signedPdf: null };
     }
 
-    const result = await response.json(); // Expect { success: boolean, message: string, signedPdfData?: string }
-
+    const data = await res.json();
     return {
-      success: result.success,
-      message: result.message,
-      signedPdf: result.signedPdfData ? Buffer.from(result.signedPdfData, 'base64') : null,
-    };
-
-  } catch (error) {
-    console.error('[digital-signature] Error calling signing API:', error);
-    return {
-      success: false,
-      message: `Failed to sign document: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      success: true,
+      message: 'SignWell document created',
       signedPdf: null,
+      signingUrl: data.signingUrl,
+      documentId: data.documentId,
     };
+  } catch (error: any) {
+    console.error('[digital-signature] Error calling SignWell API:', error);
+    return { success: false, message: error.message || 'Unknown error', signedPdf: null };
   }
-  */
 }

--- a/src/services/document-summary.ts
+++ b/src/services/document-summary.ts
@@ -1,0 +1,24 @@
+import { OpenAI } from 'openai';
+
+const getClient = () => {
+  const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY;
+  return apiKey ? new OpenAI({ apiKey }) : null;
+};
+
+export async function summarizeDocument(text: string): Promise<string> {
+  const client = getClient();
+  if (!client) {
+    return 'AI summary service not configured.';
+  }
+  try {
+    const res = await client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: `Summarize the following document:\n${text}` }],
+      temperature: 0.3,
+    });
+    return res.choices[0].message.content ?? '';
+  } catch (err: any) {
+    console.error('Failed to summarize document', err);
+    return 'Error generating summary.';
+  }
+}

--- a/src/services/signwell.ts
+++ b/src/services/signwell.ts
@@ -1,0 +1,33 @@
+export interface SignWellDocumentResponse {
+  documentId: string;
+  signingUrl?: string;
+  raw?: any;
+}
+
+/**
+ * Calls our Next.js API route to create a SignWell document for signing.
+ * Expects pdfData as base64 string and optional filename.
+ */
+export async function createSignWellDocument(pdfBase64: string, fileName = 'document.pdf'): Promise<SignWellDocumentResponse> {
+  const res = await fetch('/api/signwell', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ pdfBase64, fileName }),
+  });
+  if (!res.ok) {
+    throw new Error(`SignWell API error: ${res.status}`);
+  }
+  const data = await res.json();
+  return data as SignWellDocumentResponse;
+}
+
+/**
+ * Checks the status of a SignWell document.
+ */
+export async function fetchSignWellStatus(documentId: string): Promise<any> {
+  const res = await fetch(`/api/signwell/${documentId}`);
+  if (!res.ok) {
+    throw new Error(`Status check failed: ${res.status}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add SignWell API routes for document creation and status checks
- update digital signature service to call SignWell
- expose helper functions for SignWell and document summaries
- show signing link in the PDF preview
- add translations for new UI text

## Testing
- `npm test`
- `npm run typecheck` *(fails: testing1 TypeScript errors)*