### PR TITLE
Improve ReviewStep editing UX

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -125,6 +125,7 @@
   "Please confirm the details below are correct before proceeding.": "Please confirm the details below are correct before proceeding.",
   "Not Provided": "Not Provided",
   "Edit": "Edit",
+  "wizard.fieldRequired": "Required",
   "Could not load template.": "Could not load template.",
   "Loading document wizard...": "Loading document wizard...",
   "dynamicForm.noQuestionsNeeded": "This document type ({{documentType}}) doesn't require any specific answers from you at this stage. You can proceed directly to preview and finalize.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -125,6 +125,7 @@
   "Please confirm the details below are correct before proceeding.": "Por favor, confirma que los detalles a continuación son correctos antes de proceder.",
   "Not Provided": "No Proporcionado",
   "Edit": "Editar",
+  "wizard.fieldRequired": "Requerido",
   "Could not load template.": "No se pudo cargar la plantilla.",
   "Loading document wizard...": "Cargando asistente de documento...",
   "dynamicForm.noQuestionsNeeded": "Este tipo de documento ({{documentType}}) no requiere ninguna respuesta específica de tu parte en esta etapa. Puedes proceder directamente a la vista previa y finalización.",

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -43,6 +43,15 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
 
   useEffect(() => {
     console.log('[ReviewStep] editingFieldId changed to:', editingFieldId);
+    if (editingFieldId) {
+      const el = document.getElementById(`review-${editingFieldId}`);
+      if (el) {
+        // Delay focus slightly to ensure element is rendered
+        setTimeout(() => {
+          (el as HTMLElement).focus();
+        }, 0);
+      }
+    }
   }, [editingFieldId]);
 
   const actualSchemaShape = useMemo(() => {


### PR DESCRIPTION
## Summary
- focus the input automatically when editing a field in the Review step
- add missing `wizard.fieldRequired` translations for English and Spanish

## Testing
- `npm test`