### PR TITLE
Add centralized compliance utils

### DIFF
--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -88,20 +88,24 @@ export default function WizardForm({
     setIsHydrated(true);
   }, []);
 
-  useEffect(() => {
-    const currentState = getValues('state');
-    if (currentState && doc.compliance) {
-      const rules = doc.compliance[currentState] || doc.compliance.DEFAULT;
-      if (rules) {
-        if (rules.requireNotary !== undefined) {
-          setValue('requireNotary', rules.requireNotary);
-        }
-        if (rules.witnessCount !== undefined) {
-          setValue('witnessCount', rules.witnessCount);
-        }
+  const applyCompliance = useCallback(
+    (state?: string) => {
+      if (!state || !doc.compliance) return;
+      const rules = doc.compliance[state] || doc.compliance.DEFAULT;
+      if (!rules) return;
+      if (rules.requireNotary !== undefined) {
+        setValue('requireNotary', rules.requireNotary);
       }
-    }
-  }, [watch('state'), doc.compliance]);
+      if (rules.witnessCount !== undefined) {
+        setValue('witnessCount', rules.witnessCount);
+      }
+    },
+    [doc.compliance, setValue]
+  );
+
+  useEffect(() => {
+    applyCompliance(getValues('state'));
+  }, [watch('state'), applyCompliance]);
 
   const actualSchemaShape = useMemo(() => {
     const def = doc.schema?._def;

--- a/src/lib/compliance.ts
+++ b/src/lib/compliance.ts
@@ -1,0 +1,15 @@
+import type { ComplianceRule } from '@/types/documents';
+
+export const rules: Record<string, ComplianceRule> = {
+  CA: { requireNotary: true, witnessCount: 0 },
+  TX: { requireNotary: false, witnessCount: 1 },
+  FL: { requireNotary: true, witnessCount: 2 },
+  NY: { requireNotary: false, witnessCount: 1 },
+  DEFAULT: { requireNotary: false, witnessCount: 0 },
+};
+
+export function getCompliance(country: string, state: string): ComplianceRule {
+  const code = state?.toUpperCase();
+  const rule = rules[code] || rules.DEFAULT;
+  return rule;
+}

--- a/src/lib/documents/us/vehicle-bill-of-sale/compliance.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/compliance.ts
@@ -1,28 +1,2 @@
-export const stateRules = {
-  CA: {
-    requireNotary: true,
-    witnessCount: 0,
-  },
-  TX: {
-    requireNotary: false,
-    witnessCount: 1,
-  },
-  FL: {
-    requireNotary: true,
-    witnessCount: 2,
-  },
-  NY: {
-    requireNotary: false,
-    witnessCount: 1,
-  },
-  DEFAULT: {
-    requireNotary: false,
-    witnessCount: 0,
-  },
-} as const;
-
+export { rules as stateRules, getCompliance as getStateRules } from '@/lib/compliance';
 export type StateCode = keyof typeof stateRules;
-
-export function getStateRules(stateCode: string) {
-  return stateRules[stateCode as StateCode] || stateRules.DEFAULT;
-}

--- a/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
@@ -2,7 +2,7 @@
 import type { LegalDocument } from '@/types/documents';
 import { BillOfSaleSchema } from '@/schemas/billOfSale'; // Assuming schema is in a central location or adjust path
 import { vehicleBillOfSaleQuestions } from './questions';
-import { stateRules } from './compliance';
+import { rules as stateRules } from '@/lib/compliance';
 
 export const vehicleBillOfSaleMeta: LegalDocument = {
   id: 'bill-of-sale-vehicle',

--- a/src/lib/documents/us/vehicle-bill-of-sale/questions.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/questions.ts
@@ -1,5 +1,4 @@
 import { usStates } from '@/lib/usStates';
-import { getStateRules } from './compliance';
 
 export const vehicleBillOfSaleQuestions = [
   {

--- a/src/schemas/billOfSale.ts
+++ b/src/schemas/billOfSale.ts
@@ -1,7 +1,7 @@
 // src/schemas/billOfSale.ts
 import { z } from 'zod';
 import { isValidVIN } from '@/utils/isValidVIN';
-import { getStateRules } from '@/lib/documents/us/vehicle-bill-of-sale/compliance';
+import { getCompliance } from '@/lib/compliance';
 
 const PartySchema = z.object({
   name: z.string().min(2, { message: 'Name must be at least 2 characters.' }),
@@ -61,7 +61,7 @@ export const BillOfSaleSchema = z.object({
       message: "Warranty details are required if not sold 'as-is'",
     });
   }
-  const rules = getStateRules(data.state);
+  const rules = getCompliance('us', data.state);
   if (rules.requireNotary && data.requireNotary !== true) {
     ctx.addIssue({
       path: ['requireNotary'],


### PR DESCRIPTION
## Summary
- centralize compliance rules into `src/lib/compliance.ts`
- reference new compliance module from vehicle bill of sale metadata
- update bill of sale schema to use `getCompliance`
- apply compliance settings in WizardForm via `applyCompliance`
- clean up unused imports

## Testing
- `npm test` *(fails: Cannot find package 'zod')*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type declarations)*