### PR TITLE
Fix docs lookup fallback

### DIFF
--- a/src/app/[locale]/docs/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/DocPageClient.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { notFound, useRouter } from 'next/navigation';
-import { documentLibrary, type LegalDocument } from '@/lib/document-library';
+import { documentLibrary, allDocuments, type LegalDocument } from '@/lib/document-library';
 import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -60,7 +60,8 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
 
   const docConfig = useMemo(() => {
     if (!docId) return undefined;
-    return documentLibrary.find(d => d.id === docId);
+    return documentLibrary.find(d => d.id === docId) ||
+           allDocuments.find(d => d.id === docId);
   }, [docId]);
 
   if (!docConfig) {

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -2,14 +2,17 @@
 // This is a Server Component that defines static paths and renders the client component.
 
 import DocPageClient from './DocPageClient';
-import { documentLibrary } from '@/lib/document-library';
+import { documentLibrary, allDocuments } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
 
 // generateStaticParams is crucial for static export of dynamic routes
 export async function generateStaticParams() {
   console.log('[generateStaticParams /docs] Starting generation...');
-  if (!documentLibrary || documentLibrary.length === 0) {
-    console.warn('[generateStaticParams /docs] documentLibrary is empty or undefined. No paths will be generated.');
+  const docs = documentLibrary && documentLibrary.length > 0
+    ? documentLibrary
+    : allDocuments;
+  if (docs.length === 0) {
+    console.warn('[generateStaticParams /docs] No documents available to generate paths.');
     return [];
   }
   if (!localizations || localizations.length === 0) {
@@ -19,7 +22,7 @@ export async function generateStaticParams() {
 
   const params = [];
   for (const locale of localizations) {
-    for (const doc of documentLibrary) {
+    for (const doc of docs) {
       // Ensure doc and doc.id are valid before pushing
       if (doc && doc.id && doc.id !== 'general-inquiry') { // Exclude general inquiry or other non-detail pages
         params!.push({ locale, docId: doc.id });

--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -8,7 +8,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Loader2, Edit, Eye } from 'lucide-react';
 
-import { documentLibrary, type LegalDocument } from '@/lib/document-library';
+import { documentLibrary, allDocuments, type LegalDocument } from '@/lib/document-library';
 import Breadcrumb from '@/components/Breadcrumb';
 import WizardForm from '@/components/WizardForm';
 import PreviewPane from '@/components/PreviewPane';
@@ -42,7 +42,8 @@ export default function StartWizardPageClient() {
 
   const docConfig = useMemo(() => {
     if (!docIdFromPath) return undefined;
-    return documentLibrary.find(d => d.id === docIdFromPath);
+    return documentLibrary.find(d => d.id === docIdFromPath) ||
+           allDocuments.find(d => d.id === docIdFromPath);
   }, [docIdFromPath]);
 
   const methods = useForm<z.infer<any>>({

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -2,15 +2,18 @@
 // This is now a Server Component
 
 import StartWizardPageClient from './StartWizardPageClient';
-import { documentLibrary } from '@/lib/document-library';
+import { documentLibrary, allDocuments } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
 import type { LegalDocument } from '@/lib/document-library';
 
 // generateStaticParams is crucial for static export of dynamic routes
 export async function generateStaticParams() {
   console.log('[generateStaticParams /docs/[docId]/start] Starting generation...');
-  if (!documentLibrary || documentLibrary.length === 0) {
-    console.warn('[generateStaticParams /docs/[docId]/start] documentLibrary is empty or undefined. No paths will be generated.');
+  const docs = documentLibrary && documentLibrary.length > 0
+    ? documentLibrary
+    : allDocuments;
+  if (docs.length === 0) {
+    console.warn('[generateStaticParams /docs/[docId]/start] No documents available to generate paths.');
     return [];
   }
   if (!localizations || localizations.length === 0) {
@@ -21,7 +24,7 @@ export async function generateStaticParams() {
     const defaultLocales = ['en', 'es']; 
     const params = [];
     for (const locale of defaultLocales) {
-      for (const doc of documentLibrary) {
+      for (const doc of docs) {
          // Ensure doc and doc.id are valid and it's not a general inquiry type if that shouldn't have a start page
         if (doc && doc.id && doc.id !== 'general-inquiry' && doc.schema) { // Added check for doc.schema
             params!.push({ locale: locale, docId: doc.id });
@@ -45,7 +48,7 @@ export async function generateStaticParams() {
         console.warn(`[generateStaticParams /docs/[docId]/start] Invalid locale object encountered:`, localeObj);
         continue;
     }
-    for (const doc of documentLibrary) {
+    for (const doc of docs) {
       if (!doc.id) {
         console.warn(`[generateStaticParams /docs/[docId]/start] Document with missing ID encountered:`, doc);
         continue;


### PR DESCRIPTION
## Summary
- fallback to allDocuments when generating doc page params
- handle missing doc config in StartWizardPageClient

## Testing
- `npm test`
