### PR TITLE
Refactor document URL helper usage

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -5,7 +5,7 @@ import React, { useState, useEffect, useCallback, Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import type { LegalDocument } from '@/lib/document-library/index';
 import { usStates, documentLibrary } from '@/lib/document-library/index';
-import { getDocumentUrl } from '@/lib/document-library/utils';
+import { getDocumentUrl } from '@/lib/document-library/url';
 import HomepageHeroSteps from '@/components/landing/HomepageHeroSteps';
 import { useToast } from '@/hooks/use-toast';
 import { Separator } from '@/components/ui/separator';
@@ -136,7 +136,13 @@ export default function HomePageClient() {
       console.log('[HomePageClient] Document type selected:', doc.name);
       setSelectedDocument(doc);
       toast({ title: t('toasts.docTypeConfirmedTitle'), description: t('toasts.docTypeConfirmedDescription', { docName: doc.name_es && locale === 'es' ? doc.name_es : doc.name }) });
-      router.push(`${getDocumentUrl(doc, locale)}/start`);
+      router.push(
+        getDocumentUrl(
+          locale,
+          (doc.jurisdiction || 'US').toLowerCase(),
+          doc.id,
+        ),
+      );
     } else {
       console.warn(`[HomePageClient] Document selection received null or undefined doc.`);
     }

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -22,7 +22,7 @@ import {
   getUserPayments,
 } from "@/lib/firestore/dashboardData";
 import { documentLibrary } from "@/lib/document-library";
-import { getDocumentUrl } from "@/lib/document-library/utils";
+import { getDocumentUrl } from "@/lib/document-library/url";
 
 // Define a more specific type for Firestore Timestamps if that's what you use
 interface FirestoreTimestamp {
@@ -186,9 +186,11 @@ export default function DashboardClientContent({
                       const docConfig = documentLibrary.find(
                         (d) => d.id === (doc.docType || doc.id),
                       );
-                      const href = docConfig
-                        ? `${getDocumentUrl(docConfig, locale)}/start`
-                        : `/${locale}/docs/us/${doc.docType || doc.id}/start`;
+                      const href = getDocumentUrl(
+                        locale,
+                        (docConfig?.jurisdiction || 'US').toLowerCase(),
+                        docConfig ? docConfig.id : (doc.docType || doc.id),
+                      );
                       return <Link href={href}>{t("View/Edit")}</Link>;
                     })()}
                   </Button>

--- a/src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
@@ -17,6 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
 import VehicleBillOfSaleDisplay from '@/components/docs/VehicleBillOfSaleDisplay'; // Import the specific display component
 import PromissoryNoteDisplay from '@/components/docs/PromissoryNoteDisplay';
+import { getDocumentUrl } from '@/lib/document-library/url';
 
 // Lazy load testimonials section so it's only fetched when this page is viewed
 const TrustAndTestimonialsSection = dynamic(
@@ -87,7 +88,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
       (DocumentDetail as any).preload();
     }
     if (docId && currentLocale) {
-      router.prefetch(`/${currentLocale}/docs/${currentCountry}/${docId}/start`);
+      router.prefetch(getDocumentUrl(currentLocale, currentCountry, docId));
     }
   }, [router, docId, currentLocale, currentCountry]);
 
@@ -130,7 +131,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
       (DocumentDetail as any).preload();
     }
     if (docId && currentLocale) {
-      router.prefetch(`/${currentLocale}/docs/${currentCountry}/${docId}/start`);
+      router.prefetch(getDocumentUrl(currentLocale, currentCountry, docId));
     }
   }, [docId, currentLocale, currentCountry, isHydrated, router]);
 
@@ -142,7 +143,9 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
       name: currentLocale === 'es' && docConfig.translations?.es?.name ? docConfig.translations.es.name : docConfig.translations?.en?.name || docConfig.name,
       value: docConfig.basePrice
     });
