### PR TITLE
Upgrade bill-of-sale form

### DIFF
--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -77,8 +77,8 @@ const DocumentDetail = React.memo(function DocumentDetail({ docId, locale, altTe
                 modifiedMd = modifiedMd.replace(/^# .*/m, `# ${fallbackTitle}`);
             }
         }
-        // Replace template placeholders with blank lines to mimic a fillable form
-        modifiedMd = modifiedMd.replace(/{{[^}]+}}/g, '__________');
+        // Replace scalar placeholders but keep loops intact
+        modifiedMd = modifiedMd.replace(/{{(?!#each)(?!\/each)[^}]+}}/g, '__________');
         setMd(modifiedMd);
       })
       .catch((err) => {

--- a/src/components/PartyGroupField.tsx
+++ b/src/components/PartyGroupField.tsx
@@ -1,35 +1,114 @@
-import React, { useState } from 'react';
-import { useFormContext } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
-import FieldRenderer from './FieldRenderer';
+import React from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { Plus, Trash2 } from 'lucide-react';
+import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import type { LegalDocument } from '@/types/documents';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
 interface PartyGroupFieldProps {
-  role: 'seller' | 'buyer';
+  name: 'sellers' | 'buyers';
   locale: 'en' | 'es';
-  doc: LegalDocument;
+  max?: number;
+  itemLabel?: string;
 }
 
-export default function PartyGroupField({ role, locale, doc }: PartyGroupFieldProps) {
-  const { watch } = useFormContext();
-  const { t } = useTranslation('common');
-  const [showSecond, setShowSecond] = useState(() => !!watch(`${role}2_name` as any));
+export default function PartyGroupField({ name, locale, max = 3, itemLabel }: PartyGroupFieldProps) {
+  const { control, register, formState: { errors } } = useFormContext();
+  const { fields, append, remove } = useFieldArray({ control, name });
+
+  React.useEffect(() => {
+    if (fields.length === 0) {
+      append({ name: '', address: '', phone: '' });
+    }
+  }, [append, fields.length]);
+
+  const itemLabelText = itemLabel || (name === 'sellers' ? (locale === 'es' ? 'Vendedor' : 'Seller') : (locale === 'es' ? 'Comprador' : 'Buyer'));
 
   return (
-    <div className="space-y-4">
-      <FieldRenderer fieldKey={`${role}_name`} locale={locale} doc={doc} />
-      <FieldRenderer fieldKey={`${role}_phone`} locale={locale} doc={doc} />
-      <FieldRenderer fieldKey={`${role}_address`} locale={locale} doc={doc} />
-      {showSecond && (
-        <>
-          <FieldRenderer fieldKey={`${role}2_name`} locale={locale} doc={doc} />
-          <FieldRenderer fieldKey={`${role}2_phone`} locale={locale} doc={doc} />
-        </>
-      )}
-      {!showSecond && (
-        <Button type="button" variant="outline" onClick={() => setShowSecond(true)}>
-          {role === 'seller' ? t('Add Another Seller') : t('Add Another Buyer')}
+    <div className="space-y-6">
+      {fields.map((field, index) => {
+        const prefix = `${name}[${index}]` as const;
+        return (
+          <Card key={field.id} className="bg-muted/30 border border-muted-foreground/20">
+            <CardContent className="grid grid-cols-1 gap-4 p-4">
+              <h4 className="font-semibold text-sm mb-2">
+                {itemLabelText} {index + 1}
+              </h4>
+              <div>
+                <Label htmlFor={`${prefix}.name`} className="text-sm font-medium">
+                  {locale === 'es' ? 'Nombre completo' : 'Full Name'}
+                </Label>
+                <Input
+                  id={`${prefix}.name`}
+                  {...register(`${prefix}.name`, { required: true })}
+                  className={cn(errors?.[name]?.[index]?.name && 'border-destructive')}
+                />
+                {errors?.[name]?.[index]?.name && (
+                  <p className="text-xs text-destructive mt-1">
+                    {locale === 'es' ? 'Se requiere el nombre.' : 'Name is required.'}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <Label htmlFor={`${prefix}.address`} className="text-sm font-medium">
+                  {locale === 'es' ? 'Dirección' : 'Address'}
+                </Label>
+                <Input
+                  id={`${prefix}.address`}
+                  {...register(`${prefix}.address`, { required: true })}
+                  className={cn(errors?.[name]?.[index]?.address && 'border-destructive')}
+                />
+                {errors?.[name]?.[index]?.address && (
+                  <p className="text-xs text-destructive mt-1">
+                    {locale === 'es' ? 'Se requiere la dirección.' : 'Address is required.'}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <Label htmlFor={`${prefix}.phone`} className="text-sm font-medium">
+                  {locale === 'es' ? 'Teléfono (opcional)' : 'Phone (optional)'}
+                </Label>
+                <Input
+                  id={`${prefix}.phone`}
+                  {...register(`${prefix}.phone`)}
+                  placeholder="(123) 456-7890"
+                  className={cn(errors?.[name]?.[index]?.phone && 'border-destructive')}
+                />
+                {errors?.[name]?.[index]?.phone && (
+                  <p className="text-xs text-destructive mt-1">
+                    {locale === 'es' ? 'Formato de teléfono inválido.' : 'Invalid phone format. Expected (123) 456-7890.'}
+                  </p>
+                )}
+              </div>
+
+              {fields.length > 1 && (
+                <div className="flex justify-end">
+                  <Button type="button" variant="destructive" size="sm" onClick={() => remove(index)} className="text-xs">
+                    <Trash2 className="h-4 w-4 mr-1" /> {locale === 'es' ? 'Eliminar' : 'Remove'}
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      {fields.length < max && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => append({ name: '', address: '', phone: '' })}
+          className="text-sm"
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          {locale === 'es'
+            ? `Agregar otro ${name === 'sellers' ? 'vendedor' : 'comprador'}`
+            : `Add Another ${name === 'sellers' ? 'Seller' : 'Buyer'}`}
         </Button>
       )}
     </div>

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -183,8 +183,30 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
       </CardHeader>
       <CardContent className="space-y-2">
         {fieldsToReview.map((field) => {
+          if (field.id === 'sellers' || field.id === 'buyers') {
+            const parties = getValues(field.id) || [];
+            const heading = field.id === 'sellers'
+              ? locale === 'es' ? 'Vendedor' : 'Seller'
+              : locale === 'es' ? 'Comprador' : 'Buyer';
+            return (
+              <div key={field.id} className="py-3 border-b border-border last:border-b-0">
+                <h3 className="text-sm font-medium text-muted-foreground mb-2">
+                  {t(field.label, { ns: 'documents', defaultValue: field.label })}
+                </h3>
+                <div className="space-y-2">
+                  {parties.map((p: any, i: number) => (
+                    <div key={i} className="border rounded p-3 bg-muted/40">
+                      <p className="font-semibold mb-1">{heading} {i + 1}</p>
+                      <p><strong>{t('Full Name')}:</strong> {p.name || <em>{t('Not Provided')}</em>}</p>
+                      <p><strong>{t('Address')}:</strong> {p.address || <em>{t('Not Provided')}</em>}</p>
+                      <p><strong>{t('Phone')}:</strong> {p.phone || <em>{t('Not Provided')}</em>}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          }
           const isCurrentlyEditing = editingFieldId === field.id;
-          // console.log(`[ReviewStep] Rendering field: ${field.id}, isCurrentlyEditing: ${isCurrentlyEditing}`);
           return (
             <div
               key={field.id}

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -324,11 +324,17 @@ export default function WizardForm({
   const formContent = currentField
     ? (
         <div className="mt-6 space-y-6 min-h-[200px]">
-          {currentQuestion?.type === 'group' ? (
+          {currentQuestion?.type === 'group-array' ? (
+            <PartyGroupField
+              name={currentQuestion.id as 'sellers' | 'buyers'}
+              locale={locale}
+              itemLabel={currentQuestion.itemLabel}
+            />
+          ) : currentQuestion?.type === 'group' ? (
             currentQuestion.id === 'seller_info' ? (
-              <PartyGroupField role="seller" locale={locale} doc={doc} />
+              <PartyGroupField name="sellers" locale={locale} />
             ) : (
-              <PartyGroupField role="buyer" locale={locale} doc={doc} />
+              <PartyGroupField name="buyers" locale={locale} />
             )
           ) : currentField.id &&
             actualSchemaShape &&

--- a/src/data/templates/en/bill-of-sale-vehicle.md
+++ b/src/data/templates/en/bill-of-sale-vehicle.md
@@ -5,8 +5,13 @@
 
 This Vehicle Bill of Sale ("Agreement") is made and entered into on **{{sale_date}}**, by and between:
 
-- **Seller:** {{seller_name}}, of {{seller_address}}
-- **Buyer:**  {{buyer_name}}, of {{buyer_address}}
+{{#each sellers}}
+- **Seller:** {{this.name}}, of {{this.address}}{{#if this.phone}}, Phone: {{this.phone}}{{/if}}
+{{/each}}
+
+{{#each buyers}}
+- **Buyer:** {{this.name}}, of {{this.address}}{{#if this.phone}}, Phone: {{this.phone}}{{/if}}
+{{/each}}
 
 Collectively referred to herein as the “Parties.”
 
@@ -58,33 +63,27 @@ This Agreement shall be governed by and construed in accordance with the laws of
 
 | Seller Signature        | Date                 |
 |-------------------------|----------------------|
+{{#each sellers}}
 | ________________________| _____________________|
-| ({{seller_name}})       |                      |
-| {{#if seller_phone}}Phone: {{seller_phone}}{{/if}} | |
-{{#if seller2_name}}
-| ________________________| _____________________|
-| ({{seller2_name}})      |                      |
-| {{#if seller2_phone}}Phone: {{seller2_phone}}{{/if}} | |
-{{/if}}
+| ({{this.name}})       |                      |
+| {{#if this.phone}}Phone: {{this.phone}}{{/if}} | |
+{{/each}}
 
 
 | Buyer Signature         | Date                 |
 |-------------------------|----------------------|
+{{#each buyers}}
 | ________________________| _____________________|
-| ({{buyer_name}})        |                      |
-| {{#if buyer_phone}}Phone: {{buyer_phone}}{{/if}} | |
-{{#if buyer2_name}}
-| ________________________| _____________________|
-| ({{buyer2_name}})       |                      |
-| {{#if buyer2_phone}}Phone: {{buyer2_phone}}{{/if}} | |
-{{/if}}
+| ({{this.name}})        |                      |
+| {{#if this.phone}}Phone: {{this.phone}}{{/if}} | |
+{{/each}}
 
 ### Notary Acknowledgment
 
 State of **{{state}}**
 County of **{{county}}**
 
-On this **____** day of **______________, 20__**, before me, the undersigned, a Notary Public in and for said State, personally appeared **{{seller_name}}** and **{{buyer_name}}**, personally known to me (or proved to me on the basis of satisfactory evidence) to be the persons whose names are subscribed to this Agreement and acknowledged that they executed the same for the purposes therein contained.
+On this **____** day of **______________, 20__**, before me, the undersigned, a Notary Public in and for said State, personally appeared {{#each sellers}}{{this.name}}{{#unless @last}}, {{/unless}}{{/each}} and {{#each buyers}}{{this.name}}{{#unless @last}}, {{/unless}}{{/each}}, personally known to me (or proved to me on the basis of satisfactory evidence) to be the persons whose names are subscribed to this Agreement and acknowledged that they executed the same for the purposes therein contained.
 
 **Notary Public:**   __________________________
 My Commission Expires: ______________

--- a/src/data/templates/es/bill-of-sale-vehicle.md
+++ b/src/data/templates/es/bill-of-sale-vehicle.md
@@ -5,8 +5,13 @@
 
 Este Contrato de Compraventa de Vehículo ("Acuerdo") se celebra y entra en vigor el **{{sale_date}}**, entre:
 
-- **Vendedor:** {{seller_name}}, de {{seller_address}}
-- **Comprador:**  {{buyer_name}}, de {{buyer_address}}
+{{#each sellers}}
+- **Vendedor:** {{this.name}}, con domicilio en {{this.address}}{{#if this.phone}}, Teléfono: {{this.phone}}{{/if}}
+{{/each}}
+
+{{#each buyers}}
+- **Comprador:** {{this.name}}, con domicilio en {{this.address}}{{#if this.phone}}, Teléfono: {{this.phone}}{{/if}}
+{{/each}}
 
 Referidos colectivamente en este documento como las “Partes”.
 
@@ -58,33 +63,27 @@ Este Acuerdo se regirá e interpretará de conformidad con las leyes del Estado 
 
 | Firma del Vendedor      | Fecha                |
 |-------------------------|----------------------|
+{{#each sellers}}
 | ________________________| _____________________|
-| ({{seller_name}})       |                      |
-| {{#if seller_phone}}Teléfono: {{seller_phone}}{{/if}} | |
-{{#if seller2_name}}
-| ________________________| _____________________|
-| ({{seller2_name}})      |                      |
-| {{#if seller2_phone}}Teléfono: {{seller2_phone}}{{/if}} | |
-{{/if}}
+| ({{this.name}})       |                      |
+| {{#if this.phone}}Teléfono: {{this.phone}}{{/if}} | |
+{{/each}}
 
 
 | Firma del Comprador     | Fecha                |
 |-------------------------|----------------------|
+{{#each buyers}}
 | ________________________| _____________________|
-| ({{buyer_name}})        |                      |
-| {{#if buyer_phone}}Teléfono: {{buyer_phone}}{{/if}} | |
-{{#if buyer2_name}}
-| ________________________| _____________________|
-| ({{buyer2_name}})       |                      |
-| {{#if buyer2_phone}}Teléfono: {{buyer2_phone}}{{/if}} | |
-{{/if}}
+| ({{this.name}})        |                      |
+| {{#if this.phone}}Teléfono: {{this.phone}}{{/if}} | |
+{{/each}}
 
 ### Reconocimiento Notarial
 
 Estado de **{{state}}**
 Condado de **{{county}}**
 
-En este día **____** de **______________, 20__**, ante mí, el suscrito, Notario Público en y para dicho Estado, comparecieron personalmente **{{seller_name}}** y **{{buyer_name}}**, conocidos personalmente por mí (o comprobados ante mí sobre la base de evidencia satisfactoria) como las personas cuyos nombres están suscritos a este Acuerdo y reconocieron que lo ejecutaron para los fines contenidos en el mismo.
+En este día **____** de **______________, 20__**, ante mí, el suscrito, Notario Público en y para dicho Estado, comparecieron personalmente {{#each sellers}}{{this.name}}{{#unless @last}}, {{/unless}}{{/each}} y {{#each buyers}}{{this.name}}{{#unless @last}}, {{/unless}}{{/each}}, conocidos personalmente por mí (o comprobados ante mí sobre la base de evidencia satisfactoria) como las personas cuyos nombres están suscritos a este Acuerdo y reconocieron que lo ejecutaron para los fines contenidos en el mismo.
 
 **Notario Público:**   __________________________
 Mi Comisión Expira: ______________

--- a/src/lib/documents/us/vehicle-bill-of-sale/questions.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/questions.ts
@@ -1,79 +1,31 @@
 import { usStates } from '@/lib/usStates';
 
 export const vehicleBillOfSaleQuestions = [
-  { 
-    id: "seller_name", 
-    label: "Seller's Full Name", 
-    type: "text", 
-    required: true, 
-    tooltip: "Enter the full legal name of the person or entity selling the vehicle." 
+  {
+    id: 'sellers',
+    label: 'Seller(s)',
+    type: 'group-array',
+    itemLabel: 'Seller',
+    fields: [
+      { id: 'name', label: 'Full Name', type: 'text', required: true },
+      { id: 'address', label: 'Address', type: 'text', required: true },
+      { id: 'phone', label: 'Phone Number', type: 'text', required: false, placeholder: '(XXX) XXX-XXXX' }
+    ],
+    minItems: 1,
+    maxItems: 3
   },
   {
-    id: "seller_phone",
-    label: "Seller's Phone Number",
-    type: "text",
-    required: false,
-    placeholder: "(XXX) XXX-XXXX",
-    tooltip: "A valid phone number for the seller."
-  },
-  {
-    id: "seller2_name",
-    label: "Second Seller's Full Name",
-    type: "text",
-    required: false,
-    tooltip: "Optional second seller name if more than one person is selling the vehicle."
-  },
-  {
-    id: "seller2_phone",
-    label: "Second Seller's Phone Number",
-    type: "text",
-    required: false,
-    placeholder: "(XXX) XXX-XXXX",
-    tooltip: "Phone number for the second seller, if applicable."
-  },
-  {
-    id: "seller_address",
-    label: "Seller's Full Address", 
-    type: "address", 
-    required: true, 
-    tooltip: "Include street, city, state, and ZIP code." 
-  },
-  { 
-    id: "buyer_name", 
-    label: "Buyer's Full Name", 
-    type: "text", 
-    required: true, 
-    tooltip: "Enter the full legal name of the person or entity buying the vehicle." 
-  },
-  { 
-    id: "buyer_address", 
-    label: "Buyer's Full Address", 
-    type: "address", 
-    required: true, 
-    tooltip: "Include street, city, state, and ZIP code for the buyer." 
-  },
-  {
-    id: "buyer_phone",
-    label: "Buyer's Phone Number",
-    type: "text",
-    required: false,
-    placeholder: "(XXX) XXX-XXXX",
-    tooltip: "A valid phone number for the buyer."
-  },
-  {
-    id: "buyer2_name",
-    label: "Second Buyer's Full Name",
-    type: "text",
-    required: false,
-    tooltip: "Optional second buyer name if more than one person is purchasing the vehicle."
-  },
-  {
-    id: "buyer2_phone",
-    label: "Second Buyer's Phone Number",
-    type: "text",
-    required: false,
-    placeholder: "(XXX) XXX-XXXX",
-    tooltip: "Phone number for the second buyer, if applicable."
+    id: 'buyers',
+    label: 'Buyer(s)',
+    type: 'group-array',
+    itemLabel: 'Buyer',
+    fields: [
+      { id: 'name', label: 'Full Name', type: 'text', required: true },
+      { id: 'address', label: 'Address', type: 'text', required: true },
+      { id: 'phone', label: 'Phone Number', type: 'text', required: false, placeholder: '(XXX) XXX-XXXX' }
+    ],
+    minItems: 1,
+    maxItems: 3
   },
   {
     id: "year",

--- a/src/schemas/billOfSale.ts
+++ b/src/schemas/billOfSale.ts
@@ -2,66 +2,54 @@
 import { z } from 'zod';
 import { isValidVIN } from '@/utils/isValidVIN';
 
-export const BillOfSaleSchema = z.object({
-  /* ---------- Seller ---------- */
-  seller_name:      z.string().min(2, { message: "Seller name must be at least 2 characters." }),
-  seller_address:   z.string().min(5, { message: "Seller address must be at least 5 characters." }),
-  seller_phone:     z.string()
-                     .optional()
-                     .refine(val => val === undefined || val === "" || /^\(\d{3}\)\s\d{3}-\d{4}$/.test(val), {
-                        message: "Phone number must be in (XXX) XXX-XXXX format or empty.",
-                     }),
-  seller2_name:     z.string().optional(),
-  seller2_phone:    z.string()
-                     .optional()
-                     .refine(val => val === undefined || val === "" || /^\(\d{3}\)\s\d{3}-\d{4}$/.test(val), {
-                        message: "Phone number must be in (XXX) XXX-XXXX format or empty.",
-                     }),
+const PartySchema = z.object({
+  name: z.string().min(2, { message: 'Name must be at least 2 characters.' }),
+  address: z.string().min(5, { message: 'Address must be at least 5 characters.' }),
+  phone: z.string()
+    .optional()
+    .refine(val => !val || /^\(\d{3}\)\s\d{3}-\d{4}$/.test(val), {
+      message: 'Phone number must be in (XXX) XXX-XXXX format or empty.',
+    }),
+});
 
-  /* ---------- Buyer ---------- */
-  buyer_name:       z.string().min(2, { message: "Buyer name must be at least 2 characters." }),
-  buyer_address:    z.string().min(5, { message: "Buyer address must be at least 5 characters." }),
-  buyer_phone:      z.string()
-                     .optional()
-                     .refine(val => val === undefined || val === "" || /^\(\d{3}\)\s\d{3}-\d{4}$/.test(val), {
-                        message: "Phone number must be in (XXX) XXX-XXXX format or empty.",
-                     }),
-  buyer2_name:      z.string().optional(),
-  buyer2_phone:     z.string()
-                     .optional()
-                     .refine(val => val === undefined || val === "" || /^\(\d{3}\)\s\d{3}-\d{4}$/.test(val), {
-                        message: "Phone number must be in (XXX) XXX-XXXX format or empty.",
-                     }),
+export const BillOfSaleSchema = z.object({
+  sellers: z.array(PartySchema).min(1, 'At least one seller is required'),
+  buyers: z.array(PartySchema).min(1, 'At least one buyer is required'),
 
   /* ---------- Vehicle ---------- */
-  vin:              z.string().trim().length(17, { message: 'VIN must be 17 characters.'})
-                     .refine(isValidVIN, { message: 'Invalid VIN format or characters.'}),
-  year:             z.coerce.number({invalid_type_error: "Vehicle year must be a number."})
-                     .int({ message: "Vehicle year must be a whole number."})
-                     .gte(1900, { message: "Vehicle year must be 1900 or later." })
-                     .lte(new Date().getFullYear() + 1, { message: "Vehicle year cannot be in the far future." }),
-  make:             z.string().min(2, { message: "Vehicle make is required."}).regex(/^[a-zA-Z0-9\s-]+$/, { message: 'Invalid characters in vehicle make.'}).optional(),
-  model:            z.string().min(1, { message: "Vehicle model is required."}).optional(),
-  color:            z.string().min(2, { message: "Vehicle color is required."}).regex(/^[a-zA-Z\s]+$/, { message: 'Only letters and spaces allowed for color.'}).optional(),
-
+  vin: z.string().trim().length(17, { message: 'VIN must be 17 characters.' })
+    .refine(isValidVIN, { message: 'Invalid VIN format or characters.' }),
+  year: z.coerce.number({ invalid_type_error: 'Vehicle year must be a number.' })
+    .int({ message: 'Vehicle year must be a whole number.' })
+    .gte(1900, { message: 'Vehicle year must be 1900 or later.' })
+    .lte(new Date().getFullYear() + 1, { message: 'Vehicle year cannot be in the far future.' }),
+  make: z.string().min(2, { message: 'Vehicle make is required.' })
+    .regex(/^[a-zA-Z0-9\s-]+$/, { message: 'Invalid characters in vehicle make.' }).optional(),
+  model: z.string().min(1, { message: 'Vehicle model is required.' }).optional(),
+  color: z.string().min(2, { message: 'Vehicle color is required.' })
+    .regex(/^[a-zA-Z\s]+$/, { message: 'Only letters and spaces allowed for color.' }).optional(),
 
   /* ---------- Sale ---------- */
-  sale_date:        z.coerce.date({invalid_type_error: "Invalid sale date."}),
-  price:            z.coerce.number({invalid_type_error: "Price must be a number."}).positive({ message: "Price must be a positive number." }),
-  payment_method:   z.enum(['cash', 'check', 'wire', 'paypal', 'credit_card'], { errorMap: () => ({ message: "Please select a valid payment method."}) }).optional(),
-
+  sale_date: z.coerce.date({ invalid_type_error: 'Invalid sale date.' }),
+  price: z.coerce.number({ invalid_type_error: 'Price must be a number.' }).positive({ message: 'Price must be a positive number.' }),
+  payment_method: z.enum(['cash', 'check', 'wire', 'paypal', 'credit_card'], {
+    errorMap: () => ({ message: 'Please select a valid payment method.' }),
+  }).optional(),
 
   /* ---------- Odometer ---------- */
-  odometer:         z.coerce.number({invalid_type_error: "Odometer reading must be a number."}).int({ message: "Odometer reading must be a whole number."}).gte(0, { message: "Odometer reading must be non-negative." }),
-  odo_status:       z.enum(['ACTUAL', 'EXCEEDS', 'NOT_ACTUAL'], { errorMap: () => ({ message: "Please select a valid odometer status."}) }),
-  
-  /* ---------- Warranty & State ---------- */
-  as_is:        z.boolean().optional().default(true),
-  warranty_text:z.string().optional(),
-  existing_liens: z.string().optional(),
-  state:        z.string().length(2, { message: "State must be 2 characters." }),
-  county:       z.string().optional(),
+  odometer: z.coerce.number({ invalid_type_error: 'Odometer reading must be a number.' })
+    .int({ message: 'Odometer reading must be a whole number.' })
+    .gte(0, { message: 'Odometer reading must be non-negative.' }),
+  odo_status: z.enum(['ACTUAL', 'EXCEEDS', 'NOT_ACTUAL'], {
+    errorMap: () => ({ message: 'Please select a valid odometer status.' }),
+  }),
 
+  /* ---------- Warranty & State ---------- */
+  as_is: z.boolean().optional().default(true),
+  warranty_text: z.string().optional(),
+  existing_liens: z.string().optional(),
+  state: z.string().length(2, { message: 'State must be 2 characters.' }),
+  county: z.string().optional(),
 }).refine(data => data.as_is === false ? !!data.warranty_text && data.warranty_text.trim() !== '' : true, {
   message: "Warranty details are required if not sold 'as-is'",
   path: ['warranty_text'],

--- a/tests/prettify.test.js
+++ b/tests/prettify.test.js
@@ -22,3 +22,99 @@ test('prettify converts snake_case to title case', () => {
 test('prettify converts camelCase to title case', () => {
   assert.strictEqual(prettify('vehicleVin'), 'Vehicle Vin');
 });
+
+// -------- BillOfSaleSchema Tests --------
+import { z } from 'zod';
+function isValidVIN(vin) {
+  if (typeof vin !== 'string') return false;
+  const vinUpper = vin.trim().toUpperCase();
+  return /^[A-HJ-NPR-Z0-9]{17}$/.test(vinUpper);
+}
+
+const schemaPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'src', 'schemas', 'billOfSale.ts');
+const schemaTs = fs.readFileSync(schemaPath, 'utf8');
+const schemaJs = schemaTs
+  .replace(/import[^;]+;\n/g, '')
+  .replace('export const BillOfSaleSchema', 'const BillOfSaleSchema')
+  .replace(/export type [^;]+;/g, '');
+// eslint-disable-next-line no-new-func
+const loadSchema = new Function('z', 'isValidVIN', `${schemaJs}; return BillOfSaleSchema;`);
+const BillOfSaleSchema = loadSchema(z, isValidVIN);
+
+test('BillOfSaleSchema accepts 1 seller and 1 buyer', () => {
+  const result = BillOfSaleSchema.safeParse({
+    sellers: [{ name: 'Alice', address: '123 Main', phone: '(123) 456-7890' }],
+    buyers: [{ name: 'Bob', address: '456 Oak', phone: '' }],
+    vin: '1HGCM82633A004352',
+    year: 2020,
+    make: 'Honda',
+    model: 'Civic',
+    color: 'Blue',
+    sale_date: new Date(),
+    price: 5000,
+    odometer: 1000,
+    odo_status: 'ACTUAL',
+    state: 'CA'
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test('BillOfSaleSchema accepts multiple sellers and buyers', () => {
+  const result = BillOfSaleSchema.safeParse({
+    sellers: [
+      { name: 'Alice', address: '123 Main', phone: '' },
+      { name: 'Carol', address: '789 Pine', phone: '(111) 222-3333' }
+    ],
+    buyers: [
+      { name: 'Bob', address: '456 Oak', phone: '' },
+      { name: 'Dave', address: '321 Cedar', phone: '(222) 333-4444' }
+    ],
+    vin: '1HGCM82633A004352',
+    year: 2021,
+    make: 'Ford',
+    model: 'F150',
+    color: 'Red',
+    sale_date: new Date(),
+    price: 10000,
+    odometer: 2000,
+    odo_status: 'ACTUAL',
+    state: 'TX'
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test('BillOfSaleSchema fails with no sellers', () => {
+  const result = BillOfSaleSchema.safeParse({
+    sellers: [],
+    buyers: [{ name: 'Bob', address: '456 Oak', phone: '' }],
+    vin: '1HGCM82633A004352',
+    year: 2020,
+    make: 'Honda',
+    model: 'Civic',
+    color: 'Blue',
+    sale_date: new Date(),
+    price: 5000,
+    odometer: 1000,
+    odo_status: 'ACTUAL',
+    state: 'CA'
+  });
+  assert.strictEqual(result.success, false);
+});
+
+test('BillOfSaleSchema fails with invalid phone format', () => {
+  const result = BillOfSaleSchema.safeParse({
+    sellers: [{ name: 'Alice', address: '123 Main', phone: '123-456-7890' }],
+    buyers: [{ name: 'Bob', address: '456 Oak', phone: '' }],
+    vin: '1HGCM82633A004352',
+    year: 2020,
+    make: 'Honda',
+    model: 'Civic',
+    color: 'Blue',
+    sale_date: new Date(),
+    price: 5000,
+    odometer: 1000,
+    odo_status: 'ACTUAL',
+    state: 'CA'
+  });
+  assert.strictEqual(result.success, false);
+});


### PR DESCRIPTION
## Summary
- switch bill-of-sale schema to dynamic sellers/buyers arrays
- update questions to use `group-array` blocks
- use loops for sellers/buyers in templates
- add PartyGroupField component and integrate into WizardForm/ReviewStep
- adjust DocumentDetail placeholder logic
- add validation tests for BillOfSaleSchema
- improve party field UX

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*
