### PR TITLE
Use getDocumentUrl for doc links

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect, useCallback, Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import type { LegalDocument } from '@/lib/document-library/index';
 import { usStates, documentLibrary } from '@/lib/document-library/index';
+import { getDocumentUrl } from '@/lib/document-library/utils';
 import HomepageHeroSteps from '@/components/landing/HomepageHeroSteps';
 import { useToast } from '@/hooks/use-toast';
 import { Separator } from '@/components/ui/separator';
@@ -135,7 +136,7 @@ export default function HomePageClient() {
       console.log('[HomePageClient] Document type selected:', doc.name);
       setSelectedDocument(doc);
       toast({ title: t('toasts.docTypeConfirmedTitle'), description: t('toasts.docTypeConfirmedDescription', { docName: doc.name_es && locale === 'es' ? doc.name_es : doc.name }) });
-      router.push(`/${locale}/docs/us/${doc.id}/start`);
+      router.push(`${getDocumentUrl(doc, locale)}/start`);
     } else {
       console.warn(`[HomePageClient] Document selection received null or undefined doc.`);
     }

--- a/src/app/[locale]/api/wizard/[docId]/submit/route.ts
+++ b/src/app/[locale]/api/wizard/[docId]/submit/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { admin } from '@/lib/firebase-admin'; // Firebase Admin SDK
 import { documentLibrary, type LegalDocument } from '@/lib/document-library/index';
+import { getDocumentUrl } from '@/lib/document-library/utils';
 import { z } from 'zod';
 
 // Placeholder for user authentication - replace with your actual auth logic
@@ -72,6 +73,7 @@ export async function POST(
       return NextResponse.json({ error: 'Document configuration not found' }, { status: 404 });
     }
     console.log(`${logPrefix} Document config found: ${docConfig.name}`);
+    const docUrlBase = getDocumentUrl(docConfig, effectiveLocale);
 
     if (docConfig.schema) {
       const validationResult = docConfig.schema.safeParse(values);
@@ -138,7 +140,7 @@ export async function POST(
           },
         ],
         success_url: `${siteUrl}/${effectiveLocale}/dashboard?checkout_success=true&session_id={CHECKOUT_SESSION_ID}&doc_instance_id=${documentInstanceId}`,
-        cancel_url: `${siteUrl}/${effectiveLocale}/docs/us/${params.docId}/start?checkout_cancelled=true`,
+        cancel_url: `${siteUrl}${docUrlBase}/start?checkout_cancelled=true`,
         metadata: {
           userId: user.uid,
           docId: params.docId,

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useRouter } from 'next/navigation';
 import { Loader2, FileText } from 'lucide-react';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library/index';
+import { getDocumentUrl } from '@/lib/document-library/utils';
 
 // Placeholder data for top docs - in a real app, this would come from Firestore
 const staticTopDocIds: string[] = [
@@ -49,7 +50,7 @@ const TopDocsChips = React.memo(function TopDocsChips() {
   useEffect(() => {
     if (!isHydrated || topDocs.length === 0) return;
     topDocs.forEach(doc => {
-      router.prefetch(`/${locale}/docs/us/${doc.id}`);
+      router.prefetch(getDocumentUrl(doc, locale));
     });
   }, [isHydrated, topDocs, router, locale]);
 
@@ -91,7 +92,7 @@ const TopDocsChips = React.memo(function TopDocsChips() {
             asChild
             className="bg-card hover:bg-muted border-border text-card-foreground hover:text-primary transition-colors shadow-sm px-4 py-2 h-auto text-xs sm:text-sm"
           >
-            <Link href={`/${locale}/docs/us/${doc.id}`}
+            <Link href={getDocumentUrl(doc, locale)}
               prefetch
             >
               {React.createElement(FileText, { className: "h-4 w-4 mr-2 text-primary/80 opacity-70" })}

--- a/src/components/WizardLayout.tsx
+++ b/src/components/WizardLayout.tsx
@@ -3,8 +3,9 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation'; 
+import { useRouter } from 'next/navigation';
 import type { LegalDocument } from '@/lib/document-library/index';
+import { getDocumentUrl } from '@/lib/document-library/utils';
 // WizardForm and PreviewPane are no longer directly rendered by WizardLayout
 // They are now part of the StartWizardPage structure.
 import React, { useEffect } from 'react'; 
@@ -34,7 +35,7 @@ export default function WizardLayout({ locale, doc, children }: WizardLayoutProp
           {t('Home', { ns: 'translation' })}
         </Link>
         <span>/</span>
-        <Link href={`/${locale}/docs/us/${doc.id}`} className="hover:text-primary transition-colors">
+        <Link href={getDocumentUrl(doc, locale)} className="hover:text-primary transition-colors">
           {documentDisplayName}
         </Link>
         <span>/</span>

--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -11,6 +11,8 @@ import { track } from "@/lib/analytics";
 import { useCart } from "@/contexts/CartProvider";
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
+import { documentLibrary } from '@/lib/document-library';
+import { getDocumentUrl } from '@/lib/document-library/utils';
 
 interface PromissoryNoteDisplayProps {
   locale: "en" | "es";
@@ -21,6 +23,9 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
   const router = useRouter();
   const { addItem } = useCart();
   const [isHydrated, setIsHydrated] = useState(false);
+
+  const docConfig = documentLibrary.find(d => d.id === 'promissory-note');
+  const docUrlBase = getDocumentUrl(docConfig || { id: 'promissory-note', jurisdiction: 'US' }, locale);
 
   useEffect(() => {
     setIsHydrated(true);
@@ -35,7 +40,7 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
     const priceCents = 500; // Assuming a base price for Promissory Note
     track("add_to_cart", { item_id: "promissory-note", item_name: itemName, value: priceCents / 100, currency: "USD" });
     addItem({ id: "promissory-note", type: "doc", name: itemName, price: priceCents });
-    router.prefetch(`/${locale}/docs/us/promissory-note/start`);
+    router.prefetch(`${docUrlBase}/start`);
   };
 
   const informationalSections = [
@@ -193,9 +198,9 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
             asChild
             size="lg"
             className="bg-primary hover:bg-primary/90 text-primary-foreground"
-            onMouseEnter={() => router.prefetch(`/${locale}/docs/us/promissory-note/start`)}
+            onMouseEnter={() => router.prefetch(`${docUrlBase}/start`)}
           >
-            <Link href={`/${locale}/docs/us/promissory-note/start`} onClick={handleStartProcess} prefetch>
+            <Link href={`${docUrlBase}/start`} onClick={handleStartProcess} prefetch>
               {t('startMyPromissoryNoteButton')}
             </Link>
           </Button>


### PR DESCRIPTION
## Summary
- compute document URLs with `getDocumentUrl`
- use computed country in wizard cancel URL
- update links and prefetching for Promissory Note
- fix breadcrumbs in WizardLayout
- build TopDocs links with `getDocumentUrl`

## Testing
- `npm test` *(fails: Cannot find package 'zod')*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: numerous missing type declarations)*