### PR TITLE
Enable HTTP/2 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ npm start
 Running Lighthouse against the production build will show minified JavaScript
 files.
 
+## Using HTTP/2
+
+The `npm start` script now launches a small Node.js server that serves the built
+Next.js app over **HTTP/2** with an automatic fallback to HTTP/1.1. This requires
+TLS certificates which are not committed to the repository.
+
+Create a `cert` directory with `server.crt` and `server.key` files for local
+development. You can generate self‑signed certificates using OpenSSL:
+
+```bash
+mkdir cert
+openssl req -newkey rsa:2048 -nodes -keyout cert/server.key \
+  -x509 -days 365 -out cert/server.crt
+```
+
+After generating the certificates, build and start the app:
+
+```bash
+npm run build
+npm start
+```
+
 ## Troubleshooting Lighthouse reports
 
 If Lighthouse shows large execution times and lists files such as

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -p 9002",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "npm run gen:previews && next build",
-    "start": "next start",
+    "start": "node server.mjs",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "node --test tests/prettify.test.js",

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,26 @@
+import next from 'next';
+import { createSecureServer } from 'node:http2';
+import { readFileSync } from 'node:fs';
+import { parse } from 'node:url';
+
+const port = process.env.PORT || 3000;
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+const options = {
+  key: readFileSync('./cert/server.key'),
+  cert: readFileSync('./cert/server.crt'),
+  allowHTTP1: true,
+};
+
+app.prepare().then(() => {
+  const server = createSecureServer(options, (req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  });
+
+  server.listen(port, () => {
+    console.log(`> Ready on https://localhost:${port}`);
+  });
+});


### PR DESCRIPTION
## Summary
- add Node.js server using the `http2` module
- run the app through that server by default
- document how to use HTTP/2 in development

## Testing
- `npm test`