### PR TITLE
Add localized Online Notary page & nav link

### DIFF
--- a/public/locales/en/online-notary.json
+++ b/public/locales/en/online-notary.json
@@ -1,0 +1,18 @@
+{
+  "heroHeadline": "Online Notary – Easily notarize documents online with guaranteed security and privacy. Legal in all 50 states.",
+  "addDocument": "Add Document",
+  "whatIs": "An online notary allows you to get documents notarized remotely through secure video. Your information remains encrypted and private.",
+  "howItWorksTitle": "How it works",
+  "stepUpload": "Upload the document.",
+  "stepConnect": "Connect with a notary via secure video.",
+  "stepPay": "Pay and download the notarized document.",
+  "pricingTitle": "Pricing",
+  "pricingText": "$25 for the first seal and $10 for each additional seal.",
+  "legalTitle": "Legal Across the U.S.",
+  "legalText": "Our partner service is legal in all 50 states.",
+  "securityTitle": "Security & Compliance",
+  "securityText": "Our notary API provider uses end-to-end encryption and maintains strict compliance with state laws and identity verification requirements.",
+  "learnMoreTitle": "Learn More",
+  "faq": "Online Notary FAQs",
+  "articles": "Articles about remote notarization"
+}

--- a/public/locales/es/online-notary.json
+++ b/public/locales/es/online-notary.json
@@ -1,0 +1,18 @@
+{
+  "heroHeadline": "Notario en Línea – Notarice documentos en línea con seguridad y privacidad garantizadas. Legal en los 50 estados.",
+  "addDocument": "Agregar Documento",
+  "whatIs": "Un notario en línea le permite notarizar documentos de forma remota mediante video seguro. Su información permanece cifrada y privada.",
+  "howItWorksTitle": "Cómo funciona",
+  "stepUpload": "Suba el documento.",
+  "stepConnect": "Conéctese con un notario por video seguro.",
+  "stepPay": "Pague y descargue el documento notarizado.",
+  "pricingTitle": "Precios",
+  "pricingText": "$25 por el primer sello y $10 por cada sello adicional.",
+  "legalTitle": "Legal en los EE. UU.",
+  "legalText": "Nuestro servicio asociado es legal en los 50 estados.",
+  "securityTitle": "Seguridad y Cumplimiento",
+  "securityText": "Nuestro proveedor de API de notaría utiliza cifrado de extremo a extremo y mantiene un estricto cumplimiento con las leyes estatales y los requisitos de verificación de identidad.",
+  "learnMoreTitle": "Más información",
+  "faq": "Preguntas frecuentes sobre notario en línea",
+  "articles": "Artículos sobre notarización remota"
+}

