### PR TITLE
Fix Promissory Note questions loading

### DIFF
--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -96,25 +96,39 @@ export default function WizardForm({
   }, [doc.schema]);
 
   const steps = useMemo(() => {
+    if (doc.questions && doc.questions.length > 0) {
+      return doc.questions.map((q) => {
+        const fieldDef = (actualSchemaShape as any)?.[q.id]?._def;
+        const labelFromDescription =
+          fieldDef?.description ?? fieldDef?.schema?._def?.description;
+
+        const label = q.label
+          ? t(q.label, { defaultValue: q.label })
+          : labelFromDescription
+            ? t(labelFromDescription, { defaultValue: labelFromDescription })
+            : t(`fields.${q.id}.label`, { defaultValue: prettify(q.id) });
+
+        const tooltip =
+          q.tooltip
+            ? t(q.tooltip, { defaultValue: q.tooltip })
+            : t(fieldDef?.tooltip || fieldDef?.schema?._def?.tooltip || "", {
+                defaultValue:
+                  fieldDef?.tooltip || fieldDef?.schema?._def?.tooltip || "",
+              }) || undefined;
+
+        return { id: q.id, label, tooltip };
+      });
+    }
+
     if (!actualSchemaShape) return [];
+
     return Object.keys(actualSchemaShape).map((key) => {
       const fieldDef = (actualSchemaShape as any)[key]?._def;
       const labelFromDescription =
         fieldDef?.description ?? fieldDef?.schema?._def?.description;
-      let fieldLabel = prettify(key);
-
-      const questionConfig = doc.questions?.find((q) => q.id === key);
-      if (questionConfig?.label) {
-        fieldLabel = t(questionConfig.label, {
-          defaultValue: questionConfig.label,
-        });
-      } else if (labelFromDescription) {
-        fieldLabel = t(labelFromDescription, {
-          defaultValue: labelFromDescription,
-        });
-      } else {
-        fieldLabel = t(`fields.${key}.label`, { defaultValue: prettify(key) });
-      }
+      const fieldLabel = labelFromDescription
+        ? t(labelFromDescription, { defaultValue: labelFromDescription })
+        : t(`fields.${key}.label`, { defaultValue: prettify(key) });
 
       return {
         id: key,
@@ -126,7 +140,7 @@ export default function WizardForm({
           }) || undefined,
       };
     });
-  }, [actualSchemaShape, t, doc.questions]);
+  }, [doc.questions, actualSchemaShape, t]);
 
   const totalSteps = steps.length;
   const currentField =
@@ -367,12 +381,14 @@ export default function WizardForm({
           />
         )}
       </div>
-    ) : totalSteps === 0 && !isReviewing ? (
+    ) : (doc.questions?.length || 0) === 0 && !isReviewing ? (
       <div className="mt-6 min-h-[200px] flex flex-col items-center justify-center text-center">
         <p className="text-muted-foreground mb-4">
           {t("dynamicForm.noQuestionsNeeded", {
             documentType:
-              doc.name_es && locale === "es" ? doc.name_es : doc.name,
+              locale === "es"
+                ? doc.translations?.es?.name || doc.name_es || doc.translations?.en?.name || doc.name
+                : doc.translations?.en?.name || doc.name || doc.translations?.es?.name || doc.name_es,
           })}
         </p>
       </div>

--- a/src/lib/document-library.ts
+++ b/src/lib/document-library.ts
@@ -57,6 +57,9 @@ export function generateIdFromName(name: string): string {
 }
 
 allDocuments.forEach(doc => {
+  if (doc.id === 'promissory-note') {
+    console.log('[document-library] processing:', doc.id, doc.translations?.en?.name);
+  }
   if (!doc.id && doc.name) { // Check top-level name for ID generation
     doc.id = generateIdFromName(doc.name);
   } else if (!doc.id && doc.translations?.en?.name) { // Fallback to translation if top-level name is missing

--- a/src/lib/documents/us/promissory-note/metadata.ts
+++ b/src/lib/documents/us/promissory-note/metadata.ts
@@ -19,7 +19,7 @@ export const promissoryNoteMeta: LegalDocument = {
   schema: PromissoryNoteSchema,
   questions: promissoryNoteQuestions,
   upsellClauses: [],
-  translations: { 
+  translations: {
     en: {
       name: 'Promissory Note',
       description: 'Formalize a promise to repay a loan, with terms for principal, interest, and repayment schedule.',
@@ -32,3 +32,5 @@ export const promissoryNoteMeta: LegalDocument = {
     }
   }
 };
+
+console.log('[promissory-note metadata] questions loaded:', promissoryNoteMeta.questions?.length);


### PR DESCRIPTION
## Summary
- build WizardForm steps from `doc.questions`
- show message when no questions are defined
- log question count for Promissory Note metadata
- log when Promissory Note is processed in document library
- use translated name in no-questions message

## Testing
- `npm test`
