### PR TITLE
Add SignWell landing page and nav links

### DIFF
--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -51,6 +51,8 @@
     "blog": "Blog",
     "faq": "FAQ",
     "support": "Support",
+    "sign": "Sign",
+    "esign": "eSign",
     "searchPlaceholder": "Search documents...",
     "signUp": "Sign Up",
     "signIn": "Sign In",

--- a/public/locales/es/header.json
+++ b/public/locales/es/header.json
@@ -48,6 +48,8 @@
     "blog": "Blog",
     "faq": "Preguntas Frecuentes",
     "support": "Soporte",
+    "sign": "Firmar",
+    "esign": "eFirmar",
     "searchPlaceholder": "Buscar documentos...",
     "signUp": "Regístrate",
     "signIn": "Acceder",

--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -1,0 +1,52 @@
+'use client'
+import React, { useState } from 'react';
+import { createSignWellDocument } from '@/services/signwell';
+import { Button } from '@/components/ui/button';
+
+export async function generateStaticParams() {
+  return [{ locale: 'en' }, { locale: 'es' }];
+}
+
+export default function SignWellPage({ params }: { params: { locale: 'en' | 'es' } }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [signUrl, setSignUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) setFile(f);
+  };
+
+  const upload = async () => {
+    if (!file) return;
+    const buffer = await file.arrayBuffer();
+    const binary = Array.from(new Uint8Array(buffer))
+      .map((b) => String.fromCharCode(b))
+      .join('');
+    const base64 = btoa(binary);
+    setLoading(true);
+    try {
+      const res = await createSignWellDocument(base64, file.name);
+      setSignUrl(res.signingUrl || null);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">SignWell Demo</h1>
+      <input type="file" accept="application/pdf" onChange={handleFileChange} />
+      <Button onClick={upload} disabled={!file || loading}>
+        {loading ? 'Uploading...' : 'Upload to SignWell'}
+      </Button>
+      {signUrl && (
+        <p>
+          Signing Link: <a href={signUrl} target="_blank" className="underline text-primary">Open</a>
+        </p>
+      )}
+    </main>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -39,6 +39,7 @@ const Nav = React.memo(function Nav() {
   const navLinks = [
     { href: "/pricing", labelKey: "nav.pricing", defaultLabel: "Pricing" },
     { href: "/features", labelKey: "nav.features", defaultLabel: "Features" },
+    { href: "/signwell", labelKey: "nav.sign", defaultLabel: "Sign" },
     { href: "/blog", labelKey: "nav.blog", defaultLabel: "Blog" },
     { href: "/faq", labelKey: "nav.faq", defaultLabel: "FAQ" },
     { href: "/support", labelKey: "nav.support", defaultLabel: "Support" },
@@ -51,11 +52,22 @@ const Nav = React.memo(function Nav() {
           key={link.href}
           href={`/${currentLocale}${link.href}`}
           className={cn(
-            "hover:bg-primary/10 hover:text-primary focus-visible:bg-primary/10 focus-visible:text-primary transition-colors px-2 py-1.5 rounded-md",
+            "group hover:bg-primary/10 hover:text-primary focus-visible:bg-primary/10 focus-visible:text-primary transition-colors px-2 py-1.5 rounded-md",
             pathname === `/${currentLocale}${link.href}` && "bg-primary/10 text-primary font-semibold"
           )}
         >
-          {tHeader(link.labelKey, { defaultValue: link.defaultLabel })}
+          {link.labelKey === 'nav.sign' ? (
+            <>
+              <span className="block group-hover:hidden">
+                {tHeader('nav.sign', { defaultValue: 'Sign' })}
+              </span>
+              <span className="hidden group-hover:block">
+                {tHeader('nav.esign', { defaultValue: 'eSign' })}
+              </span>
+            </>
+          ) : (
+            tHeader(link.labelKey, { defaultValue: link.defaultLabel })
+          )}
         </Link>
       ))}
     </nav>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -367,6 +367,7 @@ const Header = React.memo(function Header() {
             {[
               { href: '/pricing', labelKey: 'nav.pricing', defaultLabel: 'Pricing' },
               { href: '/features', labelKey: 'nav.features', defaultLabel: 'Features' },
+              { href: '/signwell', labelKey: 'nav.sign', defaultLabel: 'Sign' },
               { href: '/blog', labelKey: 'nav.blog', defaultLabel: 'Blog' },
               { href: '/faq', labelKey: 'nav.faq', defaultLabel: 'FAQ' },
               { href: '/support', labelKey: 'nav.support', defaultLabel: 'Support' },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -42,6 +42,16 @@ const config: Config = {
           50: '#f6f7fb', 100: '#e9ebf3', 200: '#c8cdde', 300: '#a3a9c6', 400: '#7b83ae',
           500: '#5c6595', 600: '#474f78', 700: '#343a5b', 800: '#23283d', 900: '#151824',
         },
+
+        // brand palette
+        'brand-blue': '#2563eb',
+        'brand-green': '#22c55e',
+        'brand-slate': '#0f172a',
+        'brand-sky': '#e0f2fe',
+      },
+
+      maxWidth: {
+        content: '1240px',
       },
 
       fontFamily: {


### PR DESCRIPTION
## Summary
- add brand palette and max-width tokens to Tailwind config
- translate new sign/eSign strings
- extend desktop and mobile navigation with a Sign link
- implement hover swap from Sign to eSign
- create `/signwell` page for uploading PDFs and getting a SignWell URL

## Testing
- `npm test`