### PR TITLE
Add getDocumentUrl helper

### DIFF
--- a/src/lib/document-library/utils.ts
+++ b/src/lib/document-library/utils.ts
@@ -69,3 +69,6 @@ export const caProvinces = [
   { value: 'SK', label: 'Saskatchewan' },
   { value: 'YT', label: 'Yukon' }
 ];
+export function getDocumentUrl(doc: { id: string; jurisdiction?: string }, locale: string): string {
+  return `/${locale}/docs/${(doc.jurisdiction || 'US').toLowerCase()}/${doc.id}`;
+}

--- a/tests/DocumentUrl.test.ts
+++ b/tests/DocumentUrl.test.ts
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promissoryNoteCA } from '../src/lib/documents/ca/promissory-note';
+import { getDocumentUrl } from '../src/lib/document-library/utils';
+
+test('getDocumentUrl builds correct path for Canadian promissory note', () => {
+  const url = getDocumentUrl(promissoryNoteCA, 'en');
+  assert.strictEqual(url, '/en/docs/ca/promissory-note-ca');
+});


### PR DESCRIPTION
## Summary
- add `getDocumentUrl` in document library utils
- test `getDocumentUrl` using the Canadian promissory note

## Testing
- `npm test` *(fails: Cannot find package 'zod' imported from tests/prettify.test.js)*