### PR TITLE
Improve keyboard accessibility

### DIFF
--- a/src/components/DocumentTypeSelector.tsx
+++ b/src/components/DocumentTypeSelector.tsx
@@ -91,11 +91,20 @@ export default function DocumentTypeSelector({ onSelect, selectedDocument }: Pro
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {filteredDocuments
                   .filter((doc) => doc.category === category)
-                  .map((doc) => (
+                    .map((doc) => (
                     <Card
                       key={doc.id}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={t(doc.name, doc.name)}
                       className={`cursor-pointer hover:shadow-lg transition-all duration-200 ${selectedDocument === doc.id ? 'border-2 border-primary' : ''}`}
                       onClick={() => onSelect(doc.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          onSelect(doc.id);
+                        }
+                      }}
                     >
                       <CardHeader>
                         <CardTitle>{doc.name}</CardTitle>

--- a/src/components/Step1DocumentSelector.tsx
+++ b/src/components/Step1DocumentSelector.tsx
@@ -68,8 +68,17 @@ const MemoizedDocumentCard = React.memo(function DocumentCard({ doc, onSelect, d
   return (
     <Card
       onClick={onSelect}
+      tabIndex={disabled ? -1 : 0}
+      role="button"
+      aria-label={t(doc.name, doc.name)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
       className={cn(
-        "document-card shadow hover:shadow-lg cursor-pointer transition bg-card border border-border flex flex-col active:scale-95 active:transition-transform active:duration-100",
+        'document-card shadow hover:shadow-lg cursor-pointer transition bg-card border border-border flex flex-col active:scale-95 active:transition-transform active:duration-100',
         disabled ? 'pointer-events-none opacity-50' : ''
       )}
     >


### PR DESCRIPTION
## Summary
- add keyboard focus and aria labels to document cards
- make document type selection cards operable with keyboard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test`
- `npm run typecheck` *(fails: TypeScript errors)*