### PR TITLE
Enable automatic HTTP/2 certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ files.
 
 ## Using HTTP/2
 
-The `npm start` script now launches a small Node.js server that serves the built
-Next.js app over **HTTP/2** with an automatic fallback to HTTP/1.1. This requires
-TLS certificates which are not committed to the repository.
+The `npm start` script launches a small Node.js server that serves the built
+Next.js app over **HTTP/2** with an automatic fallback to HTTP/1.1. If no TLS
+certificates are found the server will generate a self‑signed pair on first run.
 
-Create a `cert` directory with `server.crt` and `server.key` files for local
-development. You can generate self‑signed certificates using OpenSSL:
+Certificates are placed in the `cert` directory as `server.crt` and
+`server.key`. You can also generate them manually using OpenSSL:
 
 ```bash
 mkdir cert
@@ -32,7 +32,7 @@ openssl req -newkey rsa:2048 -nodes -keyout cert/server.key \
   -x509 -days 365 -out cert/server.crt
 ```
 
-After generating the certificates, build and start the app:
+After generating the certificates (or letting the server create them), build and start the app:
 
 ```bash
 npm run build

--- a/server.mjs
+++ b/server.mjs
@@ -1,17 +1,35 @@
 import next from 'next';
 import { createSecureServer } from 'node:http2';
 import { createServer } from 'node:http';
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { parse } from 'node:url';
+import { execSync } from 'node:child_process';
 
 const port = process.env.PORT || 3000;
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
+// Ensure TLS certificates exist so HTTP/2 can be used locally.
+const certDir = './cert';
+const keyPath = `${certDir}/server.key`;
+const certPath = `${certDir}/server.crt`;
+if (!existsSync(keyPath) || !existsSync(certPath)) {
+  mkdirSync(certDir, { recursive: true });
+  console.log('Generating self-signed TLS certificate for HTTP/2...');
+  try {
+    execSync(
+      `openssl req -newkey rsa:2048 -nodes -keyout ${keyPath} -x509 -days 365 -out ${certPath} -subj "/CN=localhost"`
+    );
+  } catch (e) {
+    console.error('Failed to generate TLS certificate', e);
+    process.exit(1);
+  }
+}
+
 const options = {
-  key: readFileSync('./cert/server.key'),
-  cert: readFileSync('./cert/server.crt'),
+  key: readFileSync(keyPath),
+  cert: readFileSync(certPath),
   allowHTTP1: true,
 };
 


### PR DESCRIPTION
## Summary
- generate self-signed TLS certificates on first run so HTTP/2 works out of the box
- document automatic certificate generation in README

## Testing
- `npm test`