### PR TITLE
Add test suites and Playwright e2e skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_ENV=production node server.mjs",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "node --test tests/prettify.test.js",
+    "test": "node --test",
+    "e2e": "playwright test",
     "gen:previews": "node --experimental-modules scripts/generate-previews.js",
     "extract:i18n": "node_modules/.bin/i18next-parser \"src/**/*.{ts,tsx}\" --config i18next-parser.config.js"
   },

--- a/tests/DocumentRegistry.test.ts
+++ b/tests/DocumentRegistry.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { registry } from '../src/lib/document-library/index';
+import { getTemplatePath } from '../src/lib/templateUtils';
+
+test('registry documents expose core fields', () => {
+  for (const [key, doc] of Object.entries(registry)) {
+    assert.ok(doc.jurisdiction, `Document ${key} missing country`);
+    assert.ok(Array.isArray(doc.languageSupport) && doc.languageSupport.length > 0, `Document ${key} missing languages`);
+    const lang = doc.languageSupport[0];
+    const path = getTemplatePath(doc as any, lang, doc.jurisdiction);
+    assert.ok(path, `Document ${key} missing template path`);
+    assert.ok(Object.prototype.hasOwnProperty.call(doc, 'compliance'), `Document ${key} missing compliance`);
+  }
+});

--- a/tests/e2e/WizardFlow.e2e.ts
+++ b/tests/e2e/WizardFlow.e2e.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test('vehicle bill of sale wizard flow for CA', async ({ page }) => {
+  await page.goto('http://localhost:9002/en');
+
+  await page.getByRole('textbox', { name: /search/i }).fill('Vehicle Bill of Sale');
+  await page.getByRole('link', { name: /Vehicle Bill of Sale/i }).click();
+  await page.getByRole('button', { name: /Start/i }).click();
+
+  await page.getByRole('combobox', { name: /State/i }).selectOption('CA');
+  await page.fill('input[name="seller_name"]', 'Alice');
+  await page.fill('input[name="buyer_name"]', 'Bob');
+  await page.fill('input[name="year"]', '2020');
+  await page.fill('input[name="make"]', 'Honda');
+  await page.fill('input[name="model"]', 'Civic');
+  await page.fill('input[name="vin"]', '1HGCM82633A004352');
+  await page.fill('input[name="price"]', '5000');
+  await page.getByRole('button', { name: /Next/i }).click();
+  await page.getByRole('button', { name: /Finish/i }).click();
+
+  await expect(page.getByText(/notary/i)).toBeVisible();
+});

--- a/tests/render/TemplateRender.test.ts
+++ b/tests/render/TemplateRender.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import Handlebars from 'handlebars';
+import { bundleMDX } from 'mdx-bundler';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { JSDOM } from 'jsdom';
+
+function collect(dir: string, list: string[] = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collect(full, list);
+    else if (entry.isFile() && full.endsWith('.md')) list.push(full);
+  }
+  return list;
+}
+
+const templatesDir = path.join(__dirname, '..', '..', 'src', 'data', 'templates');
+const files = collect(templatesDir);
+
+const dummy = { sellers: [{ name: 'A', address: 'B', phone: 'C' }], buyers: [{ name: 'D', address: 'E', phone: 'F' }], state: 'CA', county: 'Alameda', sale_date: '2020-01-01', price: '1000', make: 'Toyota', model: 'Camry', year: '2020', color: 'Blue', vin: '1HGCM82633A004352', odometer: '1000', payment_method: 'cash', warranty_text: 'None', existing_liens: 'None', requireNotary: true, witnessCount: 0 } as any;
+
+async function renderMarkdown(md: string) {
+  const { code } = await bundleMDX({ source: md });
+  // eslint-disable-next-line no-new-func
+  const Component = new Function('React', `${code}; return MDXContent;`)(React);
+  return ReactDOMServer.renderToStaticMarkup(React.createElement(Component));
+}
+
+test('all markdown templates render without unresolved tags', async () => {
+  for (const file of files) {
+    const raw = fs.readFileSync(file, 'utf8');
+    const compiled = Handlebars.compile(raw);
+    const md = compiled(dummy);
+    const html = await renderMarkdown(md);
+    const dom = new JSDOM(html);
+    assert.ok(!dom.serialize().includes('{{'), `Unresolved tag in ${path.basename(file)}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add DocumentRegistry tests validating registry export structure
- add rendering test that compiles markdown templates
- add Playwright e2e wizard flow test
- update package scripts to run unit and e2e tests

## Testing
- `npm test` *(fails: Cannot find package 'zod')*
- `npm run e2e` *(fails: playwright not found)*