### PR TITLE
Use getDocumentUrl in SearchBar

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -7,6 +7,7 @@ import { Search, FileText, ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useRouter, useParams } from 'next/navigation';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library/index';
+import { getDocumentUrl } from '@/lib/document-library/utils';
 import { getDocTranslation } from '@/lib/i18nUtils';
 
 const SearchBar = React.memo(function SearchBar() {
@@ -76,11 +77,11 @@ const SearchBar = React.memo(function SearchBar() {
     }
   };
 
-  const handleSuggestionClick = (docId: string) => {
+  const handleSuggestionClick = (doc: LegalDocument) => {
     if (!isHydrated) return;
     setSearchTerm('');
     setShowSuggestions(false);
-    router.push(`/${locale}/docs/us/${docId}`);
+    router.push(getDocumentUrl(doc, locale));
   };
 
   const placeholderText = isHydrated
@@ -119,8 +120,8 @@ const SearchBar = React.memo(function SearchBar() {
                   <li key={suggestion.id}>
                     <button
                       type="button"
-                      onClick={() => handleSuggestionClick(suggestion.id)}
-                      onMouseEnter={() => router.prefetch(`/${locale}/docs/us/${suggestion.id}`)}
+                      onClick={() => handleSuggestionClick(suggestion)}
+                      onMouseEnter={() => router.prefetch(getDocumentUrl(suggestion, locale))}
                       className="w-full text-left px-3 py-2.5 hover:bg-muted text-sm flex items-center gap-2"
                     >
                       <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- standardize document navigation in SearchBar

## Testing
- `npm test` *(fails: Cannot find package 'zod')*
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing packages)*