### PR TITLE
Improve prefetching and lazy loading

### DIFF
--- a/src/app/[locale]/docs/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/DocPageClient.tsx
@@ -15,8 +15,8 @@ import { track } from '@/lib/analytics';
 import { Separator } from '@/components/ui/separator';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
-import VehicleBillOfSaleDisplay from '@/components/docs/VehicleBillOfSaleDisplay'; // Import the specific display component
-import PromissoryNoteDisplay from '@/components/docs/PromissoryNoteDisplay';
+const VehicleBillOfSaleDisplay = dynamic(() => import('@/components/docs/VehicleBillOfSaleDisplay'));
+const PromissoryNoteDisplay = dynamic(() => import('@/components/docs/PromissoryNoteDisplay'));
 
 // Lazy load testimonials section so it's only fetched when this page is viewed
 const TrustAndTestimonialsSection = dynamic(
@@ -129,6 +129,16 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
     }
   }, [docId, currentLocale, isHydrated, router]);
 
+  useEffect(() => {
+    if (!isHydrated) return;
+    if (docId === 'bill-of-sale-vehicle' && typeof (VehicleBillOfSaleDisplay as any).preload === 'function') {
+      (VehicleBillOfSaleDisplay as any).preload();
+    }
+    if (docId === 'promissory-note' && typeof (PromissoryNoteDisplay as any).preload === 'function') {
+      (PromissoryNoteDisplay as any).preload();
+    }
+  }, [docId, isHydrated]);
+
 
   const handleStartWizard = () => {
     if (!docConfig || !currentLocale || !isHydrated) return;
@@ -138,6 +148,12 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
       value: docConfig.basePrice
     });
     router.push(`/${currentLocale}/docs/${docConfig.id}/start`);
+  };
+
+  const handleStartWizardHover = () => {
+    if (docConfig && currentLocale) {
+      router.prefetch(`/${currentLocale}/docs/${docConfig.id}/start`);
+    }
   };
 
 
@@ -207,7 +223,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
               ))}
             </div>
             
-            <Button size="lg" className="w-full sm:w-auto text-base px-8 py-3" onClick={handleStartWizard} disabled={!isHydrated}>
+            <Button size="lg" className="w-full sm:w-auto text-base px-8 py-3" onClick={handleStartWizard} onMouseEnter={handleStartWizardHover} disabled={!isHydrated}>
               {t('Start For Free', {defaultValue: 'Start For Free'})}
             </Button>
             <div className="mt-4">
@@ -257,7 +273,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
                         <p className="text-xs text-muted-foreground">
                              {t('docDetail.competitivePrice', { competitorPrice: competitorPrice.toFixed(2), defaultValue: `Compare to typical attorney fees of $${competitorPrice.toFixed(2)}+`})}
                         </p>
-                         <Button size="lg" className="w-full mt-2" onClick={handleStartWizard} disabled={!isHydrated}>
+                         <Button size="lg" className="w-full mt-2" onClick={handleStartWizard} onMouseEnter={handleStartWizardHover} disabled={!isHydrated}>
                            {t('Start For Free', {defaultValue: 'Start For Free'})}
                          </Button>
                     </CardContent>
@@ -350,7 +366,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
 
         {/* Sticky CTA for mobile */}
         <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-t p-4 shadow-lg z-40">
-          <Button size="lg" className="w-full text-base" onClick={handleStartWizard} disabled={!isHydrated}>
+          <Button size="lg" className="w-full text-base" onClick={handleStartWizard} onMouseEnter={handleStartWizardHover} disabled={!isHydrated}>
              {t('Start For Free', {defaultValue: 'Start For Free'})}
           </Button>
         </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -120,6 +120,7 @@ const SearchBar = React.memo(function SearchBar() {
                     <button
                       type="button"
                       onClick={() => handleSuggestionClick(suggestion.id)}
+                      onMouseEnter={() => router.prefetch(`/${locale}/docs/${suggestion.id}`)}
                       className="w-full text-left px-3 py-2.5 hover:bg-muted text-sm flex items-center gap-2"
                     >
                       <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -53,9 +53,6 @@ const TopDocsChips = React.memo(function TopDocsChips() {
     });
   }, [isHydrated, topDocs, router, locale]);
 
-  const handleChipClick = (docId: string) => {
-    router.push(`/${locale}/docs/${docId}`);
-  };
 
   const handleExploreAll = () => {
     const workflowStartElement = document.getElementById('workflow-start');
@@ -64,6 +61,10 @@ const TopDocsChips = React.memo(function TopDocsChips() {
     } else {
       router.push(`/${locale}/`); // Fallback to homepage
     }
+  };
+
+  const handleExploreAllHover = () => {
+    router.prefetch(`/${locale}/`);
   };
 
   if (isLoading && isHydrated) {
@@ -89,22 +90,25 @@ const TopDocsChips = React.memo(function TopDocsChips() {
       <div className="flex flex-wrap justify-center items-center gap-2 md:gap-3">
         {topDocs.map((doc) => (
           <Button
+            asChild
             key={doc.id}
             variant="outline"
             size="sm"
-            onClick={() => handleChipClick(doc.id)}
             className="bg-card hover:bg-muted border-border text-card-foreground hover:text-primary transition-colors shadow-sm px-4 py-2 h-auto text-xs sm:text-sm"
+            onMouseEnter={() => router.prefetch(`/${locale}/docs/${doc.id}`)}
           >
-            {React.createElement(FileText, { className: "h-4 w-4 mr-2 text-primary/80 opacity-70" })}
-            {(doc.translations?.[locale as 'en' | 'es']?.name) ||
-             doc.translations?.en?.name ||
-             doc.name ||
-             doc.id}
+            <Link href={`/${locale}/docs/${doc.id}`}> 
+              {React.createElement(FileText, { className: "h-4 w-4 mr-2 text-primary/80 opacity-70" })}
+              {(doc.translations?.[locale as 'en' | 'es']?.name) ||
+               doc.translations?.en?.name ||
+               doc.name ||
+               doc.id}
+            </Link>
           </Button>
         ))}
       </div>
       <div className="text-center mt-6">
-        <Button variant="link" onClick={handleExploreAll} className="text-primary text-sm">
+        <Button variant="link" onClick={handleExploreAll} onMouseEnter={handleExploreAllHover} className="text-primary text-sm">
           {tCommon('stepOne.exploreAllCategoriesButton', { defaultValue: 'Explore All Document Categories' })} →
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- lazy load individual doc preview components
- prefetch doc detail route on hover in DocPageClient
- replace router.push links with `<Link>` in TopDocsChips
- prefetch suggestion links in SearchBar

## Testing
- `npm run test`
- `npm run lint` *(fails: next not found)*