### PR TITLE
Improve dynamic loading

### DIFF
--- a/src/lib/documents/us/testing1/index.ts
+++ b/src/lib/documents/us/testing1/index.ts
@@ -1,4 +1,4 @@
-// src/lib/documents/us/"first-second-third-fourth"/index.ts
-export { "firstSecondThirdFourth"Meta as "firstSecondThirdFourth" } from './metadata';
+// src/lib/documents/us/testing1/index.ts
+export { firstSecondMeta } from './metadata';
 export * from './schema';
 export * from './questions';

--- a/src/lib/documents/us/testing1/metadata.ts
+++ b/src/lib/documents/us/testing1/metadata.ts
@@ -1,6 +1,11 @@
-// src/lib/documents/us/first-second/metadata.ts
 import type { LegalDocument } from '@/types/documents';
 import { FirstSecondSchema } from './schema';
 import { firstSecondQuestions } from './questions';
 
 export const firstSecondMeta: LegalDocument = {
+  id: 'first-second',
+  name: 'First Second Document',
+  category: 'Miscellaneous',
+  schema: FirstSecondSchema,
+  questions: firstSecondQuestions,
+};

--- a/src/lib/documents/us/testing1/questions.ts
+++ b/src/lib/documents/us/testing1/questions.ts
@@ -1,3 +1,1 @@
-import { usStates } from '@/lib/usStates';
-
-export const firstSecondQuestions = [
+export const firstSecondQuestions = [];


### PR DESCRIPTION
## Summary
- dynamically load heavy components for faster page load
- lazy load document library when selecting documents
- fix test document placeholders for TypeScript

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find Node types)*