### PR TITLE
Fix i18n loading for region codes

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -12,6 +12,9 @@ if (!i18n.isInitialized) {
     .init({
       fallbackLng: 'en',
       debug: process.env.NODE_ENV === 'development',
+      // Only allow supported languages and strip region codes like en-US
+      supportedLngs: ['en', 'es'],
+      load: 'languageOnly',
       interpolation: { escapeValue: false },
       ns: [
         'common',


### PR DESCRIPTION
## Summary
- restrict i18n to supported languages and load language-only resources

## Testing
- `npm test`
