### PR TITLE
Add docs path lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+      - run: npm run check:us-paths
       - run: npm run typecheck
       - run: npm test
       - uses: microsoft/playwright-github-action@v1

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "npm run gen:previews && next build",
     "start": "NODE_ENV=production node server.mjs",
-    "lint": "next lint",
+    "lint": "next lint && npm run check:us-paths",
     "typecheck": "tsc --noEmit",
     "test": "node --test",
     "e2e": "playwright test",
     "gen:previews": "node --experimental-modules scripts/generate-previews.js",
     "extract:i18n": "node_modules/.bin/i18next-parser \"src/**/*.{ts,tsx}\" --config i18next-parser.config.js",
-    "size": "size-limit"
+    "size": "size-limit",
+    "check:us-paths": "bash scripts/check-doc-paths.sh"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.6.2",

--- a/scripts/check-doc-paths.sh
+++ b/scripts/check-doc-paths.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if grep -R "/docs/us/" src | grep -v "\.test\|\.spec"; then
+  echo "❌ Hard-coded US paths found"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add script `check-doc-paths.sh` to catch hard-coded `/docs/us/` paths
- wire the script into package.json `lint` command
- run script explicitly in CI workflow

## Testing
- `bash scripts/check-doc-paths.sh`
- `npm test` *(fails: Cannot find package 'zod')*
