### PR TITLE
Add performance marks for layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,13 +4,14 @@
 
 import './globals.css';
 import { Inter, Merriweather } from 'next/font/google';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '@/lib/i18n'; // Changed this line
 import { DefaultSeo } from 'next-seo';
 import SEO from '../../next-seo.config.js';
 import Script from 'next/script';
 import { AuthProvider } from '@/hooks/useAuth';
+import { mark, measure } from '@/utils/performance';
 
 // Dev-only helper for catching missing translation keys
 if (
@@ -38,6 +39,14 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  if (typeof window !== 'undefined') {
+    mark('root-layout-start');
+  }
+
+  useEffect(() => {
+    mark('root-layout-end');
+    measure('root-layout', 'root-layout-start', 'root-layout-end');
+  }, []);
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -1,0 +1,19 @@
+export function mark(name: string) {
+  if (typeof window !== 'undefined' && 'performance' in window && typeof performance.mark === 'function') {
+    try {
+      performance.mark(name);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function measure(name: string, startMark: string, endMark: string) {
+  if (typeof window !== 'undefined' && 'performance' in window && typeof performance.measure === 'function') {
+    try {
+      performance.measure(name, startMark, endMark);
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a tiny utility for User Timing
- instrument the root layout with `performance.mark`/`measure`

## Testing
- `npm test`