### PR TITLE
Fix preview and draft defaults

### DIFF
--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -90,9 +90,12 @@ export default function StartWizardPageClient() {
         console.warn('[StartWizardPageClient] Draft loading failed:', e);
       }
       if (Object.keys(draftData).length > 0) {
-        reset(draftData, { keepValues: true });
+        // Replace any previously appended defaults with the saved draft
+        reset(draftData);
         console.log('[StartWizardPageClient] Draft loaded:', draftData);
       } else {
+        // Keep the initial default values (like one empty seller) if no draft exists
+        reset({}, { keepValues: true });
         console.log('[StartWizardPageClient] No draft found, using initial/empty values.');
       }
     }


### PR DESCRIPTION
## Summary
- refresh preview on every form change using useWatch
- prevent duplicate seller when loading drafts

## Testing
- `npm test` *(fails: Cannot find package 'zod')*
- `npm run lint` *(fails: next not found)*