### PR TITLE
Add default title element

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,6 +55,7 @@ export default function RootLayout({
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
+        <title>{SEO.title}</title>
         {/* Preload and asynchronously apply the generated layout.css file */}
         <Script id="defer-layout-css" strategy="beforeInteractive">
           {`


### PR DESCRIPTION
## Summary
- add a default `<title>` element in the HTML layout

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: TypeScript errors in repository)*
- `npm test`