--- a/src/app/[locale]/online-notary/online-notary-client-content.tsx
+++ b/src/app/[locale]/online-notary/online-notary-client-content.tsx
@@ -1,0 +1,92 @@
+'use client';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { ShieldCheck } from 'lucide-react';
+import { usStates } from '@/lib/usStates';
+
+export default function OnlineNotaryClientContent({ locale }: { locale: 'en' | 'es' }) {
+  const { t } = useTranslation('online-notary');
+
+  return (
+    <main className="container mx-auto px-4 py-8 space-y-12">
+      <section className="text-center space-y-4">
+        <h1 className="text-3xl font-bold text-foreground">
+          {t('heroHeadline', 'Online Notary – Easily notarize documents online with guaranteed security and privacy. Legal in all 50 states.')}
+        </h1>
+        <Button asChild>
+          <Link href={`/${locale}/templates`}>{t('addDocument', 'Add Document')}</Link>
+        </Button>
+      </section>
+
+      <section className="flex flex-col items-center md:flex-row md:items-start gap-4">
+        <ShieldCheck className="h-10 w-10 text-primary" />
+        <p className="text-muted-foreground max-w-xl">
+          {t('whatIs', 'An online notary allows you to get documents notarized remotely through secure video. Your information remains encrypted and private.')}
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4 text-foreground">
+          {t('howItWorksTitle', 'How it works')}
+        </h2>
+        <ol className="list-decimal ml-6 space-y-2 text-muted-foreground">
+          <li>{t('stepUpload', 'Upload the document.')}</li>
+          <li>{t('stepConnect', 'Connect with a notary via secure video.')}</li>
+          <li>{t('stepPay', 'Pay and download the notarized document.')}</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4 text-foreground">
+          {t('pricingTitle', 'Pricing')}
+        </h2>
+        <p className="text-muted-foreground">
+          {t('pricingText', '$25 for the first seal and $10 for each additional seal.')}
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4 text-foreground">
+          {t('legalTitle', 'Legal Across the U.S.')}
+        </h2>
+        <p className="text-muted-foreground mb-4">
+          {t('legalText', 'Our partner service is legal in all 50 states.')}
+        </p>
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 text-sm text-muted-foreground">
+          {usStates.map(s => (
+            <li key={s.value}>{s.label}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4 text-foreground">
+          {t('securityTitle', 'Security & Compliance')}
+        </h2>
+        <p className="text-muted-foreground">
+          {t('securityText', 'Our notary API provider uses end-to-end encryption and maintains strict compliance with state laws and identity verification requirements.')}
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4 text-foreground">
+          {t('learnMoreTitle', 'Learn More')}
+        </h2>
+        <ul className="list-disc ml-6 space-y-2 text-muted-foreground">
+          <li>
+            <Link href={`/${locale}/faq`} className="hover:underline">
+              {t('faq', 'Online Notary FAQs')}
+            </Link>
+          </li>
+          <li>
+            <Link href={`/${locale}/blog`} className="hover:underline">
+              {t('articles', 'Articles about remote notarization')}
+            </Link>
+          </li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/app/[locale]/online-notary/page.tsx
+++ b/src/app/[locale]/online-notary/page.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import OnlineNotaryClientContent from './online-notary-client-content';
+
+export async function generateStaticParams() {
+  return [{ locale: 'en' }, { locale: 'es' }];
+}
+
+interface OnlineNotaryPageProps {
+  params: { locale: 'en' | 'es' };
+}
+
+export default function OnlineNotaryPage({ params }: OnlineNotaryPageProps) {
+  return <OnlineNotaryClientContent locale={params.locale} />;
+}

--- a/src/app/online-notary/page.tsx
+++ b/src/app/online-notary/page.tsx
@@ -1,78 +1,10 @@
-import React from 'react'
-import Link from 'next/link'
-import { Button } from '@/components/ui/button'
-import { ShieldCheck } from 'lucide-react'
-import { usStates } from '@/lib/usStates'
+import { redirect } from 'next/navigation'
 
 export const metadata = {
   title: 'Online Notary'
 }
 
 export default function OnlineNotaryPage() {
-  return (
-    <main className="container mx-auto px-4 py-8 space-y-12">
-      <section className="text-center space-y-4">
-        <h1 className="text-3xl font-bold text-foreground">
-          Online Notary – Easily notarize documents online with guaranteed security and privacy. Legal in all 50 states.
-        </h1>
-        <Button asChild>
-          <Link href="/templates">Add Document</Link>
-        </Button>
-      </section>
-
-      <section className="flex flex-col items-center md:flex-row md:items-start gap-4">
-        <ShieldCheck className="h-10 w-10 text-primary" />
-        <p className="text-muted-foreground max-w-xl">
-          An online notary allows you to get documents notarized remotely through secure video. Your information remains encrypted and private.
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-2xl font-semibold mb-4 text-foreground">How it works</h2>
-        <ol className="list-decimal ml-6 space-y-2 text-muted-foreground">
-          <li>Upload the document.</li>
-          <li>Connect with a notary via secure video.</li>
-          <li>Pay and download the notarized document.</li>
-        </ol>
-      </section>
-
-      <section>
-        <h2 className="text-2xl font-semibold mb-4 text-foreground">Pricing</h2>
-        <p className="text-muted-foreground">$25 for the first seal and $10 for each additional seal.</p>
-      </section>
-
-      <section>
-        <h2 className="text-2xl font-semibold mb-4 text-foreground">Legal Across the U.S.</h2>
-        <p className="text-muted-foreground mb-4">Our partner service is legal in all 50 states.</p>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 text-sm text-muted-foreground">
-          {usStates.map((s) => (
-            <li key={s.value}>{s.label}</li>
-          ))}
-        </ul>
-      </section>
-
-      <section>
-        <h2 className="text-2xl font-semibold mb-4 text-foreground">Security & Compliance</h2>
-        <p className="text-muted-foreground">
-          Our notary API provider uses end-to-end encryption and maintains strict compliance with state laws and identity verification requirements.
-        </p>
-      </section>
-
-      <section>
-        <h2 className="text-2xl font-semibold mb-4 text-foreground">Learn More</h2>
-        <ul className="list-disc ml-6 space-y-2 text-muted-foreground">
-          <li>
-            <Link href="/faq" className="hover:underline">
-              Online Notary FAQs
-            </Link>
-          </li>
-          <li>
-            <Link href="/blog" className="hover:underline">
-              Articles about remote notarization
-            </Link>
-          </li>
-        </ul>
-      </section>
-    </main>
-  )
+  redirect('/en/online-notary')
+  return null
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -44,6 +44,7 @@ const Nav = React.memo(function Nav() {
   const navLinks = [
     { href: "/pricing", labelKey: "nav.pricing", defaultLabel: "Pricing" },
     { href: "/features", labelKey: "nav.features", defaultLabel: "Features" },
+    { href: "/online-notary", labelKey: "nav.onlineNotary", defaultLabel: "Online Notary" },
     { href: "/blog", labelKey: "nav.blog", defaultLabel: "Blog" },
     { href: "/faq", labelKey: "nav.faq", defaultLabel: "FAQ" },
     { href: "/support", labelKey: "nav.support", defaultLabel: "Support" },

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -383,6 +383,7 @@ const Header = React.memo(function Header() {
               { href: '/pricing', labelKey: 'nav.pricing', defaultLabel: 'Pricing' },
               { href: '/features', labelKey: 'nav.features', defaultLabel: 'Features' },
               { href: '/signwell', labelKey: 'nav.sign', defaultLabel: 'Sign' },
+              { href: '/online-notary', labelKey: 'nav.onlineNotary', defaultLabel: 'Online Notary' },
               { href: '/blog', labelKey: 'nav.blog', defaultLabel: 'Blog' },
               { href: '/faq', labelKey: 'nav.faq', defaultLabel: 'FAQ' },
               { href: '/support', labelKey: 'nav.support', defaultLabel: 'Support' },

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -16,7 +16,7 @@ if (!i18n.isInitialized) {
       fallbackLng: 'en',
       supportedLngs: ['en', 'es'],
       load: 'languageOnly', // Loads 'en' instead of 'en-US'
-      ns: ['common', 'header', 'footer', 'support', 'electronic-signature', 'documents', 'doc_bill_of_sale_vehicle'],
+      ns: ['common', 'header', 'footer', 'support', 'electronic-signature', 'online-notary', 'documents', 'doc_bill_of_sale_vehicle'],
       defaultNS: 'common',
       backend: {
         loadPath: '/locales/{{lng}}/{{ns}}.json',


### PR DESCRIPTION
## Summary
- create localized Online Notary page under `[locale]/online-notary`
- redirect old `/online-notary` route to `/en/online-notary`
- add Online Notary link to desktop and mobile navigation
- register new `online-notary` i18n namespace
- supply translations for the new page

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*