### PR TITLE
Fix inline editing width in review step

### DIFF
--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -219,7 +219,7 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                           id={`review-${field.id}`}
                           type="tel" // SmartInput expects 'tel'
                           placeholder={t(field.placeholder || '', {ns: 'documents', defaultValue: field.placeholder || ''})}
-                          className={cn("max-w-md text-sm", errors[field.id] && "border-destructive")}
+                          className={cn("w-full max-w-md text-sm", errors[field.id] && "border-destructive")}
                           aria-invalid={!!errors[field.id]}
                           rhfProps={register(field.id as any, { required: field.required })}
                         />
@@ -243,7 +243,7 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                                 }
                               }}
                               placeholder={t(field.placeholder || 'Enter address...', {ns: 'documents', defaultValue: field.placeholder || 'Enter address...'})}
-                              className="max-w-md"
+                              className="w-full max-w-md"
                               error={errors[field.id]?.message as string | undefined}
                               tooltip={field.tooltip ? t(field.tooltip, {ns: 'documents', defaultValue: field.tooltip}) : undefined}
                             />
@@ -276,7 +276,7 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                               name: controllerField.name,
                               ref: controllerField.ref,
                               placeholder: t(field.placeholder || '', {ns: 'documents', defaultValue: field.placeholder || ''}),
-                              className: cn("max-w-md text-sm", errors[field.id] && "border-destructive"),
+                              className: cn("w-full max-w-md text-sm", errors[field.id] && "border-destructive"),
                               "aria-invalid": !!errors[field.id],
                             };
 
@@ -292,7 +292,7 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                                 >
                                   <SelectTrigger
                                     id={`review-${field.id}`}
-                                    className={cn("max-w-md text-sm", errors[field.id] && "border-destructive focus:ring-destructive")}
+                                    className={cn("w-full max-w-md text-sm", errors[field.id] && "border-destructive focus:ring-destructive")}
                                     aria-invalid={!!errors[field.id]}
                                     aria-label={t(field.placeholder || 'Select...', {ns: 'documents', defaultValue: field.placeholder || 'Select...'})}
                                   >

--- a/src/components/wizard/SmartInput.tsx
+++ b/src/components/wizard/SmartInput.tsx
@@ -84,7 +84,7 @@ const SmartInput = React.memo(React.forwardRef<HTMLInputElement, SmartInputProps
         name={rhfName}
         type={type === 'tel' ? 'text' : type} 
         inputMode={type === 'tel' ? 'tel' : undefined}
-        className={cn("max-w-sm", className)}
+        className={cn("w-full max-w-sm", className)}
         value={displayValue} 
         onChange={handleInputChange}
         onBlur={handleBlur} 


### PR DESCRIPTION
## Summary
- ensure SmartInput spans full width
- keep layout stable for ReviewStep editing inputs

## Testing
- `npm test`