### PR TITLE
Update preview pane integration

### DIFF
--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -3,7 +3,7 @@
 
 import { useParams, notFound, useRouter } from 'next/navigation';
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Loader2, Edit, Eye } from 'lucide-react';
@@ -13,7 +13,7 @@ import Breadcrumb from '@/components/Breadcrumb';
 import WizardForm from '@/components/WizardForm';
 import dynamic from 'next/dynamic';
 
-const DocumentDetail = dynamic(() => import('@/components/DocumentDetail'), {
+const PreviewPane = dynamic(() => import('@/components/PreviewPane'), {
   loading: () => (
     <div className="flex items-center justify-center border rounded-lg bg-muted p-4 aspect-[8.5/11] max-h-[500px] md:max-h-[700px] w-full shadow-lg">
       <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -60,7 +60,6 @@ export default function StartWizardPageClient() {
     resolver: docConfig?.schema ? zodResolver(docConfig.schema) : undefined,
   });
   const { reset, watch } = methods;
-  const watchedData = useWatch({ control: methods.control });
 
   useEffect(() => {
     if (!isMounted) {
@@ -226,7 +225,7 @@ export default function StartWizardPageClient() {
                 {t('Live Preview')}
               </h3>
               <div className="flex-grow overflow-hidden rounded-lg shadow-md border border-border bg-card">
-                 <DocumentDetail docId={docIdFromPath} locale={locale} liveData={watchedData as Record<string, any>} />
+                 <PreviewPane docId={docIdFromPath} locale={locale} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- dynamically import `PreviewPane`
- remove unused `useWatch` logic and use `PreviewPane` instead of `DocumentDetail`

## Testing
- `npm test` *(fails: Cannot find package 'zod')*
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing type declarations)*