### PR TITLE
Fix hydration mismatch in client providers

### DIFF
--- a/src/components/providers/ClientProviders.tsx
+++ b/src/components/providers/ClientProviders.tsx
@@ -1,7 +1,7 @@
 // src/components/providers/ClientProviders.tsx
 "use client";
 
-import React, { ReactNode, useEffect, useState, Suspense } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import I18nClientProvider from '@/components/providers/I18nProvider';
 import { Toaster } from "@/components/ui/toaster";
@@ -54,19 +54,29 @@ const AppShell = React.memo(function AppShell({ children }: { children: ReactNod
 
 export function ClientProviders({ children, locale }: ClientProvidersProps) {
   return (
-    <Suspense fallback={ // Global suspense for initial provider setup
-        <div id="app-providers-loading" style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+    <I18nClientProvider
+      locale={locale}
+      fallback={
+        <div
+          id="app-providers-loading"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100vh',
+          }}
+        >
           <Loader2 className="h-12 w-12 animate-spin text-primary" />
-           <p className="ml-2 mt-2 text-muted-foreground">Initializing Application...</p>
+          <p className="ml-2 mt-2 text-muted-foreground">Initializing Application...</p>
         </div>
-    }>
-      <I18nClientProvider locale={locale}>
-        <AuthProvider>
-          <CartProvider>
-            <AppShell>{children}</AppShell>
-          </CartProvider>
-        </AuthProvider>
-      </I18nClientProvider>
-    </Suspense>
+      }
+    >
+      <AuthProvider>
+        <CartProvider>
+          <AppShell>{children}</AppShell>
+        </CartProvider>
+      </AuthProvider>
+    </I18nClientProvider>
   );
 }

--- a/src/components/providers/I18nProvider.tsx
+++ b/src/components/providers/I18nProvider.tsx
@@ -10,6 +10,8 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 interface I18nProviderProps {
   children: ReactNode;
   locale: 'en' | 'es';
+  /** Optional element shown until the i18n instance is ready */
+  fallback?: ReactNode;
 }
 
 let clientSidePluginsApplied = false;
@@ -65,9 +67,12 @@ const I18nClientProvider: React.FC<I18nProviderProps> = ({ children, locale }) =
     }
   }, [locale]);
 
-  // Always render the provider so that the server and client markup match.
-  // The surrounding Suspense boundary handles displaying a fallback while
-  // initialization occurs on the client.
+  // Render children only once the client-side i18n instance is ready to
+  // avoid hydration mismatches when translations load.
+  if (!isClientInitialized) {
+    return <>{fallback || null}</>;
+  }
+
   return <I18nextProvider i18n={i18nInstance}>{children}</I18nextProvider>;
 };
 


### PR DESCRIPTION
## Summary
- avoid using Suspense around providers
- defer rendering of i18n provider until initialized

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*