### PR TITLE
Enable source maps for production builds

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,10 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   swcMinify: true,
+  // Generate source maps for production bundles so Lighthouse can access
+  // original source when analyzing the site. This adds `.map` files next to
+  // the JavaScript bundles and slightly increases build size.
+  productionBrowserSourceMaps: true,
 
   images: {
     unoptimized: true, // Disable Image Optimization for static export

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,10 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true, // Avoid blocking builds on ESLint errors
   },
   swcMinify: true,
+  // Generate source maps for production bundles so Lighthouse can access the
+  // original TypeScript sources. This adds `.map` files next to the compiled
+  // JavaScript output and slightly increases build size.
+  productionBrowserSourceMaps: true,
   images: {
     unoptimized: true, // Disable Next.js image optimization for static export
     remotePatterns: [


### PR DESCRIPTION
## Summary
- generate production source maps for JavaScript and TypeScript builds

## Testing
- `npm test`