### PR TITLE
Improve route prefetching

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -120,6 +120,7 @@ const SearchBar = React.memo(function SearchBar() {
                     <button
                       type="button"
                       onClick={() => handleSuggestionClick(suggestion.id)}
+                      onMouseEnter={() => router.prefetch(`/${locale}/docs/${suggestion.id}`)}
                       className="w-full text-left px-3 py-2.5 hover:bg-muted text-sm flex items-center gap-2"
                     >
                       <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -53,10 +53,6 @@ const TopDocsChips = React.memo(function TopDocsChips() {
     });
   }, [isHydrated, topDocs, router, locale]);
 
-  const handleChipClick = (docId: string) => {
-    router.push(`/${locale}/docs/${docId}`);
-  };
-
   const handleExploreAll = () => {
     const workflowStartElement = document.getElementById('workflow-start');
     if (workflowStartElement) {
@@ -92,14 +88,18 @@ const TopDocsChips = React.memo(function TopDocsChips() {
             key={doc.id}
             variant="outline"
             size="sm"
-            onClick={() => handleChipClick(doc.id)}
+            asChild
             className="bg-card hover:bg-muted border-border text-card-foreground hover:text-primary transition-colors shadow-sm px-4 py-2 h-auto text-xs sm:text-sm"
           >
-            {React.createElement(FileText, { className: "h-4 w-4 mr-2 text-primary/80 opacity-70" })}
-            {(doc.translations?.[locale as 'en' | 'es']?.name) ||
-             doc.translations?.en?.name ||
-             doc.name ||
-             doc.id}
+            <Link href={`/${locale}/docs/${doc.id}`}
+              prefetch
+            >
+              {React.createElement(FileText, { className: "h-4 w-4 mr-2 text-primary/80 opacity-70" })}
+              {(doc.translations?.[locale as 'en' | 'es']?.name) ||
+               doc.translations?.en?.name ||
+               doc.name ||
+               doc.id}
+            </Link>
           </Button>
         ))}
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -111,12 +111,6 @@ const Header = React.memo(function Header() {
     setSearchQuery(''); setShowResults(false);
     setIsMobileMenuOpen(false); setIsMegaMenuOpen(false);
   };
-  const handleResultClick = (docId: string) => {
-    setShowResults(false);
-    setSearchQuery('');
-    setIsMobileMenuOpen(false); setIsMegaMenuOpen(false);
-    router.push(`/${clientLocale}/docs/${docId}`);
-  };
   const handleLogout = () => {
     logout();
     setIsMobileMenuOpen(false);
@@ -214,17 +208,17 @@ const Header = React.memo(function Header() {
                     const docName = translatedDoc.name;
                     return (
                       <li key={doc.id}>
-                        <button
-                          type="button" // Added type="button"
-                          onClick={() => handleResultClick(doc.id)}
+                        <Link
+                          href={`/${clientLocale}/docs/${doc.id}`}
                           className="flex items-center gap-2 px-3 py-2.5 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground transition-colors w-full text-left"
+                          prefetch
                         >
                           <FileText className="h-4 w-4 shrink-0 text-muted-foreground"/>
                           <span className="truncate">
                             {docName}
                           </span>
                           <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground/70"/>
-                        </button>
+                        </Link>
                       </li>
                     );
                   })}
@@ -325,15 +319,15 @@ const Header = React.memo(function Header() {
                     const docName = translatedDoc.name;
                     return (
                       <li key={doc.id}>
-                        <button
-                          type="button" // Added type="button"
-                          onClick={() => handleResultClick(doc.id)}
+                        <Link
+                          href={`/${clientLocale}/docs/${doc.id}`}
                           className="flex items-center gap-2 px-3 py-2.5 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground transition-colors w-full text-left"
+                          prefetch
                         >
                           <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
                           <span className="truncate">{docName}</span>
                           <ExternalLink className="h-3 w-3 ml-auto text-muted-foreground/70" />
-                        </button>
+                        </Link>
                       </li>
                     );
                   })}


### PR DESCRIPTION
## Summary
- prefetch doc pages on suggestion hover in `SearchBar`
- convert TopDocsChips buttons to `<Link>` for automatic prefetch
- use `<Link>` for search results in `Header` for automatic prefetch

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react')*
- `npm test`
- `npm run lint` *(fails: next not found)*