### PR TITLE
Optimize third-party script loading

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,3 @@
-@import url("https://rsms.me/inter/inter.css");
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,8 +38,6 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const googleMapsApiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
-
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -47,12 +45,6 @@ export default function RootLayout({
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
-        <link
-          rel="preconnect"
-          href="https://maps.googleapis.com"
-          crossOrigin=""
-        />
-        <link rel="preconnect" href="https://rsms.me" crossOrigin="" />
         <link
           rel="preload"
           href="/images/hero-placeholder.png"
@@ -90,13 +82,6 @@ export default function RootLayout({
           </AuthProvider>
         </I18nextProvider>
 
-        {/* Load Google Maps API on the client */}
-        {googleMapsApiKey && (
-          <Script
-            src={`https://maps.googleapis.com/maps/api/js?key=${googleMapsApiKey}&libraries=places&loading=async`}
-            strategy="afterInteractive"
-          />
-        )}
       </body>
     </html>
   );

--- a/src/components/AddressField.tsx
+++ b/src/components/AddressField.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
+import GooglePlacesLoader from './GooglePlacesLoader';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next'; // Added
 import { Label } from '@/components/ui/label';
@@ -124,7 +125,9 @@ const AddressField = React.memo(function AddressField({
   };
 
   return (
-    <div className={cn('space-y-1', className)}>
+    <>
+      <GooglePlacesLoader />
+      <div className={cn('space-y-1', className)}>
       <div className="flex items-center gap-1">
         <Label htmlFor={name} className={cn(fieldErrorActual && "text-destructive")}>{t(label)}{required && <span className="text-destructive">*</span>}</Label>
         {tooltip && (
@@ -155,7 +158,8 @@ const AddressField = React.memo(function AddressField({
         aria-invalid={!!fieldErrorActual}
       />
       {fieldErrorActual && <p className="text-xs text-destructive mt-1">{t(String(fieldErrorActual))}</p>} {/* Changed */}
-    </div>
+      </div>
+    </>
   );
 });
 export default AddressField;

--- a/src/components/GooglePlacesLoader.tsx
+++ b/src/components/GooglePlacesLoader.tsx
@@ -10,7 +10,12 @@ export default function GooglePlacesLoader() {
   useEffect(() => {
     if ((window as any).google?.maps?.places) {
       setLoaded(true);
+      return;
     }
+
+    const handler = () => setLoaded(true);
+    window.addEventListener('google-maps-loaded', handler);
+    return () => window.removeEventListener('google-maps-loaded', handler);
   }, []);
 
   if (!apiKey) {
@@ -18,16 +23,19 @@ export default function GooglePlacesLoader() {
     return null;
   }
 
+  const scriptExists = typeof document !== 'undefined' &&
+    document.getElementById('google-maps-script');
+
   return (
     <>
-      {!loaded && (
+      {!loaded && !scriptExists && (
         <Script
+          id="google-maps-script"
           src={`https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&loading=async`}
           strategy="afterInteractive"
           onLoad={() => {
             console.log('Google Maps API script loaded.');
             setLoaded(true);
-             // Dispatch a custom event to notify that Google Maps is loaded
             window.dispatchEvent(new Event('google-maps-loaded'));
           }}
           onError={(e) => {

--- a/src/components/providers/ClientProviders.tsx
+++ b/src/components/providers/ClientProviders.tsx
@@ -7,7 +7,6 @@ import I18nClientProvider from '@/components/providers/I18nProvider';
 import { Toaster } from "@/components/ui/toaster";
 import { CartProvider } from '@/contexts/CartProvider';
 import { AuthProvider } from '@/hooks/useAuth'; // Corrected: AuthProvider is a named export
-import GooglePlacesLoader from '@/components/GooglePlacesLoader';
 import { useTranslation } from 'react-i18next';
 import { Loader2 } from 'lucide-react';
 
@@ -72,7 +71,6 @@ export function ClientProviders({ children, locale }: ClientProvidersProps) {
       <I18nClientProvider locale={locale}>
         <AuthProvider>
           <CartProvider>
-            <GooglePlacesLoader />
             <AppShell>{children}</AppShell>
           </CartProvider>
         </AuthProvider>


### PR DESCRIPTION
## Summary
- remove preconnects and Google Maps loader from layout
- load Google Maps only when `AddressField` mounts
- dedupe Google Maps script in `GooglePlacesLoader`
- drop unused Inter font import
- add missing newline at EOF

## Testing
- `npm test`
