### PR TITLE
Lazy-load Firebase modules

### DIFF
--- a/src/app/[locale]/documents/bill-of-sale-vehicle/VehicleBillOfSalePage.tsx
+++ b/src/app/[locale]/documents/bill-of-sale-vehicle/VehicleBillOfSalePage.tsx
@@ -46,7 +46,7 @@ import {
   getVehicleCompliance,
   vehicleComplianceStates,
 } from '@/lib/states/vehicle-compliance';
-import { db } from '@/lib/firebase';
+import { getDb } from '@/lib/firebase';
 import {
   collection,
   doc,
@@ -81,6 +81,7 @@ export default function VehicleBillOfSalePage() {
     // Example Firestore read for compliance data
     async function loadCompliance() {
       try {
+        const db = await getDb();
         const ref = doc(collection(db, 'compliance'), 'vehicle');
         const snap = await getDoc(ref);
         if (snap.exists()) {

--- a/src/lib/firestore/bundles.ts
+++ b/src/lib/firestore/bundles.ts
@@ -3,7 +3,7 @@ ts
 // Firestore helpers for bundles (optional – can be omitted if
 // you’ll ship with static bundles only)
 //--------------------------------------------------------------
-import { db } from '@/lib/firebase'
+import { getDb } from '@/lib/firebase'
 import {
   collection,
   getDocs,
@@ -19,6 +19,7 @@ import type { Bundle } from '@/data/bundles'
  */
 export async function loadBundles(max = 20): Promise<Bundle[]> {
   try {
+    const db = await getDb()
     const col = collection(db, 'bundles')
     const q   = query(col, orderBy('name'), limit(max))
     const snap = await getDocs(q)

--- a/src/lib/firestore/dashboardData.ts
+++ b/src/lib/firestore/dashboardData.ts
@@ -1,4 +1,4 @@
-import { db } from '@/lib/firebase';
+import { getDb } from '@/lib/firebase';
 import {
   collection,
   getDocs,
@@ -21,6 +21,7 @@ export async function getUserDocuments(
   userId: string,
   max = 20
 ): Promise<DashboardDocument[]> {
+  const db = await getDb();
   const col = collection(db, 'users', userId, 'documents');
   const q = query(col, orderBy('createdAt', 'desc'), limit(max));
   const snap = await getDocs(q);
@@ -50,6 +51,7 @@ export async function getUserPayments(
   userId: string,
   max = 20
 ): Promise<DashboardPayment[]> {
+  const db = await getDb();
   const col = collection(db, 'users', userId, 'payments');
   const q = query(col, orderBy('date', 'desc'), limit(max));
   const snap = await getDocs(q);

--- a/src/lib/firestore/recentDocs.ts
+++ b/src/lib/firestore/recentDocs.ts
@@ -3,7 +3,7 @@
 // Firestore convenience helpers for the “recently used” widget
 //--------------------------------------------------------------
 
-import { db } from '@/lib/firebase'
+import { getDb } from '@/lib/firebase'
 import {
   collection,
   doc,
@@ -29,6 +29,7 @@ export async function loadRecentDocs(
   userId: string,
   max: number = 20,
 ): Promise<RecentDocEntry[]> {
+  const db = await getDb()
   const col = collection(db, 'users', userId, 'recentDocs')
   const q   = query(col, orderBy('lastOpened', 'desc'), limit(max))
   const snap = await getDocs(q)
@@ -42,6 +43,7 @@ export async function saveRecentDoc(
   userId: string,
   entry: RecentDocEntry,
 ): Promise<void> {
+  const db = await getDb()
   const ref = doc(db, 'users', userId, 'recentDocs', entry.id)
   await setDoc(ref, {
     ...entry,


### PR DESCRIPTION
## Summary
- refactor Firebase client to load Firestore/Analytics on demand
- update Firestore helpers and vehicle doc page to call `getDb`

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: TS errors)*
