### PR TITLE
Update template paths and migration util

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -1,1 +1,8 @@
-[]
+[
+  { "from": "/templates/en/bill-of-sale-vehicle.md", "to": "/templates/en/us/bill-of-sale-vehicle.md" },
+  { "from": "/templates/es/bill-of-sale-vehicle.md", "to": "/templates/es/us/bill-of-sale-vehicle.md" },
+  { "from": "/templates/en/promissory-note.md", "to": "/templates/en/us/promissory-note.md" },
+  { "from": "/templates/es/promissory-note.md", "to": "/templates/es/us/promissory-note.md" },
+  { "from": "/templates/en/termination-letter.md", "to": "/templates/en/us/termination-letter.md" },
+  { "from": "/templates/es/termination-letter.md", "to": "/templates/es/us/termination-letter.md" }
+]

--- a/scripts/generate-previews.js
+++ b/scripts/generate-previews.js
@@ -5,7 +5,7 @@ import puppeteer from 'puppeteer';
 import { marked } from 'marked';
 import Handlebars from 'handlebars';
 
-const templatesDir = path.join(process.cwd(), 'public', 'templates'); // Updated to read from public/templates
+const templatesDir = path.join(process.cwd(), 'templates');
 const outDir       = path.join(process.cwd(), 'public', 'images', 'previews');
 const languages    = ['en','es'];
 

--- a/scripts/new-doc1.sh
+++ b/scripts/new-doc1.sh
@@ -10,8 +10,8 @@ DOC="$1"
 ROOT="$(pwd)"
 
 # 1️⃣ The two Markdown templates (you’ll rename .md → .tpl if you prefer)
-T_EN="$ROOT/public/templates/en/${DOC}.md"
-T_ES="$ROOT/public/templates/es/${DOC}.md"
+T_EN="$ROOT/templates/en/us/${DOC}.md"
+T_ES="$ROOT/templates/es/us/${DOC}.md"
 
 # 2️⃣ The two i18n JSON files
 I18N_EN="$ROOT/public/locales/en/documents/${DOC}.json"

--- a/scripts/new-doc2.sh
+++ b/scripts/new-doc2.sh
@@ -10,8 +10,8 @@ DOC="$1"                           # e.g. "promissory-note"
 ROOT="$(pwd)"
 
 # ─── The 8 files we expect ────────────────────────────────────────
-T_EN="$ROOT/public/templates/en/${DOC}.md"
-T_ES="$ROOT/public/templates/es/${DOC}.md"
+T_EN="$ROOT/templates/en/us/${DOC}.md"
+T_ES="$ROOT/templates/es/us/${DOC}.md"
 I18N_EN="$ROOT/public/locales/en/documents/${DOC}.json"
 I18N_ES="$ROOT/public/locales/es/documents/${DOC}.json"
 SCHEMA="$ROOT/src/lib/documents/us/${DOC}/schema.ts"

--- a/src/lib/documents/employment-termination-letter.ts
+++ b/src/lib/documents/employment-termination-letter.ts
@@ -17,8 +17,8 @@ export const employmentTerminationLetter: LegalDocument = {
   offerRecordingHelp: false,
   basePrice: 5,
   states: 'all',
-  templatePath: "/templates/en/termination-letter.md",
-  templatePath_es: "/templates/es/termination-letter.md",
+  templatePath: "/templates/en/us/termination-letter.md",
+  templatePath_es: "/templates/es/us/termination-letter.md",
   schema: z.object({
     employerName: z.string().min(1, "Employer name is required."),
     employerAddress: z.string().min(1, "Employer address is required."),

--- a/src/lib/documents/us/employment-termination-letter/metadata.ts
+++ b/src/lib/documents/us/employment-termination-letter/metadata.ts
@@ -18,8 +18,8 @@ export const employmentTerminationLetter: LegalDocument = {
   offerRecordingHelp: false,
   basePrice: 5,
   states: 'all',
-  templatePath: "/templates/en/termination-letter.md",
-  templatePath_es: "/templates/es/termination-letter.md",
+  templatePath: "/templates/en/us/termination-letter.md",
+  templatePath_es: "/templates/es/us/termination-letter.md",
   schema: z.object({
     employerName: z.string().min(1, "Employer name is required."),
     employerAddress: z.string().min(1, "Employer address is required."),

--- a/src/lib/documents/us/promissory-note/metadata.ts
+++ b/src/lib/documents/us/promissory-note/metadata.ts
@@ -14,8 +14,8 @@ export const promissoryNoteMeta: LegalDocument = {
   offerNotarization: false,
   offerRecordingHelp: false,
   states: 'all',
-  templatePath: '/templates/en/promissory-note.md', // Path relative to public folder
-  templatePath_es: '/templates/es/promissory-note.md', // Path relative to public folder
+  templatePath: '/templates/en/us/promissory-note.md',
+  templatePath_es: '/templates/es/us/promissory-note.md',
   schema: PromissoryNoteSchema,
   questions: promissoryNoteQuestions,
   upsellClauses: [],

--- a/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
@@ -16,8 +16,8 @@ export const vehicleBillOfSaleMeta: LegalDocument = {
   basePrice: 19.95,
   states: 'all', // Indicates available in all US states unless overridden
   // Standardized template paths
-  templatePath: '/templates/en/bill-of-sale-vehicle.md',
-  templatePath_es: '/templates/es/bill-of-sale-vehicle.md',
+  templatePath: '/templates/en/us/bill-of-sale-vehicle.md',
+  templatePath_es: '/templates/es/us/bill-of-sale-vehicle.md',
   requiresNotarizationStates: ['AZ','KY','LA','MT','NV','OH','OK','PA','WV','WY'], // States where notarization is mandatory
   compliance: stateRules,
   schema: BillOfSaleSchema,

--- a/src/types/documents.ts
+++ b/src/types/documents.ts
@@ -78,7 +78,7 @@ export type LegalDocument = {
   requiresNotarizationStates?: string[]; // Specific states within its jurisdiction
   compliance?: Record<string, ComplianceRule>; // e.g., { CA: { requireNotary: true } }
 
-  // Template paths (relative to /public folder)
+  // Template paths (relative to project root)
   // Prefer templatePaths over individual templatePath/templatePath_es for multi-language
   templatePaths?: {
     [lang: string]: string; // e.g., { en: '/templates/en/my-doc.md', es: '/templates/es/my-doc.md' }


### PR DESCRIPTION
## Summary
- centralize template location under `/templates`
- update migration script to rewrite template references
- add redirect config for moved templates
- fix template paths in metadata files
- update helper scripts to new template locations

## Testing
- `npm test` *(fails: Cannot find package 'zod')*