### PR TITLE
Fix fallback prop in I18nProvider

### DIFF
--- a/src/components/providers/I18nProvider.tsx
+++ b/src/components/providers/I18nProvider.tsx
@@ -16,7 +16,7 @@ interface I18nProviderProps {
 
 let clientSidePluginsApplied = false;
 
-const I18nClientProvider: React.FC<I18nProviderProps> = ({ children, locale }) => {
+const I18nClientProvider: React.FC<I18nProviderProps> = ({ children, locale, fallback }) => {
   const [isClientInitialized, setIsClientInitialized] = useState(clientSidePluginsApplied);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- correctly pass `fallback` to `I18nClientProvider`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test`
