### PR TITLE
Fix review editing and image dims

### DIFF
--- a/src/components/AutoImage.tsx
+++ b/src/components/AutoImage.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import Image, { type ImageProps } from 'next/image';
+
+// src/components/AutoImage.tsx
+// FIXED: new component ensuring images always have explicit width and height
+
+interface AutoImageProps extends Omit<ImageProps, 'width' | 'height'> {
+  width?: number;
+  height?: number;
+}
+
+const AutoImage: React.FC<AutoImageProps> = ({ width, height, ...props }) => {
+  const [dims, setDims] = useState<{ width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    if (width && height) return;
+    if (typeof props.src === 'string') {
+      const img = new window.Image();
+      img.src = props.src;
+      img.onload = () => {
+        setDims({ width: img.naturalWidth, height: img.naturalHeight });
+      };
+    }
+  }, [width, height, props.src]);
+
+  const finalWidth = width ?? dims?.width ?? 1;
+  const finalHeight = height ?? dims?.height ?? 1;
+
+  return <Image width={finalWidth} height={finalHeight} {...props} />;
+};
+
+export default AutoImage;

--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library';
 import { Loader2, AlertTriangle } from 'lucide-react';
 import Image from 'next/image';
+import AutoImage from './AutoImage';
 import { cn } from '@/lib/utils';
 import { getTemplatePath } from '@/lib/templateUtils'; // Centralized util
 
@@ -147,13 +148,15 @@ const DocumentDetail = React.memo(function DocumentDetail({ docId, locale, altTe
         <div className="prose prose-sm dark:prose-invert max-w-none w-full h-full overflow-y-auto p-4 md:p-6 relative z-0 bg-white dark:bg-background text-foreground">
            <ReactMarkdown
              remarkPlugins={[remarkGfm]}
-             components={{
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                p: ({node, ...props}) => <p {...props} className="select-none" />,
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                h1: ({node, ...props}) => <h1 {...props} className="text-center" />,
-             }}
-           >
+           components={{
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              p: ({node, ...props}) => <p {...props} className="select-none" />,
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              h1: ({node, ...props}) => <h1 {...props} className="text-center" />,
+              // FIXED: ensure markdown images include dimensions
+              img: ({node, ...props}) => <AutoImage {...props} className="mx-auto" />,
+            }}
+          >
             {md}
            </ReactMarkdown>
         </div>

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -5,7 +5,8 @@ import React, { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next'; 
-import Image from 'next/image'; 
+import Image from 'next/image';
+import AutoImage from './AutoImage';
 import { Loader2 } from 'lucide-react';
 
 interface DocumentPreviewProps {
@@ -93,11 +94,15 @@ const DocumentPreview = React.memo(function DocumentPreview({
         </p>
       ) : md ? (
         <div className="prose prose-sm dark:prose-invert max-w-none w-full h-full overflow-y-auto p-4 md:p-6 bg-background text-foreground">
-          <ReactMarkdown 
+          <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              p: ({ node, ...props }) => <p {...props} className="select-none" />, 
+              p: ({ node, ...props }) => <p {...props} className="select-none" />,
+              // FIXED: ensure images have explicit dimensions
+              img: ({ node, ...props }) => (
+                <AutoImage {...props} className="mx-auto" />
+              ),
             }}
           >
             {md}

--- a/src/components/FieldRenderer.tsx
+++ b/src/components/FieldRenderer.tsx
@@ -300,8 +300,12 @@ const FieldRenderer = React.memo(function FieldRenderer({ fieldKey, locale, doc 
           {t("Decoded")}: {vinData.year} {vinData.make} {vinData.model} {vinData.bodyClass ? `(${vinData.bodyClass})` : ''}
         </p>
       )}
-      {fieldKey === 'vin' && vinError && <p className="text-xs text-destructive mt-1">{vinError}</p>}
-      {fieldError && <p className="text-xs text-destructive mt-1">{String(fieldError.message)}</p>}
+      {fieldKey === 'vin' && vinError && (
+        <p className="block text-xs text-destructive mt-1">{vinError}</p>
+      )}
+      {fieldError && (
+        <p className="block text-xs text-destructive mt-1">{String(fieldError.message)}</p>
+      )}
       {fieldSchema?.helperText && !fieldError && <p className="text-xs text-muted-foreground">{t(fieldSchema.helperText, {defaultValue: fieldSchema.helperText})}</p>}
     </div>
   );

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -11,6 +11,7 @@ import { debounce } from 'lodash-es';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library';
 import { cn } from '@/lib/utils';
 import Image from 'next/image';
+import AutoImage from './AutoImage';
 
 interface PreviewPaneProps {
   locale: 'en' | 'es';
@@ -161,11 +162,13 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
         style={{ userSelect: 'none' }}
       >
         <div className={cn("prose prose-sm max-w-none w-full h-full overflow-y-auto overflow-x-hidden p-4 md:p-6 scrollbar-hide bg-card text-card-foreground")}>
-          <ReactMarkdown 
+          <ReactMarkdown
               remarkPlugins={[remarkGfm]}
-              components={{ 
+              components={{
                 p: ({node, ...props}) => <p {...props} className="select-none" />,
                 h1: ({node, ...props}) => <h1 {...props} className="text-center" />,
+                // FIXED: ensure markdown images include dimensions
+                img: ({node, ...props}) => <AutoImage {...props} className="mx-auto" />,
               }}
           >
             {processedMarkdown}

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -186,7 +186,11 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
           const isCurrentlyEditing = editingFieldId === field.id;
           // console.log(`[ReviewStep] Rendering field: ${field.id}, isCurrentlyEditing: ${isCurrentlyEditing}`);
           return (
-            <div key={field.id} className="py-3 border-b border-border last:border-b-0">
+            <div
+              key={field.id}
+              className="py-3 border-b border-border last:border-b-0 cursor-pointer"
+              onClick={() => !isCurrentlyEditing && handleEdit(field.id)}
+            >
               <div className="flex justify-between items-start gap-2">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-1 mb-0.5">
@@ -352,7 +356,7 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                 )}
               </div>
               {errors[field.id] && isCurrentlyEditing && (
-                <p className="text-xs text-destructive mt-1 flex items-center gap-1">
+                <p className="block text-xs text-destructive mt-1 flex items-center gap-1">
                   <AlertTriangle className="h-3 w-3" /> {String(errors[field.id]?.message)}
                 </p>
               )}


### PR DESCRIPTION
## Summary
- add `AutoImage` to guarantee height & width
- use `AutoImage` in markdown previews
- let rows in `ReviewStep` be clickable and show errors clearly
- show error messages consistently across devices

## Testing
- `npm test`