### PR TITLE
Fix support page translations

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -163,6 +163,23 @@
   "authModal.promptSignUp": "Don't have an account? Create one",
   "authModal.promptSignIn": "Already have an account? Sign In",
   "authModal.createFreeAccount": "Create Free Account",
+  "support": {
+    "title": "Support Center",
+    "subtitle": "Need help? We're here to assist you.",
+    "contact": {
+      "title": "Contact Us",
+      "hours": "Mon–Fri, 9am–6pm EST"
+    },
+    "help": {
+      "title": "Common Help Topics",
+      "item1": "I didn’t receive my document",
+      "item2": "I need to edit a clause",
+      "item3": "I can’t download the PDF",
+      "item4": "I need a refund"
+    },
+    "note": "You can also check our FAQ for common questions.",
+    "cta": "Go to FAQ"
+  },
   "home.hero.title": "Legal Docs at Your Fingertips",
   "home.hero.subtitle": "Create, sign & share professional contracts in minutes—no lawyer required.",
   "home.hero.pricingBadge": "One-time $35/document • No subscription",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -163,6 +163,23 @@
   "authModal.promptSignUp": "¿No tienes cuenta? Crea una",
   "authModal.promptSignIn": "¿Ya tienes cuenta? Inicia Sesión",
   "authModal.createFreeAccount": "Crear Cuenta Gratis",
+  "support": {
+    "title": "Centro de Soporte",
+    "subtitle": "¿Necesitas ayuda? Estamos aquí para asistirte.",
+    "contact": {
+      "title": "Contáctanos",
+      "hours": "Lun–Vie, 9am–6pm EST"
+    },
+    "help": {
+      "title": "Temas de Ayuda Comunes",
+      "item1": "No recibí mi documento",
+      "item2": "Necesito editar una cláusula",
+      "item3": "No puedo descargar el PDF",
+      "item4": "Necesito un reembolso"
+    },
+    "note": "También puedes consultar nuestras Preguntas Frecuentes para preguntas comunes.",
+    "cta": "Ir a Preguntas Frecuentes"
+  },
   "home.hero.title": "Documentos Legales al Alcance de tu Mano",
   "home.hero.subtitle": "Crea, firma y comparte contratos profesionales en minutos—sin necesidad de abogado.",
   "home.hero.pricingBadge": "Pago único de $35/documento • Sin suscripción",


### PR DESCRIPTION
## Summary
- restore `support` translation block in English/Spanish `common.json`

## Testing
- `npm test`
