### PR TITLE
Fix preconnect hints

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,7 +47,12 @@ export default function RootLayout({
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
-        <link rel="preconnect" href="https://maps.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://maps.googleapis.com"
+          crossOrigin=""
+        />
+        <link rel="preconnect" href="https://rsms.me" crossOrigin="" />
         <link
           rel="preload"
           href="/images/hero-placeholder.png"


### PR DESCRIPTION
## Summary
- update preconnect for Google Maps with `crossOrigin`
- preconnect to `rsms.me` for font loading

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*