-    router.push(`/${currentLocale}/docs/${currentCountry}/${docConfig.id}/start`);
+    router.push(
+      getDocumentUrl(currentLocale, currentCountry, docConfig.id),
+    );
   };
 
 

--- a/src/app/[locale]/docs/[country]/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/start/StartWizardPageClient.tsx
@@ -29,6 +29,7 @@ import TrustBadges from '@/components/TrustBadges';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from '@/lib/utils';
+import { getDocumentUrl } from '@/lib/document-library/url';
 
 export default function StartWizardPageClient() {
   const params = useParams();
@@ -196,7 +197,10 @@ export default function StartWizardPageClient() {
          <Breadcrumb
           items={[
             { label: t('breadcrumb.home'), href: `/${locale}` },
-            { label: documentDisplayName, href: `/${locale}/docs/${country}/${docConfig!.id}` },
+            {
+              label: documentDisplayName,
+              href: getDocumentUrl(locale, country, docConfig!.id),
+            },
             { label: t('breadcrumb.start') },
           ]}
         />

--- a/src/app/[locale]/docs/[country]/page.tsx
+++ b/src/app/[locale]/docs/[country]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { getDocumentsForCountry, supportedCountries } from '@/lib/document-library/index';
+import { getDocumentUrl } from '@/lib/document-library/url';
 import { localizations } from '@/lib/localizations';
 
 export const revalidate = 3600;
@@ -23,7 +24,12 @@ export default async function CountryDocsPage({ params }: { params: { locale: st
       <ul className="space-y-2">
         {docs.map(doc => (
           <li key={doc.id}>
-            <Link className="text-blue-600 underline" href={`/${locale}/docs/${country}/${doc.id}`}>{doc.translations?.[locale]?.name ?? doc.name}</Link>
+            <Link
+              className="text-blue-600 underline"
+              href={getDocumentUrl(locale, country, doc.id)}
+            >
+              {doc.translations?.[locale]?.name ?? doc.name}
+            </Link>
           </li>
         ))}
       </ul>

--- a/src/components/DocumentFlow.tsx
+++ b/src/components/DocumentFlow.tsx
@@ -10,7 +10,7 @@ import { StepThreeInput } from "@/components/StepThreeInput"; // This might be r
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { documentLibrary } from "@/lib/document-library/index"; // Import documentLibrary
-import { getDocumentUrl } from "@/lib/document-library/utils";
+import { getDocumentUrl } from "@/lib/document-library/url";
 
 interface DocumentFlowProps {
   initialDocId?: string;
@@ -52,10 +52,8 @@ export default function DocumentFlow({
     console.log("DocumentFlow: Wizard complete with values:", values);
     const docConfig = documentLibrary.find((d) => d.id === templateId);
     const docCountry = docConfig?.jurisdiction?.toLowerCase() || "us";
-    const baseUrl = getDocumentUrl(
-      docConfig || { id: templateId, jurisdiction: docCountry.toUpperCase() },
-      initialLocale,
-    );
+    const docIdForUrl = docConfig?.id || templateId;
+    const baseUrl = getDocumentUrl(initialLocale, docCountry, docIdForUrl);
     router.push(
       `${baseUrl}/checkout?data=${encodeURIComponent(JSON.stringify(values))}`,
     );

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -7,7 +7,7 @@ import { Search, FileText, ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useRouter, useParams } from 'next/navigation';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library/index';
-import { getDocumentUrl } from '@/lib/document-library/utils';
+import { getDocumentUrl } from '@/lib/document-library/url';
 import { getDocTranslation } from '@/lib/i18nUtils';
 
 const SearchBar = React.memo(function SearchBar() {
@@ -81,7 +81,13 @@ const SearchBar = React.memo(function SearchBar() {
     if (!isHydrated) return;
     setSearchTerm('');
     setShowSuggestions(false);
-    router.push(getDocumentUrl(doc, locale));
+    router.push(
+      getDocumentUrl(
+        locale,
+        (doc.jurisdiction || 'US').toLowerCase(),
+        doc.id,
+      ),
+    );
   };
 
   const placeholderText = isHydrated
@@ -121,7 +127,14 @@ const SearchBar = React.memo(function SearchBar() {
                     <button
                       type="button"
                       onClick={() => handleSuggestionClick(suggestion)}
-                      onMouseEnter={() => router.prefetch(getDocumentUrl(suggestion, locale))}
+                      onMouseEnter={() =>
+                        router.prefetch(
+                          getDocumentUrl(
+                            locale,
+                            (suggestion.jurisdiction || 'US').toLowerCase(),
+                            suggestion.id,
+                          ),
+                        )}
                       className="w-full text-left px-3 py-2.5 hover:bg-muted text-sm flex items-center gap-2"
                     >
                       <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useRouter } from 'next/navigation';
 import { Loader2, FileText } from 'lucide-react';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library/index';
-import { getDocumentUrl } from '@/lib/document-library/utils';
+import { getDocumentUrl } from '@/lib/document-library/url';
 
 // Placeholder data for top docs - in a real app, this would come from Firestore
 const staticTopDocIds: string[] = [
@@ -50,7 +50,13 @@ const TopDocsChips = React.memo(function TopDocsChips() {
   useEffect(() => {
     if (!isHydrated || topDocs.length === 0) return;
     topDocs.forEach(doc => {
-      router.prefetch(getDocumentUrl(doc, locale));
+      router.prefetch(
+        getDocumentUrl(
+          locale,
+          (doc.jurisdiction || 'US').toLowerCase(),
+          doc.id,
+        ),
+      );
     });
   }, [isHydrated, topDocs, router, locale]);
 
@@ -92,7 +98,12 @@ const TopDocsChips = React.memo(function TopDocsChips() {
             asChild
             className="bg-card hover:bg-muted border-border text-card-foreground hover:text-primary transition-colors shadow-sm px-4 py-2 h-auto text-xs sm:text-sm"
           >
-            <Link href={getDocumentUrl(doc, locale)}
+            <Link
+              href={getDocumentUrl(
+                locale,
+                (doc.jurisdiction || 'US').toLowerCase(),
+                doc.id,
+              )}
               prefetch
             >
               {React.createElement(FileText, { className: "h-4 w-4 mr-2 text-primary/80 opacity-70" })}

--- a/src/components/WizardLayout.tsx
+++ b/src/components/WizardLayout.tsx
@@ -5,7 +5,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import type { LegalDocument } from '@/lib/document-library/index';
-import { getDocumentUrl } from '@/lib/document-library/utils';
+import { getDocumentUrl } from '@/lib/document-library/url';
 // WizardForm and PreviewPane are no longer directly rendered by WizardLayout
 // They are now part of the StartWizardPage structure.
 import React, { useEffect } from 'react'; 
@@ -35,7 +35,14 @@ export default function WizardLayout({ locale, doc, children }: WizardLayoutProp
           {t('Home', { ns: 'translation' })}
         </Link>
         <span>/</span>
-        <Link href={getDocumentUrl(doc, locale)} className="hover:text-primary transition-colors">
+        <Link
+          href={getDocumentUrl(
+            locale,
+            (doc.jurisdiction || 'US').toLowerCase(),
+            doc.id,
+          )}
+          className="hover:text-primary transition-colors"
+        >
           {documentDisplayName}
         </Link>
         <span>/</span>

--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -12,7 +12,7 @@ import { useCart } from "@/contexts/CartProvider";
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { documentLibrary } from '@/lib/document-library';
-import { getDocumentUrl } from '@/lib/document-library/utils';
+import { getDocumentUrl } from '@/lib/document-library/url';
 
 interface PromissoryNoteDisplayProps {
   locale: "en" | "es";
@@ -25,7 +25,11 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
   const [isHydrated, setIsHydrated] = useState(false);
 
   const docConfig = documentLibrary.find(d => d.id === 'promissory-note');
-  const docUrlBase = getDocumentUrl(docConfig || { id: 'promissory-note', jurisdiction: 'US' }, locale);
+  const docUrlBase = getDocumentUrl(
+    locale,
+    (docConfig?.jurisdiction || 'US').toLowerCase(),
+    docConfig?.id || 'promissory-note',
+  );
 
   useEffect(() => {
     setIsHydrated(true);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
 import { getDocTranslation } from '@/lib/i18nUtils';
-import { getDocumentUrl } from '@/lib/document-library/utils';
+import { getDocumentUrl } from '@/lib/document-library/url';
 
 const Header = React.memo(function Header() {
   // Scoped translations
@@ -210,7 +210,11 @@ const Header = React.memo(function Header() {
                     return (
                       <li key={doc.id}>
                         <Link
-                          href={getDocumentUrl(doc, clientLocale)}
+                          href={getDocumentUrl(
+                            clientLocale,
+                            (doc.jurisdiction || 'US').toLowerCase(),
+                            doc.id,
+                          )}
                           className="flex items-center gap-2 px-3 py-2.5 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground transition-colors w-full text-left"
                           prefetch
                         >
@@ -321,7 +325,11 @@ const Header = React.memo(function Header() {
                     return (
                       <li key={doc.id}>
                         <Link
-                          href={getDocumentUrl(doc, clientLocale)}
+                          href={getDocumentUrl(
+                            clientLocale,
+                            (doc.jurisdiction || 'US').toLowerCase(),
+                            doc.id,
+                          )}
                           className="flex items-center gap-2 px-3 py-2.5 text-sm text-popover-foreground hover:bg-accent hover:text-accent-foreground transition-colors w-full text-left"
                           prefetch
                         >

--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -10,7 +10,7 @@ import type { CategoryInfo } from '@/components/Step1DocumentSelector';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { FileText } from 'lucide-react';
 import { getDocTranslation } from '@/lib/i18nUtils'; // Import the utility
-import { getDocumentUrl } from '@/lib/document-library/utils';
+import { getDocumentUrl } from '@/lib/document-library/url';
 
 interface MegaMenuContentProps {
   categories: CategoryInfo[];
@@ -23,7 +23,11 @@ const MAX_DOCS_PER_CATEGORY_INITIAL = 5;
 const MemoizedDocLink = React.memo(function DocLink({ doc, locale, onClick, t }: { doc: LegalDocument; locale: 'en' | 'es'; onClick?: () => void; t: (key: string, fallback?: string | object) => string; }) {
   const translatedDoc = getDocTranslation(doc, locale); // Use utility
   const docName = translatedDoc.name;
-  const docHref = getDocumentUrl(doc, locale);
+  const docHref = getDocumentUrl(
+    locale,
+    (doc.jurisdiction || 'US').toLowerCase(),
+    doc.id,
+  );
   const router = useRouter();
 
   return (

--- a/tests/DocumentUrl.test.ts
+++ b/tests/DocumentUrl.test.ts
@@ -1,11 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { promissoryNoteCA } from '../src/lib/documents/ca/promissory-note';
-import { getDocumentUrl } from '../src/lib/document-library/utils';
+import { getDocumentUrl } from '../src/lib/document-library/url';
 
 // Basic sanity check for URL generation using the CA promissory note document
 
 test('getDocumentUrl builds correct path for Canadian promissory note', () => {
-  const url = getDocumentUrl(promissoryNoteCA, 'en');
-  assert.strictEqual(url, '/en/docs/ca/promissory-note-ca');
+  const url = getDocumentUrl('en', 'ca', promissoryNoteCA.id);
+  assert.strictEqual(url, '/en/docs/ca/promissory-note-ca/start');
 });


### PR DESCRIPTION
## Summary
- update imports to use `@/lib/document-library/url`
- use new `getDocumentUrl(locale, country, docId)` API
- adjust dashboard and wizard links
- update unit test for new helper output

## Testing
- `npm test` *(fails: Cannot find package 'zod')*
- `npm run lint` *(fails: next not found)*