### PR TITLE
Add document URL and mega menu tests

### DIFF
--- a/tests/DocumentUrl.test.ts
+++ b/tests/DocumentUrl.test.ts
@@ -6,6 +6,6 @@ import { getDocumentUrl } from '../src/lib/document-library/url';
 // Basic sanity check for URL generation using the CA promissory note document
 
 test('getDocumentUrl builds correct path for Canadian promissory note', () => {
-  const url = getDocumentUrl('en', 'ca', promissoryNoteCA.id);
+  const url = getDocumentUrl('en', 'ca', promissoryNoteCA.id, 'start');
   assert.strictEqual(url, '/en/docs/ca/promissory-note-ca/start');
 });

--- a/tests/components/MegaMenuContent.test.tsx
+++ b/tests/components/MegaMenuContent.test.tsx
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { JSDOM } from 'jsdom';
+import { render, cleanup } from '@testing-library/react';
+import MegaMenuContent from '../../src/components/mega-menu/MegaMenuContent';
+import { CATEGORY_LIST } from '../../src/components/Step1DocumentSelector';
+import { promissoryNoteCA } from '../../src/lib/documents/ca/promissory-note';
+
+// Helper to setup a DOM environment for React Testing Library
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  // @ts-ignore
+  global.window = dom.window as any;
+  // @ts-ignore
+  global.document = dom.window.document as any;
+  // @ts-ignore
+  global.navigator = dom.window.navigator as any;
+  // @ts-ignore
+  global.HTMLElement = dom.window.HTMLElement;
+}
+
+setupDom();
+
+const financeCategory = CATEGORY_LIST.find(c => c.key === 'Finance')!;
+
+test('MegaMenuContent locale="es" has no US document links', () => {
+  const { container, asFragment } = render(
+    <MegaMenuContent locale="es" categories={[financeCategory]} documents={[promissoryNoteCA]} />
+  );
+
+  // Basic snapshot to ensure consistent markup
+  assert.ok(asFragment());
+
+  const links = Array.from(container.querySelectorAll('a'));
+  for (const link of links) {
+    assert.ok(!link.getAttribute('href')?.includes('/docs/us/'));
+  }
+
+  cleanup();
+});

--- a/tests/url/getDocumentUrl.test.ts
+++ b/tests/url/getDocumentUrl.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDocumentUrl } from '../../src/lib/document-library/url';
+import { promissoryNoteCA } from '../../src/lib/documents/ca/promissory-note';
+import { billOfSaleVehicle } from '../../src/lib/documents/us/bill-of-sale-vehicle';
+
+test('builds review URL for Canadian promissory note', () => {
+  const url = getDocumentUrl('en', 'ca', promissoryNoteCA.id, 'review');
+  assert.strictEqual(url, '/en/docs/ca/promissory-note-ca/review');
+});
+
+test('builds share URL for US vehicle bill of sale', () => {
+  const url = getDocumentUrl('es', 'us', billOfSaleVehicle.id, 'share');
+  assert.strictEqual(url, '/es/docs/us/bill-of-sale-vehicle/share');
+});


### PR DESCRIPTION
## Summary
- expand `getDocumentUrl` tests to cover step parameter
- update existing url test for new helper signature
- add RTL snapshot-style test for `MegaMenuContent`

## Testing
- `npm test` *(fails: Cannot find package 'zod')*