### PR TITLE
Improve party group behavior and review headings

### DIFF
--- a/src/components/PartyGroupField.tsx
+++ b/src/components/PartyGroupField.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { Plus, Trash2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -11,11 +12,19 @@ interface PartyGroupFieldProps {
   name: 'sellers' | 'buyers';
   locale: 'en' | 'es';
   max?: number;
+  itemLabel?: string;
 }
 
-export default function PartyGroupField({ name, locale, max = 3 }: PartyGroupFieldProps) {
+export default function PartyGroupField({ name, locale, max = 3, itemLabel }: PartyGroupFieldProps) {
+  const { t } = useTranslation('common');
   const { control, register, formState: { errors } } = useFormContext();
   const { fields, append, remove } = useFieldArray({ control, name });
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      append({ name: '', address: '', phone: '' });
+    }
+  }, [fields, append]);
 
   return (
     <div className="space-y-6">
@@ -24,6 +33,9 @@ export default function PartyGroupField({ name, locale, max = 3 }: PartyGroupFie
         return (
           <Card key={field.id} className="bg-muted/30 border border-muted-foreground/20">
             <CardContent className="grid grid-cols-1 gap-4 p-4">
+              <h4 className="text-sm font-semibold">
+                {t(itemLabel || (name === 'sellers' ? 'Seller' : 'Buyer'), { defaultValue: itemLabel || (name === 'sellers' ? 'Seller' : 'Buyer') })} {index + 1}
+              </h4>
               <div>
                 <Label htmlFor={`${prefix}.name`} className="text-sm font-medium">
                   {locale === 'es' ? 'Nombre completo' : 'Full Name'}
@@ -87,7 +99,10 @@ export default function PartyGroupField({ name, locale, max = 3 }: PartyGroupFie
 
       {fields.length < max && (
         <Button type="button" variant="outline" size="sm" onClick={() => append({ name: '', address: '', phone: '' })} className="text-sm">
-          <Plus className="h-4 w-4 mr-1" /> {locale === 'es' ? 'Agregar otro' : 'Add another'}
+          <Plus className="h-4 w-4 mr-1" />
+          {locale === 'es'
+            ? `Agregar otro ${name === 'sellers' ? 'vendedor' : 'comprador'}`
+            : `Add Another ${t(itemLabel || (name === 'sellers' ? 'Seller' : 'Buyer'), { defaultValue: itemLabel || (name === 'sellers' ? 'Seller' : 'Buyer') })}`}
         </Button>
       )}
     </div>

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -118,7 +118,8 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
         const tooltip = questionConfig?.tooltip || (schemaFieldDef as any)?.tooltip;
         const required = questionConfig?.required ?? (schemaFieldDef?.typeName !== 'ZodOptional' && schemaFieldDef?.innerType?._def?.typeName !== 'ZodOptional');
 
-        return { id: fieldId, label, type: fieldType, options, required, placeholder, tooltip };
+        const itemLabel = questionConfig?.itemLabel;
+        return { id: fieldId, label, type: fieldType, options, required, placeholder, tooltip, itemLabel };
       });
   }, [doc, actualSchemaShape, getValues, t, watchedValues]); // watchedValues dependency
 
@@ -185,6 +186,7 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
         {fieldsToReview.map((field) => {
           if (field.id === 'sellers' || field.id === 'buyers') {
             const parties = getValues(field.id) || [];
+            const baseLabel = field.itemLabel || (field.id === 'sellers' ? 'Seller' : 'Buyer');
             return (
               <div key={field.id} className="py-3 border-b border-border last:border-b-0">
                 <h3 className="text-sm font-medium text-muted-foreground mb-2">
@@ -193,6 +195,9 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                 <div className="space-y-2">
                   {parties.map((p: any, i: number) => (
                     <div key={i} className="border rounded p-3 bg-muted/40">
+                      <h4 className="text-sm font-semibold mb-1">
+                        {t(baseLabel, { defaultValue: baseLabel })} {i + 1}
+                      </h4>
                       <p><strong>{t('Full Name')}:</strong> {p.name || <em>{t('Not Provided')}</em>}</p>
                       <p><strong>{t('Address')}:</strong> {p.address || <em>{t('Not Provided')}</em>}</p>
                       <p><strong>{t('Phone')}:</strong> {p.phone || <em>{t('Not Provided')}</em>}</p>

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -325,13 +325,11 @@ export default function WizardForm({
     ? (
         <div className="mt-6 space-y-6 min-h-[200px]">
           {currentQuestion?.type === 'group-array' ? (
-            <PartyGroupField name={currentQuestion.id as 'sellers' | 'buyers'} locale={locale} />
-          ) : currentQuestion?.type === 'group' ? (
-            currentQuestion.id === 'seller_info' ? (
-              <PartyGroupField name="sellers" locale={locale} />
-            ) : (
-              <PartyGroupField name="buyers" locale={locale} />
-            )
+            <PartyGroupField
+              name={currentQuestion.id as 'sellers' | 'buyers'}
+              locale={locale}
+              itemLabel={currentQuestion.itemLabel}
+            />
           ) : currentField.id &&
             actualSchemaShape &&
             (actualSchemaShape as any)[currentField.id] ? (


### PR DESCRIPTION
## Summary
- auto-create first party entry and show numbering
- show seller/buyer headings in review step
- pass item label to party component

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*