### PR TITLE
Use getDocumentUrl in search links

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
 import { getDocTranslation } from '@/lib/i18nUtils';
+import { getDocumentUrl } from '@/lib/document-library/utils';
 
 const Header = React.memo(function Header() {
   // Scoped translations
@@ -209,7 +210,7 @@ const Header = React.memo(function Header() {
                     return (
                       <li key={doc.id}>
                         <Link
-                          href={`/${clientLocale}/docs/us/${doc.id}`}
+                          href={getDocumentUrl(doc, clientLocale)}
                           className="flex items-center gap-2 px-3 py-2.5 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground transition-colors w-full text-left"
                           prefetch
                         >
@@ -320,7 +321,7 @@ const Header = React.memo(function Header() {
                     return (
                       <li key={doc.id}>
                         <Link
-                          href={`/${clientLocale}/docs/us/${doc.id}`}
+                          href={getDocumentUrl(doc, clientLocale)}
                           className="flex items-center gap-2 px-3 py-2.5 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground transition-colors w-full text-left"
                           prefetch
                         >


### PR DESCRIPTION
## Notes
- Could not run tests because dependencies weren't installed.

## Summary
- import `getDocumentUrl` in the header
- generate search result links using `getDocumentUrl`
