### PR TITLE
Fix fonts caching

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,3 @@
-@import url("https://rsms.me/inter/inter.css");
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,6 @@ export default function RootLayout({
           href="https://maps.googleapis.com"
           crossOrigin=""
         />
-        <link rel="preconnect" href="https://rsms.me" crossOrigin="" />
         <link
           rel="preload"
           href="/images/hero-placeholder.png"


### PR DESCRIPTION
## Summary
- stop loading Inter fonts from rsms.me
- remove rsms preconnect entry

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*