### PR TITLE
Fix layout shift by using Next Image

### DIFF
--- a/src/app/bundle/[id]/page.tsx
+++ b/src/app/bundle/[id]/page.tsx
@@ -1,5 +1,6 @@
 // src/app/bundle/[id]/page.tsx
 import React from 'react'
+import Image from 'next/image'
 import { notFound } from 'next/navigation'
 import { bundles } from '@/data/bundles'
 import { loadBundles } from '@/lib/firestore/bundles'   // harmless if collection absent
@@ -41,8 +42,13 @@ function BundleClient({ bundle }: { bundle: (typeof bundles)[number] }) {
     <main className="max-w-3xl mx-auto p-6">
       <Card className="border border-border shadow-sm">
         {bundle.imageUrl && (
-          // eslint-disable-next-line @next/next/no-img-element
-          (<img src={bundle.imageUrl} alt={bundle.name} className="h-48 w-full object-cover rounded-t" />)
+          <Image
+            src={bundle.imageUrl}
+            alt={bundle.name}
+            width={768}
+            height={192}
+            className="h-48 w-full object-cover rounded-t"
+          />
         )}
 
         <CardHeader className="space-y-1">

--- a/src/components/BundlesCarousel.tsx
+++ b/src/components/BundlesCarousel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
+import Image from 'next/image'
 import Link from 'next/link'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -54,8 +55,14 @@ export default function BundlesCarousel({ max = 6 }: Props) {
               className="card-hover min-w-[260px] w-64 shrink-0 border border-border shadow-sm"
             >
               {b.imageUrl && (
-                // eslint-disable-next-line @next/next/no-img-element
-                (<img src={b.imageUrl} alt={b.name} className="h-32 w-full object-cover rounded-t" data-ai-hint="legal document bundle" />)
+                <Image
+                  src={b.imageUrl}
+                  alt={b.name}
+                  width={256}
+                  height={128}
+                  className="h-32 w-full object-cover rounded-t"
+                  data-ai-hint="legal document bundle"
+                />
               )}
 
               <CardHeader className="pb-1">


### PR DESCRIPTION
## Summary
- use `next/image` for bundle screenshots

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*