### PR TITLE
Add dedicated Vehicle Bill of Sale page

### DIFF
--- a/src/app/[locale]/documents/bill-of-sale-vehicle/page.tsx
+++ b/src/app/[locale]/documents/bill-of-sale-vehicle/page.tsx
@@ -1,22 +1,23 @@
-'use client';
+import VehicleBillOfSaleDisplay from '@/components/docs/VehicleBillOfSaleDisplay'
 
-import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { useParams } from 'next/navigation';
-import BillOfSaleTemplate from '@/templates/BillOfSaleTemplate';
+export const metadata = {
+  title: 'Vehicle Bill of Sale - 100% Legal in All 50 States',
+  description: 'Create a legally binding vehicle bill of sale online in minutes. Valid in all 50 states. Free PDF, bilingual, attorney-reviewed.'
+}
 
-export default function Page() {
-  const { locale } = useParams() as { locale: 'en' | 'es' };
-  const { i18n } = useTranslation("common");
+export async function generateStaticParams() {
+  return [{ locale: 'en' }, { locale: 'es' }]
+}
 
-  // when the URL segment changes, switch i18n
-  React.useEffect(() => {
-    i18n.changeLanguage(locale);
-  }, [locale, i18n]);
+interface PageProps {
+  params: { locale: 'en' | 'es' }
+}
 
+export default function VehicleBillOfSalePage({ params }: PageProps) {
+  const { locale } = params
   return (
     <main className="py-8">
-      <BillOfSaleTemplate />
+      <VehicleBillOfSaleDisplay locale={locale} />
     </main>
-  );
+  )
 }

--- a/src/components/BillOfSalePreview.tsx
+++ b/src/components/BillOfSalePreview.tsx
@@ -1,0 +1,10 @@
+'use client'
+import DocumentPreview from './DocumentPreview'
+
+export default function BillOfSalePreview({ locale = 'en', height = 400 }: { locale?: 'en' | 'es'; height?: number }) {
+  return (
+    <div style={{ height }} className="w-full">
+      <DocumentPreview docId="bill-of-sale-vehicle" locale={locale} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `BillOfSalePreview` wrapper component
- add new server page for `/[locale]/documents/bill-of-sale-vehicle` that uses `VehicleBillOfSaleDisplay` and sets basic SEO metadata

## Testing
- `npm test`