### PR TITLE
Enable country aware doc routes

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -135,7 +135,7 @@ export default function HomePageClient() {
       console.log('[HomePageClient] Document type selected:', doc.name);
       setSelectedDocument(doc);
       toast({ title: t('toasts.docTypeConfirmedTitle'), description: t('toasts.docTypeConfirmedDescription', { docName: doc.name_es && locale === 'es' ? doc.name_es : doc.name }) });
-      router.push(`/${locale}/docs/${doc.id}/start`);
+      router.push(`/${locale}/docs/us/${doc.id}/start`);
     } else {
       console.warn(`[HomePageClient] Document selection received null or undefined doc.`);
     }

--- a/src/app/[locale]/api/wizard/[docId]/submit/route.ts
+++ b/src/app/[locale]/api/wizard/[docId]/submit/route.ts
@@ -138,7 +138,7 @@ export async function POST(
           },
         ],
         success_url: `${siteUrl}/${effectiveLocale}/dashboard?checkout_success=true&session_id={CHECKOUT_SESSION_ID}&doc_instance_id=${documentInstanceId}`,
-        cancel_url: `${siteUrl}/${effectiveLocale}/docs/${params.docId}/start?checkout_cancelled=true`,
+        cancel_url: `${siteUrl}/${effectiveLocale}/docs/us/${params.docId}/start?checkout_cancelled=true`,
         metadata: {
           userId: user.uid,
           docId: params.docId,

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -147,7 +147,7 @@ export default function DashboardClientContent({ locale }: DashboardClientConten
                 <CardHeader className="flex flex-row items-center justify-between pb-2">
                   <CardTitle className="text-md font-medium text-card-foreground">{t(doc.name, doc.name)}</CardTitle>
                   <Button variant="outline" size="sm" asChild>
-                    <Link href={`/${locale}/docs/${doc.docType || doc.id}/start`}>{t('View/Edit')}</Link>
+                    <Link href={`/${locale}/docs/us/${doc.docType || doc.id}/start`}>{t('View/Edit')}</Link>
                   </Button>
                 </CardHeader>
                 <CardContent>

--- a/src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
@@ -1,0 +1,362 @@
+// src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
+'use client';
+
+import { useParams, notFound, useRouter } from 'next/navigation';
+import { getDocumentsForCountry, type LegalDocument } from '@/lib/document-library/index';
+import { useTranslation } from 'react-i18next';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import React, { useEffect, useState, useMemo } from 'react';
+import dynamic from 'next/dynamic';
+import { Loader2, Star, ShieldCheck, Zap, HelpCircle, Award, FileText, Edit3, FileSignature, Info } from 'lucide-react';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { Badge } from '@/components/ui/badge';
+import { track } from '@/lib/analytics';
+import { Separator } from '@/components/ui/separator';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
+import VehicleBillOfSaleDisplay from '@/components/docs/VehicleBillOfSaleDisplay'; // Import the specific display component
+import PromissoryNoteDisplay from '@/components/docs/PromissoryNoteDisplay';
+
+// Lazy load testimonials section so it's only fetched when this page is viewed
+const TrustAndTestimonialsSection = dynamic(
+  () => import('@/components/landing/TrustAndTestimonialsSection'),
+  {
+    loading: () => (
+      <div className="flex justify-center items-center h-32">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    ),
+  }
+);
+
+const DocumentDetail = dynamic(() => import('@/components/DocumentDetail'), {
+  loading: () => (
+    <div className="flex items-center justify-center border rounded-lg bg-muted p-4 aspect-[8.5/11] max-h-[500px] md:max-h-[700px] w-full shadow-lg">
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <p className="ml-2 text-muted-foreground">Loading preview...</p>
+    </div>
+  ),
+});
+
+interface DocPageClientProps {
+  params: {
+    locale: string;
+    country: string;
+    docId: string;
+  };
+}
+
+// Placeholder for AI dynamic highlights
+const AiHighlightPlaceholder = ({ text }: { text: string }) => (
+  <span className="bg-primary/10 text-primary px-1 py-0.5 rounded-sm text-xs font-medium border border-primary/30 cursor-help" title="AI Highlight: This section will be auto-customized based on your answers.">
+    {text} <Zap size={12} className="inline ml-1" />
+  </span>
+);
+
+
+export default function DocPageClient({ params: routeParams }: DocPageClientProps) {
+  const params = useParams();
+  const { t, i18n } = useTranslation("common");
+  const router = useRouter();
+
+  const currentLocale = (Array.isArray(params!.locale) ? params!.locale[0] : params!.locale) as 'en' | 'es' | undefined;
+  const currentCountry = (Array.isArray(params!.country) ? params!.country[0] : params!.country) as string | undefined;
+  const docId = Array.isArray(params!.docId) ? params!.docId[0] : params!.docId as string | undefined;
+
+  const docConfig = useMemo(() => {
+    if (!docId) return undefined;
+    const docs = getDocumentsForCountry(currentCountry);
+    return docs.find(d => d.id === docId);
+  }, [docId, currentCountry]);
+  
+  const [isLoading, setIsLoading] = useState(true);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  // Preload detail component and next step route for quicker interactions
+  useEffect(() => {
+    if (typeof (DocumentDetail as any).preload === 'function') {
+      (DocumentDetail as any).preload();
+    }
+    if (docId && currentLocale) {
+      router.prefetch(`/${currentLocale}/docs/${currentCountry}/${docId}/start`);
+    }
+  }, [router, docId, currentLocale, currentCountry]);
+
+  useEffect(() => {
+    if (isHydrated) {
+        if (docId) {
+            const foundDoc = getDocumentsForCountry(currentCountry).find(d => d.id === docId);
+            if (!foundDoc) {
+                console.error(`[DocPageClient] Doc config not found for ID: ${docId}. Triggering 404.`);
+                notFound();
+            }
+        } else {
+            console.error("[DocPageClient] docId is undefined. Triggering 404.");
+            notFound();
+        }
+        setIsLoading(false);
+    }
+  }, [docId, isHydrated, notFound, currentCountry]);
+
+
+
+
+  useEffect(() => {
+    if (currentLocale && i18n.language !== currentLocale && isHydrated) {
+      i18n.changeLanguage(currentLocale);
+    }
+  }, [currentLocale, i18n, isHydrated]);
+
+  useEffect(() => {
+    if (docConfig && isHydrated) {
+      track('view_item', {
+        id: docConfig.id,
+        name: currentLocale === 'es' && docConfig.translations?.es?.name ? docConfig.translations.es.name : docConfig.translations?.en?.name || docConfig.name,
+        value: docConfig.basePrice
+      });
+    }
+  }, [docConfig, currentLocale, isHydrated]);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    if (typeof (DocumentDetail as any).preload === 'function') {
+      (DocumentDetail as any).preload();
+    }
+    if (docId && currentLocale) {
+      router.prefetch(`/${currentLocale}/docs/${currentCountry}/${docId}/start`);
+    }
+  }, [docId, currentLocale, currentCountry, isHydrated, router]);
+
+
+  const handleStartWizard = () => {
+    if (!docConfig || !currentLocale || !isHydrated) return;
+    track('add_to_cart', {
+      id: docConfig.id,
+      name: currentLocale === 'es' && docConfig.translations?.es?.name ? docConfig.translations.es.name : docConfig.translations?.en?.name || docConfig.name,
+      value: docConfig.basePrice
+    });
+    router.push(`/${currentLocale}/docs/${currentCountry}/${docConfig.id}/start`);
+  };
+
+
+  if (!isHydrated || isLoading || !docConfig || !currentLocale) {
+    return (
+       <div className="flex items-center justify-center min-h-[calc(100vh-10rem)]">
+        <Loader2 className="h-12 w-12 animate-spin text-primary" />
+        <p className="ml-2 text-muted-foreground">Loading document details...</p>
+      </div>
+    );
+  }
+
+  const documentDisplayName = currentLocale === 'es' && docConfig.translations?.es?.name ? docConfig.translations.es.name : docConfig.translations?.en?.name || docConfig.name;
+  const documentDescription = currentLocale === 'es' && docConfig.translations?.es?.description ? docConfig.translations.es.description : docConfig.translations?.en?.description || docConfig.description;
+
+
+  const benefits = [
+    { icon: ShieldCheck, textKey: 'docDetail.benefit1', defaultText: 'Legally Sound & State-Specific' },
+    { icon: Zap, textKey: 'docDetail.benefit2', defaultText: 'Quick & Easy Customization' },
+    { icon: Award, textKey: 'docDetail.benefit3', defaultText: 'Instant Download & Secure Sharing' },
+  ];
+
+  const features = [
+    { icon: FileText, title: 'Fill your responses and complete your document', desc: 'Guided questions populate every field' },
+    { icon: Edit3, title: 'Personalize with a rich editor', desc: 'Make custom tweaks before finalizing' },
+    { icon: FileSignature, title: 'E-sign documents easily and securely', desc: 'Sign online and send to others' },
+  ];
+  
+  const competitorPrice = 200; 
+
+  return (
+    <main className="container mx-auto py-12 px-4 sm:px-6 lg:px-8">
+       <nav className="text-sm mb-6 space-x-1 text-muted-foreground">
+          <Link href={`/${currentLocale}`} className="hover:text-primary transition-colors">
+            {t('Home')}
+          </Link>
+          <span>/</span>
+           <span className="text-foreground font-medium">
+            {documentDisplayName}
+          </span>
+        </nav>
+
+        {/* Hero Section */}
+        <div className="text-center mb-10 md:mb-16">
+            <div className="inline-block p-3 mb-4 bg-primary/10 rounded-full">
+              <FileText className="h-8 w-8 text-primary" />
+            </div>
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-3 text-foreground">
+                {documentDisplayName}
+            </h1>
+             <div className="flex items-center justify-center space-x-2 mb-3">
+                {Array(5).fill(0).map((_, i) => (
+                  <Star key={i} className="h-5 w-5 text-yellow-400 fill-yellow-400" />
+                ))}
+                <span className="text-sm text-muted-foreground">(4.9 stars - 200+ reviews)</span>
+             </div>
+            <p className="text-lg text-muted-foreground mb-6 max-w-2xl mx-auto">
+               {documentDescription}
+            </p>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-3xl mx-auto mb-8">
+              {benefits.map((benefit, index) => (
+                <div key={index} className="flex items-center space-x-2 p-3 bg-card border border-border rounded-lg text-left">
+                  <benefit.icon className="h-5 w-5 text-primary shrink-0" />
+                  <span className="text-xs text-card-foreground">{t(benefit.textKey, benefit.defaultText)}</span>
+                </div>
+              ))}
+            </div>
+            
+            <Button size="lg" className="w-full sm:w-auto text-base px-8 py-3" onClick={handleStartWizard} disabled={!isHydrated}>
+              {t('Start For Free', {defaultValue: 'Start For Free'})}
+            </Button>
+            <div className="mt-4">
+              <Link href={`/${currentLocale}#workflow-start`} className="text-sm text-primary underline">
+                {t('Browse Templates', {defaultValue: 'Browse Templates'})}
+              </Link>
+            </div>
+        </div>
+        
+        <Separator className="my-8 md:my-12" />
+
+        {/* Preview & Pricing Information Section */}
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-8 items-start">
+            <section className="md:col-span-3 bg-card shadow-xl rounded-xl p-2 md:p-4 lg:p-6 border border-border">
+                <div className="text-center mb-4">
+                    <h2 className="text-xl md:text-2xl font-semibold text-foreground mb-1 flex items-center justify-center gap-1">
+                        {t('docDetail.previewTitle', {defaultValue: 'Document Preview'})}
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="text-xs">This shows a sample layout of your completed form.</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                    </h2>
+                    <p className="text-xs text-muted-foreground">
+                        {t('docDetail.previewSubtitle', {defaultValue: "This is how your document will generally look. Specific clauses and details will be customized by your answers."})}
+                    </p>
+                </div>
+                <DocumentDetail locale={currentLocale as 'en' | 'es'} docId={docId as string} altText={`${documentDisplayName} preview`} />
+                 <p className="text-xs text-muted-foreground mt-2 text-center italic">
+                    AI Highlight: <AiHighlightPlaceholder text="Key clauses" /> will be automatically tailored.
+                 </p>
+            </section>
+
+            <aside className="md:col-span-2 space-y-6">
+                 <Card className="shadow-lg border-primary">
+                    <CardHeader>
+                        <CardTitle className="text-lg text-primary">{t('docDetail.pricingTitle', 'Transparent Pricing')}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        <div className="flex items-baseline justify-between">
+                            <span className="text-3xl font-bold text-foreground">${docConfig.basePrice.toFixed(2)}</span>
+                            <span className="text-sm text-muted-foreground">{t('pricing.perDocument', {defaultValue: 'per document'})}</span>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                             {t('docDetail.competitivePrice', { competitorPrice: competitorPrice.toFixed(2), defaultValue: `Compare to typical attorney fees of $${competitorPrice.toFixed(2)}+`})}
+                        </p>
+                         <Button size="lg" className="w-full mt-2" onClick={handleStartWizard} disabled={!isHydrated}>
+                           {t('Start For Free', {defaultValue: 'Start For Free'})}
+                         </Button>
+                    </CardContent>
+                 </Card>
+
+                 {docConfig.upsellClauses && docConfig.upsellClauses.length > 0 && (
+                    <Card className="shadow-md">
+                        <CardHeader>
+                            <CardTitle className="text-md flex items-center gap-2">
+                                <Zap size={18} className="text-accent" /> {t('docDetail.optionalAddons', 'Optional Add-ons')}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-2">
+                            {docConfig.upsellClauses.map(clause => (
+                                <div key={clause.id} className="text-xs flex justify-between items-center p-2 bg-muted/50 rounded-md">
+                                    <span>{currentLocale === 'es' && clause.translations?.es?.description ? clause.translations.es.description : clause.translations?.en?.description || clause.description}</span>
+                                    <Badge variant="secondary">+${clause.price.toFixed(2)}</Badge>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+                 )}
+
+                 <Card className="shadow-md">
+                    <CardHeader>
+                        <CardTitle className="text-md flex items-center gap-2">
+                            <HelpCircle size={18} className="text-blue-500" /> {t('docDetail.aiAssistance', 'AI Assistance')}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-xs text-muted-foreground">
+                            Our AI will help suggest <AiHighlightPlaceholder text="relevant clauses" /> and ensure your document is tailored to the <AiHighlightPlaceholder text="specifics of your situation" /> as you answer questions in the next step.
+                        </p>
+                    </CardContent>
+                 </Card>
+            </aside>
+        </div>
+
+        {/* Conditional rendering for document-specific content vs generic content */}
+        {docConfig.id === 'bill-of-sale-vehicle' ? (
+          <VehicleBillOfSaleDisplay locale={currentLocale as 'en' | 'es'} />
+        ) : docConfig.id === 'promissory-note' ? (
+          <PromissoryNoteDisplay locale={currentLocale as 'en' | 'es'} />
+        ) : (
+          <>
+            {/* Feature Highlights */}
+            <section className="mt-16 grid md:grid-cols-3 gap-6">
+              {features.map((f, i) => (
+                <div key={i} className="text-center p-4 bg-card border border-border rounded-lg shadow-md">
+                  <f.icon className="h-6 w-6 mx-auto mb-2 text-primary" />
+                  <p className="text-sm font-medium text-card-foreground mb-1">{f.title}</p>
+                  <p className="text-xs text-muted-foreground">{f.desc}</p>
+                </div>
+              ))}
+            </section>
+
+            {/* How-to Guide & FAQ */}
+            <section className="mt-16 max-w-3xl mx-auto space-y-6">
+              <h2 className="text-2xl font-semibold text-center text-foreground">How to Use This Template</h2>
+              <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
+                <li>Answer each question in the guided form.</li>
+                <li>Make any tweaks using the built-in editor.</li>
+                <li>E-sign and download your completed document.</li>
+              </ol>
+
+              <div>
+                <h3 className="text-xl font-semibold mb-2 text-foreground">Frequently Asked Questions</h3>
+                <Accordion type="single" collapsible className="w-full">
+                  <AccordionItem value="q1">
+                    <AccordionTrigger>Do I need a notary for this document?</AccordionTrigger>
+                    <AccordionContent>Requirements vary by state, but notarization can add extra authenticity.</AccordionContent>
+                  </AccordionItem>
+                  <AccordionItem value="q2">
+                    <AccordionTrigger>Can I use it for any vehicle type?</AccordionTrigger>
+                    <AccordionContent>Yes, simply describe the vehicle accurately in the form.</AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+                <div className="mt-4 text-center">
+                  <Link href={`/${currentLocale}/faq`} className="text-sm text-primary underline">More questions? Visit our FAQ</Link>
+                </div>
+              </div>
+            </section>
+          </>
+        )}
+
+        {/* Testimonials - Rendered for all documents */}
+        <div className="mt-16">
+          <TrustAndTestimonialsSection />
+        </div>
+
+        {/* Sticky CTA for mobile */}
+        <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-t p-4 shadow-lg z-40">
+          <Button size="lg" className="w-full text-base" onClick={handleStartWizard} disabled={!isHydrated}>
+             {t('Start For Free', {defaultValue: 'Start For Free'})}
+          </Button>
+        </div>
+    </main>
+  );
+}

--- a/src/app/[locale]/docs/[country]/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/page.tsx
@@ -1,0 +1,49 @@
+// src/app/[locale]/docs/[country]/[docId]/page.tsx
+// This is a Server Component that defines static paths and renders the client component.
+
+import DocPageClient from './DocPageClient';
+import { getDocumentsForCountry, supportedCountries } from '@/lib/document-library/index';
+import { localizations } from '@/lib/localizations'; // Ensure this path is correct
+
+// Revalidate this page every hour for fresh content while caching aggressively
+export const revalidate = 3600;
+
+// generateStaticParams is crucial for static export of dynamic routes
+export async function generateStaticParams() {
+  console.log('[generateStaticParams /docs] Starting generation...');
+  if (!localizations || localizations.length === 0) {
+    console.warn('[generateStaticParams /docs] localizations is empty or undefined. No paths will be generated.');
+    return [];
+  }
+
+  const params = [] as Array<{ locale: string; country: string; docId: string }>;
+  for (const locale of localizations) {
+    for (const country of supportedCountries) {
+      const docs = getDocumentsForCountry(country);
+      for (const doc of docs) {
+        if (doc && doc.id && doc.id !== 'general-inquiry') {
+          params.push({ locale, country, docId: doc.id });
+        }
+      }
+    }
+  }
+  console.log(`[generateStaticParams /docs] Generated ${params.length} paths.`);
+  return params;
+}
+
+interface DocPageProps { // Renamed from DocPageContainerProps for clarity
+  params: {
+    locale: string;
+    country: string;
+    docId: string;
+  };
+}
+
+// This Server Component now correctly passes params to the Client Component
+export default async function DocPage({ params }: DocPageProps) {
+  // Await a microtask to comply with Next.js dynamic param handling
+  await Promise.resolve();
+  // The `params` prop is directly available here from Next.js
+  // It's then passed down to the client component.
+  return <DocPageClient params={params} />;
+}

--- a/src/app/[locale]/docs/[country]/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/start/StartWizardPageClient.tsx
@@ -1,0 +1,237 @@
+// src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+'use client';
+
+import { useParams, notFound, useRouter } from 'next/navigation';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Loader2, Edit, Eye } from 'lucide-react';
+
+import { getDocumentsForCountry, type LegalDocument } from '@/lib/document-library/index';
+import Breadcrumb from '@/components/Breadcrumb';
+import WizardForm from '@/components/WizardForm';
+import dynamic from 'next/dynamic';
+
+const PreviewPane = dynamic(() => import('@/components/PreviewPane'), {
+  loading: () => (
+    <div className="flex items-center justify-center border rounded-lg bg-muted p-4 aspect-[8.5/11] max-h-[500px] md:max-h-[700px] w-full shadow-lg">
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <p className="ml-2 text-muted-foreground">Loading preview...</p>
+    </div>
+  ),
+});
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '@/hooks/useAuth';
+import { loadFormProgress, saveFormProgress } from '@/lib/firestore/saveFormProgress';
+import { debounce } from 'lodash-es';
+import TrustBadges from '@/components/TrustBadges';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from '@/lib/utils';
+
+export default function StartWizardPageClient() {
+  const params = useParams();
+  const { t, i18n, ready } = useTranslation("common"); 
+  const router = useRouter();
+  const { isLoggedIn, user, isLoading: authIsLoading } = useAuth();
+
+  const locale = (Array.isArray(params!.locale) ? params!.locale[0] : params!.locale) as 'en' | 'es';
+  const country = (Array.isArray(params!.country) ? params!.country[0] : params!.country) as string;
+  const docIdFromPath = (Array.isArray(params!.docId) ? params!.docId[0] : params!.docId) as string;
+
+  const [isMounted, setIsMounted] = useState(false); // <-- New state for mounted status
+  const [isLoadingConfig, setIsLoadingConfig] = useState(true);
+  const [isHydrated, setIsHydrated] = useState(false); // Retained for clarity, though isMounted covers initial client render
+  const [activeMobileTab, setActiveMobileTab] = useState<'form' | 'preview'>('form');
+  
+  useEffect(() => {
+    setIsMounted(true); // <-- Set mounted to true on client
+    setIsHydrated(true); // Keep for consistency if other logic depends on it
+  }, []);
+
+  const docConfig = useMemo(() => {
+    if (!docIdFromPath) return undefined;
+    return getDocumentsForCountry(country).find(d => d.id === docIdFromPath);
+  }, [docIdFromPath, country]);
+
+  const methods = useForm<z.infer<any>>({
+    defaultValues: {},
+    mode: 'onBlur',
+    resolver: docConfig?.schema ? zodResolver(docConfig.schema) : undefined,
+  });
+  const { reset, watch } = methods;
+
+  useEffect(() => {
+    if (!isMounted) {
+      return; 
+    }
+    if (docConfig) {
+      if (docConfig!.schema && typeof docConfig!.schema.safeParse === 'function') {
+        methods.reset({});
+      } else {
+        console.warn(`[StartWizardPageClient] No valid Zod schema for doc ID: ${docIdFromPath}. Validation might not work.`);
+        methods.reset({});
+      }
+      setIsLoadingConfig(false);
+    } else if (isMounted && docIdFromPath) {
+      console.log(`[StartWizardPageClient] docConfig not found for ${docIdFromPath} after mount. Setting isLoadingConfig to false.`);
+      setIsLoadingConfig(false);
+    } else if (!docIdFromPath && isMounted) {
+      console.error(`[StartWizardPageClient] docIdFromPath is missing after mount.`);
+      setIsLoadingConfig(false);
+    }
+  }, [docConfig, isMounted, methods, docIdFromPath, reset]);
+
+  useEffect(() => {
+    if (!docConfig?.id || !isMounted || authIsLoading || isLoadingConfig || !locale || !ready) return;
+    
+    async function loadDraft() {
+      let draftData: Record<string, any> = {};
+      try {
+        if (isLoggedIn && user?.uid) {
+          draftData = await loadFormProgress({ userId: user.uid, docType: docConfig!.id, state: locale });
+        } else {
+          const lsKey = `draft-${docConfig!.id}-${locale}`;
+          const lsDraft = localStorage.getItem(lsKey);
+          if (lsDraft) draftData = JSON.parse(lsDraft);
+        }
+      } catch (e) {
+        console.warn('[StartWizardPageClient] Draft loading failed:', e);
+      }
+      if (Object.keys(draftData).length > 0) {
+        // Replace any previously appended defaults with the saved draft
+        reset(draftData);
+        console.log('[StartWizardPageClient] Draft loaded:', draftData);
+      } else {
+        // Keep the initial default values (like one empty seller) if no draft exists
+        reset({}, { keepValues: true });
+        console.log('[StartWizardPageClient] No draft found, using initial/empty values.');
+      }
+    }
+    loadDraft();
+  }, [docConfig, locale, isMounted, reset, authIsLoading, isLoggedIn, user, isLoadingConfig, ready]);
+
+  const debouncedSave = useCallback(
+    debounce(async (data: Record<string, any>) => {
+      if (!docConfig?.id || authIsLoading || !isMounted || Object.keys(data).length === 0 || isLoadingConfig || !locale || !ready) return;
+      
+      const relevantDataToSave = Object.keys(data).reduce((acc, key) => {
+        if (data[key] !== undefined) { acc[key] = data[key]; }
+        return acc;
+      }, {} as Record<string,any>);
+
+      if (Object.keys(relevantDataToSave).length === 0) return;
+
+      if (isLoggedIn && user?.uid) {
+        await saveFormProgress({ userId: user.uid, docType: docConfig!.id, state: locale, formData: relevantDataToSave });
+      } else {
+         localStorage.setItem(`draft-${docConfig!.id}-${locale}`, JSON.stringify(relevantDataToSave));
+      }
+      console.log('[WizardForm] Autosaved draft for:', docConfig!.id, locale, relevantDataToSave);
+    }, 1000),
+    [isLoggedIn, user?.uid, docConfig, locale, authIsLoading, isMounted, isLoadingConfig, ready] 
+  );
+
+  useEffect(() => {
+    if (!docConfig?.id || authIsLoading || !isMounted || !watch || isLoadingConfig || !locale || !ready) return () => {};
+    
+    const subscription = watch((values) => {
+       debouncedSave(values as Record<string, any>);
+    });
+    return () => {
+      subscription.unsubscribe();
+      debouncedSave.cancel();
+    } ;
+  }, [watch, docConfig, debouncedSave, authIsLoading, isMounted, isLoadingConfig, locale, ready]);
+
+  const handleWizardComplete = useCallback(
+    (redirectUrl: string) => {
+      router.push(redirectUrl);
+    },
+    [router]
+  );
+
+  // Primary loading state: waits for client mount, i18next readiness, and initial config/param check.
+  if (!isMounted) {
+    // Render a minimal, static placeholder or null on initial client render to match SSR
+    return (
+        <div className="flex justify-center items-center min-h-[calc(100vh-8rem)]">
+            <Loader2 className="h-12 w-12 animate-spin text-primary" />
+            <p className="ml-2 text-muted-foreground">Loading...</p> {/* Non-translated, static text */}
+        </div>
+    );
+  }
+
+  if (!ready || isLoadingConfig) { 
+    return (
+      <div className="flex justify-center items-center min-h-[calc(100vh-8rem)]">
+        <Loader2 className="h-12 w-12 animate-spin text-primary" />
+        <p className="ml-2 text-muted-foreground">
+          {ready ? t('Loading document wizard...') : 'Preparing interface...'}
+        </p>
+      </div>
+    );
+  }
+  
+  if (!docIdFromPath || !docConfig) {
+    console.error(`[StartWizardPageClient] Critical failure: docIdFromPath (${docIdFromPath}) or docConfig is missing. Calling notFound().`);
+    notFound();
+    return null; 
+  }
+  
+  const documentDisplayName =
+    locale === 'es' && docConfig?.translations?.es?.name
+      ? docConfig.translations.es.name
+      : docConfig?.translations?.en?.name || docConfig?.name;
+
+  return (
+    <FormProvider {...methods}>
+      <main className="container mx-auto py-8 px-4 sm:px-6 lg:px-8">
+         <Breadcrumb
+          items={[
+            { label: t('breadcrumb.home'), href: `/${locale}` },
+            { label: documentDisplayName, href: `/${locale}/docs/${country}/${docConfig!.id}` },
+            { label: t('breadcrumb.start') },
+          ]}
+        />
+        
+        <div className="lg:hidden mb-4 sticky top-14 z-30 bg-background/90 backdrop-blur-sm py-2 -mx-4 px-4 border-b">
+          <Tabs value={activeMobileTab} onValueChange={(value) => setActiveMobileTab(value as 'form' | 'preview')} className="w-full">
+            <TabsList className="grid w-full grid-cols-2 h-10">
+              <TabsTrigger value="form" className="text-xs sm:text-sm data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
+                <Edit className="w-4 h-4 mr-1.5" /> {t('Form')}
+              </TabsTrigger>
+              <TabsTrigger value="preview" className="text-xs sm:text-sm data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
+                <Eye className="w-4 h-4 mr-1.5" /> {t('Preview')}
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-2 lg:mt-6">
+          <div className={cn("lg:col-span-1", activeMobileTab !== 'form' && 'hidden lg:block')}>
+            <WizardForm
+              locale={locale}
+              doc={docConfig}
+              onComplete={handleWizardComplete}
+            />
+            <div className="mt-6 lg:mt-8">
+              <TrustBadges />
+            </div>
+          </div>
+          <div className={cn("lg:col-span-1", activeMobileTab !== 'preview' && 'hidden lg:block')}>
+             <div className="sticky top-32 lg:top-24 h-[calc(100vh-14rem)] lg:h-[calc(100vh-8rem)] max-h-[calc(100vh-14rem)] lg:max-h-[calc(100vh-6rem)] flex flex-col">
+              <h3 className="text-xl font-semibold mb-4 text-center text-card-foreground shrink-0 hidden lg:block">
+                {t('Live Preview')}
+              </h3>
+              <div className="flex-grow overflow-hidden rounded-lg shadow-md border border-border bg-card">
+                 <PreviewPane docId={docIdFromPath} locale={locale} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </FormProvider>
+  );
+}

--- a/src/app/[locale]/docs/[country]/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/start/page.tsx
@@ -1,0 +1,51 @@
+// src/app/[locale]/docs/[country]/[docId]/start/page.tsx
+// This is now a Server Component
+
+import StartWizardPageClient from './StartWizardPageClient';
+import { getDocumentsForCountry, supportedCountries } from '@/lib/document-library/index';
+import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
+import type { LegalDocument } from '@/lib/document-library/index';
+
+// Revalidate every hour so start pages stay fresh without rebuilding constantly
+export const revalidate = 3600;
+
+// generateStaticParams is crucial for static export of dynamic routes
+export async function generateStaticParams() {
+  console.log('[generateStaticParams /docs/[docId]/start] Starting generation...');
+  if (!localizations || localizations.length === 0) {
+    console.warn('[generateStaticParams /docs/[docId]/start] localizations is empty or undefined. No paths will be generated.');
+    return [];
+  }
+
+  const params = [] as Array<{ locale: string; country: string; docId: string }>;
+  for (const locale of localizations) {
+    for (const country of supportedCountries) {
+      const docs = getDocumentsForCountry(country);
+      for (const doc of docs) {
+        if (doc && doc.id !== 'general-inquiry' && doc.schema) {
+          params.push({ locale, country, docId: doc.id });
+        }
+      }
+    }
+  }
+  console.log(`[generateStaticParams /docs/[docId]/start] Generated ${params.length} params.`);
+  return params;
+}
+
+interface StartWizardPageProps {
+  params: {
+    locale: 'en' | 'es';
+    country: string;
+    docId: string;
+  };
+}
+
+// This Server Component now correctly passes params to the Client Component
+export default async function StartWizardPage({ params }: StartWizardPageProps) {
+  const { locale, docId } = params;
+  // Await a microtask to satisfy Next.js dynamic route requirements
+  await Promise.resolve();
+  // The StartWizardPageClient will handle fetching its own specific document data
+  // and form schema based on the docId and locale.
+  return <StartWizardPageClient params={params} />;
+}

--- a/src/components/DocumentFlow.tsx
+++ b/src/components/DocumentFlow.tsx
@@ -54,7 +54,7 @@ export default function DocumentFlow({
     // For a flow embedded on the homepage, this might trigger a modal or summary
     // For the dedicated /start page, WizardLayout's onComplete will handle redirection
     // Redirect to a checkout or review page.
-    router.push(`/${initialLocale}/docs/${templateId}/checkout?data=${encodeURIComponent(JSON.stringify(values))}`); 
+    router.push(`/${initialLocale}/docs/us/${templateId}/checkout?data=${encodeURIComponent(JSON.stringify(values))}`);
   };
 
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -80,7 +80,7 @@ const SearchBar = React.memo(function SearchBar() {
     if (!isHydrated) return;
     setSearchTerm('');
     setShowSuggestions(false);
-    router.push(`/${locale}/docs/${docId}`);
+    router.push(`/${locale}/docs/us/${docId}`);
   };
 
   const placeholderText = isHydrated
@@ -120,7 +120,7 @@ const SearchBar = React.memo(function SearchBar() {
                     <button
                       type="button"
                       onClick={() => handleSuggestionClick(suggestion.id)}
-                      onMouseEnter={() => router.prefetch(`/${locale}/docs/${suggestion.id}`)}
+                      onMouseEnter={() => router.prefetch(`/${locale}/docs/us/${suggestion.id}`)}
                       className="w-full text-left px-3 py-2.5 hover:bg-muted text-sm flex items-center gap-2"
                     >
                       <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -49,7 +49,7 @@ const TopDocsChips = React.memo(function TopDocsChips() {
   useEffect(() => {
     if (!isHydrated || topDocs.length === 0) return;
     topDocs.forEach(doc => {
-      router.prefetch(`/${locale}/docs/${doc.id}`);
+      router.prefetch(`/${locale}/docs/us/${doc.id}`);
     });
   }, [isHydrated, topDocs, router, locale]);
 
@@ -91,7 +91,7 @@ const TopDocsChips = React.memo(function TopDocsChips() {
             asChild
             className="bg-card hover:bg-muted border-border text-card-foreground hover:text-primary transition-colors shadow-sm px-4 py-2 h-auto text-xs sm:text-sm"
           >
-            <Link href={`/${locale}/docs/${doc.id}`}
+            <Link href={`/${locale}/docs/us/${doc.id}`}
               prefetch
             >
               {React.createElement(FileText, { className: "h-4 w-4 mr-2 text-primary/80 opacity-70" })}

--- a/src/components/WizardLayout.tsx
+++ b/src/components/WizardLayout.tsx
@@ -34,7 +34,7 @@ export default function WizardLayout({ locale, doc, children }: WizardLayoutProp
           {t('Home', { ns: 'translation' })}
         </Link>
         <span>/</span>
-        <Link href={`/${locale}/docs/${doc.id}`} className="hover:text-primary transition-colors">
+        <Link href={`/${locale}/docs/us/${doc.id}`} className="hover:text-primary transition-colors">
           {documentDisplayName}
         </Link>
         <span>/</span>

--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -35,7 +35,7 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
     const priceCents = 500; // Assuming a base price for Promissory Note
     track("add_to_cart", { item_id: "promissory-note", item_name: itemName, value: priceCents / 100, currency: "USD" });
     addItem({ id: "promissory-note", type: "doc", name: itemName, price: priceCents });
-    router.prefetch(`/${locale}/docs/promissory-note/start`);
+    router.prefetch(`/${locale}/docs/us/promissory-note/start`);
   };
 
   const informationalSections = [
@@ -189,16 +189,16 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
       <section className="text-center py-8 bg-secondary/30 rounded-lg border border-border">
         <h2 className="text-2xl font-semibold text-foreground mb-3">{t('finalCtaTitle')}</h2>
         <p className="text-muted-foreground mb-6 max-w-lg mx-auto">{t('finalCtaSubtitle')}</p>
-        <Button
-          asChild
-          size="lg"
-          className="bg-primary hover:bg-primary/90 text-primary-foreground"
-          onMouseEnter={() => router.prefetch(`/${locale}/docs/promissory-note/start`)}
-        >
-          <Link href={`/${locale}/docs/promissory-note/start`} onClick={handleStartProcess} prefetch>
-            {t('startMyPromissoryNoteButton')}
-          </Link>
-        </Button>
+          <Button
+            asChild
+            size="lg"
+            className="bg-primary hover:bg-primary/90 text-primary-foreground"
+            onMouseEnter={() => router.prefetch(`/${locale}/docs/us/promissory-note/start`)}
+          >
+            <Link href={`/${locale}/docs/us/promissory-note/start`} onClick={handleStartProcess} prefetch>
+              {t('startMyPromissoryNoteButton')}
+            </Link>
+          </Button>
       </section>
     </div>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -209,7 +209,7 @@ const Header = React.memo(function Header() {
                     return (
                       <li key={doc.id}>
                         <Link
-                          href={`/${clientLocale}/docs/${doc.id}`}
+                          href={`/${clientLocale}/docs/us/${doc.id}`}
                           className="flex items-center gap-2 px-3 py-2.5 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground transition-colors w-full text-left"
                           prefetch
                         >
@@ -320,7 +320,7 @@ const Header = React.memo(function Header() {
                     return (
                       <li key={doc.id}>
                         <Link
-                          href={`/${clientLocale}/docs/${doc.id}`}
+                          href={`/${clientLocale}/docs/us/${doc.id}`}
                           className="flex items-center gap-2 px-3 py-2.5 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground transition-colors w-full text-left"
                           prefetch
                         >

--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -22,7 +22,7 @@ const MAX_DOCS_PER_CATEGORY_INITIAL = 5;
 const MemoizedDocLink = React.memo(function DocLink({ doc, locale, onClick, t }: { doc: LegalDocument; locale: 'en' | 'es'; onClick?: () => void; t: (key: string, fallback?: string | object) => string; }) {
   const translatedDoc = getDocTranslation(doc, locale); // Use utility
   const docName = translatedDoc.name;
-  const docHref = `/${locale}/docs/${doc.id}`;
+  const docHref = `/${locale}/docs/us/${doc.id}`;
   const router = useRouter();
 
   return (


### PR DESCRIPTION
## Summary
- add new dynamic route layer `[country]` under docs
- generate static params by country and locale for doc and start pages
- load documents for selected country in doc pages and wizards
- pass country in navigation links and router interactions
- update checkout cancel URL for country-specific start page

## Testing
- `npm test` *(fails: Cannot find package 'zod')*