### PR TITLE
Fix tsconfig types references

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "types": [
-      "node"
-    ],
     "baseUrl": ".",
     "paths": {
       "@/*": [
@@ -36,9 +33,7 @@
   "include": [
     "**/*.ts",
     "**/*.tsx",
-    "next-env.d.ts",
-    "scripts/**/*",
-    ".next/types/**/*.ts"
+    "scripts/**/*"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- remove `node` type requirement from tsconfig
- stop including `next-env.d.ts` and `.next` types so tsc doesn't fail when node_modules are absent

## Testing
- `npm test`