### PR TITLE
Add document URL helper

### DIFF
--- a/src/lib/document-library/index.ts
+++ b/src/lib/document-library/index.ts
@@ -219,4 +219,5 @@ export default defaultDocumentLibrary;
 export { defaultDocumentLibrary as documentLibrary };
 
 export { usStates } from '../usStates'; // Corrected path
+export { getDocumentUrl } from './url';
 export type { Question, LegalDocument, UpsellClause } from '@/types/documents';

--- a/src/lib/document-library/url.client.ts
+++ b/src/lib/document-library/url.client.ts
@@ -1,0 +1,5 @@
+// src/lib/document-library/url.client.ts
+'use client';
+
+export { getDocumentUrl } from './url';
+

--- a/src/lib/document-library/url.ts
+++ b/src/lib/document-library/url.ts
@@ -1,0 +1,11 @@
+// src/lib/document-library/url.ts
+
+export function getDocumentUrl(
+  locale: string,
+  country: string,
+  docId: string,
+  step: 'start' | 'review' | 'share' = 'start'
+) {
+  return `/${locale}/docs/${country}/${docId}/${step}`;
+}
+


### PR DESCRIPTION
## Summary
- add `getDocumentUrl` helper for building document paths
- expose helper via `url.client.ts` for use in client components
- export helper from document library index

## Testing
- `npm test` *(fails: Cannot find package 'zod')*