### PR TITLE
Lazy load Google Maps script

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,6 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const googleMapsApiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
 
   return (
     <html lang="en" suppressHydrationWarning>
@@ -90,13 +89,6 @@ export default function RootLayout({
           </AuthProvider>
         </I18nextProvider>
 
-        {/* Load Google Maps API on the client */}
-        {googleMapsApiKey && (
-          <Script
-            src={`https://maps.googleapis.com/maps/api/js?key=${googleMapsApiKey}&libraries=places&loading=async`}
-            strategy="afterInteractive"
-          />
-        )}
       </body>
     </html>
   );

--- a/src/components/AddressField.tsx
+++ b/src/components/AddressField.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
+import dynamic from 'next/dynamic';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next'; // Added
 import { Label } from '@/components/ui/label';
@@ -14,6 +15,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from '@/components/ui/button';
+
+const GooglePlacesLoader = dynamic(() => import('./GooglePlacesLoader'), { ssr: false });
 
 interface AddressFieldProps {
   name: string;
@@ -124,7 +127,9 @@ const AddressField = React.memo(function AddressField({
   };
 
   return (
-    <div className={cn('space-y-1', className)}>
+    <>
+      <GooglePlacesLoader />
+      <div className={cn('space-y-1', className)}>
       <div className="flex items-center gap-1">
         <Label htmlFor={name} className={cn(fieldErrorActual && "text-destructive")}>{t(label)}{required && <span className="text-destructive">*</span>}</Label>
         {tooltip && (
@@ -155,7 +160,8 @@ const AddressField = React.memo(function AddressField({
         aria-invalid={!!fieldErrorActual}
       />
       {fieldErrorActual && <p className="text-xs text-destructive mt-1">{t(String(fieldErrorActual))}</p>} {/* Changed */}
-    </div>
+      </div>
+    </>
   );
 });
 export default AddressField;

--- a/src/components/providers/ClientProviders.tsx
+++ b/src/components/providers/ClientProviders.tsx
@@ -7,7 +7,6 @@ import I18nClientProvider from '@/components/providers/I18nProvider';
 import { Toaster } from "@/components/ui/toaster";
 import { CartProvider } from '@/contexts/CartProvider';
 import { AuthProvider } from '@/hooks/useAuth'; // Corrected: AuthProvider is a named export
-import GooglePlacesLoader from '@/components/GooglePlacesLoader';
 import { useTranslation } from 'react-i18next';
 import { Loader2 } from 'lucide-react';
 import { FooterSkeleton } from '@/components/layout/Footer';
@@ -72,7 +71,6 @@ export function ClientProviders({ children, locale }: ClientProvidersProps) {
       <I18nClientProvider locale={locale}>
         <AuthProvider>
           <CartProvider>
-            <GooglePlacesLoader />
             <AppShell>{children}</AppShell>
           </CartProvider>
         </AuthProvider>


### PR DESCRIPTION
## Summary
- lazy load Google Maps only where needed
- drop global maps script from layout
- remove maps loader from ClientProviders

## Testing
- `npm test`