### PR TITLE
Use templateUtils in DocumentPreview

### DIFF
--- a/tests/DocumentPreviewPath.test.ts
+++ b/tests/DocumentPreviewPath.test.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { documentLibrary } from '../src/lib/document-library/index';
+import { getTemplatePath } from '../src/lib/templateUtils';
+
+// Ensure getTemplatePath constructs correct path used by DocumentPreview
+
+test('DocumentPreview fallback path generation', () => {
+  const doc = documentLibrary.find(d => d.id === 'bill-of-sale-vehicle');
+  const path = getTemplatePath(doc!, 'en', 'us');
+  assert.strictEqual(path, '/templates/en/us/bill-of-sale-vehicle.md');
+});


### PR DESCRIPTION
## Summary
- use `getTemplatePath` in `DocumentPreview`
- allow specifying `country` for `DocumentPreview`
- add unit test for preview path generation

## Testing
- `npm test` *(fails: Cannot find package 'zod')*