### PR TITLE
Add compliance map to legal docs

### DIFF
--- a/src/app/[locale]/documents/bill-of-sale-vehicle/VehicleBillOfSalePage.tsx
+++ b/src/app/[locale]/documents/bill-of-sale-vehicle/VehicleBillOfSalePage.tsx
@@ -39,10 +39,7 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { usStates } from "@/lib/document-library";
 import { vehicleBillOfSaleFaqs, type FaqItem } from "./faqs";
-import {
-  getVehicleCompliance,
-  vehicleComplianceStates,
-} from "@/lib/states/vehicle-compliance";
+import { vehicleBillOfSale } from "@/lib/documents/us";
 import { getDb } from "@/lib/firebase";
 import { collection, doc, getDoc } from "firebase/firestore";
 
@@ -59,12 +56,15 @@ export default function VehicleBillOfSalePage() {
 
   useEffect(() => {
     if (selectedState) {
-      const compliance = getVehicleCompliance(selectedState);
-      if (compliance) {
+      const rule =
+        vehicleBillOfSale.compliance?.[selectedState] ||
+        vehicleBillOfSale.compliance?.DEFAULT;
+      if (rule) {
+        const stateName = usStates.find(s => s.value === selectedState)?.label || selectedState;
         setComplianceMessage(
-          compliance.notarizationRequired
-            ? `⚠️ Notarization required in ${compliance.state}`
-            : `✔ Valid in ${compliance.state}`,
+          rule.requireNotary
+            ? `⚠️ Notarization required in ${stateName}`
+            : `✔ Valid in ${stateName}`,
         );
       }
     }

--- a/src/components/FieldRenderer.tsx
+++ b/src/components/FieldRenderer.tsx
@@ -59,8 +59,8 @@ const FieldRenderer = React.memo(function FieldRenderer({ fieldKey, locale, doc 
     placeholder: (fieldSchemaFromZod._def as any)?.placeholder || undefined,
   } : undefined);
 
-  const formStateCode = watch('state'); 
-  const { isRequired: notaryIsRequiredByState } = useNotary(formStateCode);
+  const formStateCode = watch('state');
+  const { isRequired: notaryIsRequiredByState } = useNotary(formStateCode, doc.compliance);
   
   const { decode, data: vinData, loading: vinLoading, error: vinError } = useVinDecoder();
 

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -91,12 +91,21 @@ export default function WizardForm({
 
   useEffect(() => {
     const currentState = getValues('state');
-    if (currentState) {
+    if (!currentState) return;
+    const ruleFromDoc = doc.compliance?.[currentState] || doc.compliance?.DEFAULT;
+    if (ruleFromDoc) {
+      if (ruleFromDoc.requireNotary !== undefined) {
+        setValue('requireNotary', ruleFromDoc.requireNotary);
+      }
+      if (ruleFromDoc.witnessCount !== undefined) {
+        setValue('witnessCount', ruleFromDoc.witnessCount);
+      }
+    } else {
       const rules = getStateRules(currentState);
       setValue('requireNotary', rules.requireNotary);
       setValue('witnessCount', rules.witnessCount);
     }
-  }, [watch('state')]);
+  }, [watch('state'), doc]);
 
   const actualSchemaShape = useMemo(() => {
     const def = doc.schema?._def;

--- a/src/hooks/useNotary.ts
+++ b/src/hooks/useNotary.ts
@@ -5,8 +5,12 @@
 import { useState, useEffect } from 'react';
 import { requiredNotaryStates } from '@/lib/stateNotaryRequirements'; // Use the main source
 
-export function useNotary(stateCode: string | undefined | null) {
-  const isRequired = !!stateCode && requiredNotaryStates.includes(stateCode); // Use imported list
+type ComplianceMap = Record<string, { requireNotary?: boolean }>;
+export function useNotary(stateCode: string | undefined | null, compliance?: ComplianceMap) {
+  const isRequired = !!stateCode && (
+    compliance?.[stateCode]?.requireNotary ?? compliance?.DEFAULT?.requireNotary ??
+    requiredNotaryStates.includes(stateCode)
+  );
   const [isChecked, setIsChecked] = useState(isRequired);
 
   useEffect(() => {

--- a/src/lib/documents/us/bill-of-sale-vehicle.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { BillOfSaleSchema } from '@/schemas/billOfSale';
 import type { LegalDocument } from '@/types/documents';
 import { usStates } from '@/lib/document-library/utils';
+import { stateRules } from './vehicle-bill-of-sale/compliance';
 
 export const billOfSaleVehicle: LegalDocument = {
   id: "bill-of-sale-vehicle",
@@ -14,6 +15,7 @@ export const billOfSaleVehicle: LegalDocument = {
   offerRecordingHelp: false,
   basePrice: 19.95,
   states: 'all',
+  compliance: stateRules,
   translations: {
     en: {
       name: "Vehicle Bill of Sale",

--- a/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
@@ -1,7 +1,8 @@
 // src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
 import type { LegalDocument } from '@/types/documents';
 import { BillOfSaleSchema } from '@/schemas/billOfSale'; // Assuming schema is in a central location or adjust path
-import { vehicleBillOfSaleQuestions } from './questions'; 
+import { vehicleBillOfSaleQuestions } from './questions';
+import { stateRules } from './compliance';
 
 export const vehicleBillOfSaleMeta: LegalDocument = {
   id: 'bill-of-sale-vehicle',
@@ -18,6 +19,7 @@ export const vehicleBillOfSaleMeta: LegalDocument = {
   templatePath: '/templates/en/bill-of-sale-vehicle.md',
   templatePath_es: '/templates/es/bill-of-sale-vehicle.md',
   requiresNotarizationStates: ['AZ','KY','LA','MT','NV','OH','OK','PA','WV','WY'], // States where notarization is mandatory
+  compliance: stateRules,
   schema: BillOfSaleSchema,
   questions: vehicleBillOfSaleQuestions,
   upsellClauses: [],

--- a/src/types/documents.ts
+++ b/src/types/documents.ts
@@ -72,6 +72,12 @@ export type LegalDocument = {
   upsellClauses?: UpsellClause[];
   requiresNotarizationStates?: string[]; // Specific states within its jurisdiction
 
+  // Optional map of state/province specific compliance rules
+  compliance?: Record<string, {
+    requireNotary?: boolean;
+    witnessCount?: number;
+  }>;
+
   // Template paths (relative to /public folder)
   // Prefer templatePaths over individual templatePath/templatePath_es for multi-language
   templatePaths?: {


### PR DESCRIPTION
## Summary
- extend `LegalDocument` with optional `compliance` map
- populate `vehicle-bill-of-sale` metadata with state rules
- expose compliance rules to old US doc definition
- read compliance map in WizardForm and FieldRenderer hooks
- update notary hook and vehicle bill of sale page to use new data

## Testing
- `npm test` *(fails: cannot find package 'zod')*
- `npm run lint` *(fails: next not found)*