### PR TITLE
Ensure production start uses NODE_ENV=production

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ production mode:
 
 ```bash
 npm run build
-npm start
+npm start   # automatically sets NODE_ENV=production
 ```
 
 Running Lighthouse against the production build will show minified JavaScript
@@ -48,8 +48,8 @@ increases bundle size and CPU usage. Build and serve the app in production mode
 before running Lighthouse:
 
 ```bash
-NODE_ENV=production npm run build
-NODE_ENV=production npm start
+npm run build
+npm start
 ```
 
 ## Reducing Main-Thread Work

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -p 9002",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "npm run gen:previews && next build",
-    "start": "node server.mjs",
+    "start": "NODE_ENV=production node server.mjs",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "node --test tests/prettify.test.js",


### PR DESCRIPTION
## Summary
- set `NODE_ENV=production` in the `start` script
- document that `npm start` now sets NODE_ENV
- update Lighthouse guidance

## Testing
- `npm test`
