### PR TITLE
Implement country-aware docs start routing

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 import webpack from 'webpack';
+import fs from 'fs';
+import path from 'path';
+
+let redirects = [];
+try {
+  const redirectsJson = fs.readFileSync(path.join(process.cwd(), 'config', 'redirects.json'), 'utf-8');
+  redirects = JSON.parse(redirectsJson);
+} catch (e) {
+  console.warn('[next.config.mjs] No redirects loaded:', e);
+}
 
 const nextConfig = {
   /* config options here */
@@ -37,6 +47,9 @@ const nextConfig = {
   //   );
   //   return config;
   // },
+  async redirects() {
+    return redirects;
+  },
 };
 
 export default nextConfig;

--- a/src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useParams, notFound, useRouter } from 'next/navigation';
-import { getDocumentsForCountry, type LegalDocument } from '@/lib/document-library/index';
+import { getDoc, type LegalDocument } from '@/lib/document-library/index';
 import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -66,8 +66,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
 
   const docConfig = useMemo(() => {
     if (!docId) return undefined;
-    const docs = getDocumentsForCountry(currentCountry);
-    return docs.find(d => d.id === docId);
+    return getDoc(docId, currentCountry);
   }, [docId, currentCountry]);
   
   const [isLoading, setIsLoading] = useState(true);
@@ -90,7 +89,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
   useEffect(() => {
     if (isHydrated) {
         if (docId) {
-            const foundDoc = getDocumentsForCountry(currentCountry).find(d => d.id === docId);
+            const foundDoc = getDoc(docId, currentCountry);
             if (!foundDoc) {
                 console.error(`[DocPageClient] Doc config not found for ID: ${docId}. Triggering 404.`);
                 notFound();

--- a/src/app/[locale]/docs/[country]/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/start/StartWizardPageClient.tsx
@@ -8,7 +8,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Loader2, Edit, Eye } from 'lucide-react';
 
-import { getDocumentsForCountry, type LegalDocument } from '@/lib/document-library/index';
+import { getDocumentsForCountry, getDoc, type LegalDocument } from '@/lib/document-library/index';
 import Breadcrumb from '@/components/Breadcrumb';
 import WizardForm from '@/components/WizardForm';
 import dynamic from 'next/dynamic';
@@ -52,7 +52,7 @@ export default function StartWizardPageClient() {
 
   const docConfig = useMemo(() => {
     if (!docIdFromPath) return undefined;
-    return getDocumentsForCountry(country).find(d => d.id === docIdFromPath);
+    return getDoc(docIdFromPath, country);
   }, [docIdFromPath, country]);
 
   const methods = useForm<z.infer<any>>({

--- a/src/app/[locale]/docs/[country]/page.tsx
+++ b/src/app/[locale]/docs/[country]/page.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import { getDocumentsForCountry, supportedCountries } from '@/lib/document-library/index';
+import { localizations } from '@/lib/localizations';
+
+export const revalidate = 3600;
+
+export async function generateStaticParams() {
+  const params: Array<{ locale: string; country: string }> = [];
+  for (const locale of localizations) {
+    for (const country of supportedCountries) {
+      params.push({ locale, country });
+    }
+  }
+  return params;
+}
+
+export default async function CountryDocsPage({ params }: { params: { locale: string; country: string } }) {
+  const { locale, country } = params;
+  const docs = getDocumentsForCountry(country);
+  return (
+    <main className="container mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-4">Documents for {country.toUpperCase()}</h1>
+      <ul className="space-y-2">
+        {docs.map(doc => (
+          <li key={doc.id}>
+            <Link className="text-blue-600 underline" href={`/${locale}/docs/${country}/${doc.id}`}>{doc.translations?.[locale]?.name ?? doc.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- use `getDoc` from the registry to resolve docs in detail and wizard pages
- read `config/redirects.json` for Next.js redirects
- expose redirects via `next.config.mjs`
- add `/[locale]/docs/[country]` page to list documents by country

## Testing
- `npm test` *(fails: cannot find module 'zod')*