### PR TITLE
Fix multi-party wizard flow and preview

### DIFF
--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -77,8 +77,32 @@ const DocumentDetail = React.memo(function DocumentDetail({ docId, locale, altTe
                 modifiedMd = modifiedMd.replace(/^# .*/m, `# ${fallbackTitle}`);
             }
         }
-        // Replace scalar placeholders but keep loops intact
-        modifiedMd = modifiedMd.replace(/{{(?!#each)(?!\/each)[^}]+}}/g, '__________');
+        const sampleData: Record<string, string> = {
+          'seller_name': 'Alice Carter',
+          'seller_address': '123 Maple St, Austin, TX',
+          'seller_phone': '(512) 555-1234',
+          'buyer_name': 'Bob Rivera',
+          'buyer_address': '456 Oak Ave, Houston, TX',
+          'buyer_phone': '(832) 555-5678',
+          'vin': '1HGCM82633A004352',
+          'make': 'Toyota',
+          'model': 'Camry',
+          'year': '2018',
+          'color': 'Silver',
+          'odometer': '45,000',
+          'sale_date': 'April 10, 2024',
+          'price': '$10,000',
+          'payment_method': 'Cash',
+          'state': 'TX',
+          'county': 'Travis',
+          'warranty_text': 'Seller guarantees no defects for 30 days.',
+          'existing_liens': 'None'
+        };
+
+        modifiedMd = modifiedMd.replace(/{{(?!#each)(?!\/each)[^}]+}}/g, (match) => {
+          const key = match.replace(/[{}]/g, '').trim();
+          return sampleData[key] || '__________';
+        });
         setMd(modifiedMd);
       })
       .catch((err) => {

--- a/src/components/PartyGroupField.tsx
+++ b/src/components/PartyGroupField.tsx
@@ -24,7 +24,7 @@ export default function PartyGroupField({ name, locale, max = 3, itemLabel }: Pa
     if (fields.length === 0) {
       append({ name: '', address: '', phone: '' });
     }
-  }, [fields, append]);
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -33,9 +33,9 @@ export default function PartyGroupField({ name, locale, max = 3, itemLabel }: Pa
         return (
           <Card key={field.id} className="bg-muted/30 border border-muted-foreground/20">
             <CardContent className="grid grid-cols-1 gap-4 p-4">
-              <h4 className="text-sm font-semibold">
-                {t(itemLabel || (name === 'sellers' ? 'Seller' : 'Buyer'), { defaultValue: itemLabel || (name === 'sellers' ? 'Seller' : 'Buyer') })} {index + 1}
-              </h4>
+              <h3 className="text-sm font-semibold">
+                {name === 'sellers' ? `Seller ${index + 1}` : `Buyer ${index + 1}`}
+              </h3>
               <div>
                 <Label htmlFor={`${prefix}.name`} className="text-sm font-medium">
                   {locale === 'es' ? 'Nombre completo' : 'Full Name'}
@@ -102,7 +102,7 @@ export default function PartyGroupField({ name, locale, max = 3, itemLabel }: Pa
           <Plus className="h-4 w-4 mr-1" />
           {locale === 'es'
             ? `Agregar otro ${name === 'sellers' ? 'vendedor' : 'comprador'}`
-            : `Add Another ${t(itemLabel || (name === 'sellers' ? 'Seller' : 'Buyer'), { defaultValue: itemLabel || (name === 'sellers' ? 'Seller' : 'Buyer') })}`}
+            : `Add another ${name === 'sellers' ? 'seller' : 'buyer'}`}
         </Button>
       )}
     </div>

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -185,25 +185,16 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
       <CardContent className="space-y-2">
         {fieldsToReview.map((field) => {
           if (field.id === 'sellers' || field.id === 'buyers') {
-            const parties = getValues(field.id) || [];
-            const baseLabel = field.itemLabel || (field.id === 'sellers' ? 'Seller' : 'Buyer');
             return (
-              <div key={field.id} className="py-3 border-b border-border last:border-b-0">
-                <h3 className="text-sm font-medium text-muted-foreground mb-2">
-                  {t(field.label, { ns: 'documents', defaultValue: field.label })}
-                </h3>
-                <div className="space-y-2">
-                  {parties.map((p: any, i: number) => (
-                    <div key={i} className="border rounded p-3 bg-muted/40">
-                      <h4 className="text-sm font-semibold mb-1">
-                        {t(baseLabel, { defaultValue: baseLabel })} {i + 1}
-                      </h4>
-                      <p><strong>{t('Full Name')}:</strong> {p.name || <em>{t('Not Provided')}</em>}</p>
-                      <p><strong>{t('Address')}:</strong> {p.address || <em>{t('Not Provided')}</em>}</p>
-                      <p><strong>{t('Phone')}:</strong> {p.phone || <em>{t('Not Provided')}</em>}</p>
-                    </div>
-                  ))}
-                </div>
+              <div key={field.id} className="space-y-4">
+                <h3 className="text-md font-semibold text-muted-foreground">{field.label}</h3>
+                {getValues(field.id)?.map((entry: any, i: number) => (
+                  <div key={i} className="border rounded p-3 bg-muted/40">
+                    <p><strong>{t('Full Name')}:</strong> {entry.name || <em>{t('Not Provided')}</em>}</p>
+                    <p><strong>{t('Address')}:</strong> {entry.address || <em>{t('Not Provided')}</em>}</p>
+                    <p><strong>{t('Phone')}:</strong> {entry.phone || <em>{t('Not Provided')}</em>}</p>
+                  </div>
+                ))}
               </div>
             );
           }

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -148,10 +148,14 @@ export default function WizardForm({
     !isReviewing && totalSteps > 0 && currentStepIndex < totalSteps
       ? steps[currentStepIndex]
       : null;
-  const progress =
-    totalSteps > 0
-      ? ((isReviewing ? totalSteps : currentStepIndex + 1) / totalSteps) * 100
-      : 0;
+
+  const totalRequired = doc.questions?.filter(q => q.required).length || 0;
+  const completed = doc.questions?.filter(q => {
+    const val = getValues(q.id as any);
+    return val !== undefined && val !== null && String(val).trim() !== '';
+  }).length || 0;
+
+  const progress = totalRequired > 0 ? (completed / totalRequired) * 100 : 0;
 
   const handlePreviousStep = useCallback(() => {
     if (isReviewing) {
@@ -321,22 +325,21 @@ export default function WizardForm({
 
   const currentQuestion = doc.questions?.find((q) => q.id === currentField?.id);
 
-  const formContent = currentField
-    ? (
-        <div className="mt-6 space-y-6 min-h-[200px]">
-          {currentQuestion?.type === 'group-array' ? (
-            <PartyGroupField
-              name={currentQuestion.id as 'sellers' | 'buyers'}
-              locale={locale}
-              itemLabel={currentQuestion.itemLabel}
-            />
-          ) : currentField.id &&
-            actualSchemaShape &&
-            (actualSchemaShape as any)[currentField.id] ? (
-            (currentField.id.includes('_address') || currentField.id.includes('Address')) ? (
-              <Controller
-                key={`${currentField.id}-controller`}
-                control={control}
+  const formContent =
+    currentField?.id === 'sellers' || currentField?.id === 'buyers'
+      ? (
+          <PartyGroupField name={currentField.id as 'sellers' | 'buyers'} locale={locale} />
+        )
+      : currentField
+        ? (
+            <div className="mt-6 space-y-6 min-h-[200px]">
+              {currentField.id &&
+                actualSchemaShape &&
+                (actualSchemaShape as any)[currentField.id] ? (
+                  (currentField.id.includes('_address') || currentField.id.includes('Address')) ? (
+                    <Controller
+                      key={`${currentField.id}-controller`}
+                      control={control}
                 name={currentField.id as any}
                 render={({ field: { onChange: rhfOnChange, value: rhfValue, name: rhfName } }) => (
                   <AddressField


### PR DESCRIPTION
## Summary
- initialize sellers and buyers by default
- tweak heading and add button for party groups
- render sellers/buyers in review step
- calculate progress from required fields
- improve preview placeholder replacement with sample data

## Testing
- `npm run typecheck` *(fails: Cannot find modules)*
- `npm test` *(fails: Cannot find package 'zod')*
- `npm run lint` *(fails: next not found)*