### PR TITLE
Fix document navigation

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -5,7 +5,7 @@ import React, { useState, useEffect, useCallback, Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import type { LegalDocument } from '@/lib/document-library/index';
 import { usStates, documentLibrary } from '@/lib/document-library/index';
-import { getDocumentUrl } from '@/lib/document-library/url';
+import { getDocumentStartUrl } from '@/lib/document-library/url';
 import HomepageHeroSteps from '@/components/landing/HomepageHeroSteps';
 import { useToast } from '@/hooks/use-toast';
 import { Separator } from '@/components/ui/separator';
@@ -137,7 +137,7 @@ export default function HomePageClient() {
       setSelectedDocument(doc);
       toast({ title: t('toasts.docTypeConfirmedTitle'), description: t('toasts.docTypeConfirmedDescription', { docName: doc.name_es && locale === 'es' ? doc.name_es : doc.name }) });
       router.push(
-        getDocumentUrl(
+        getDocumentStartUrl(
           locale,
           (doc.jurisdiction || 'US').toLowerCase(),
           doc.id,

--- a/src/app/[locale]/api/wizard/[docId]/submit/route.ts
+++ b/src/app/[locale]/api/wizard/[docId]/submit/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { admin } from '@/lib/firebase-admin'; // Firebase Admin SDK
 import { documentLibrary, type LegalDocument } from '@/lib/document-library/index';
-import { getDocumentUrl } from '@/lib/document-library/url';
+import { getDocumentStartUrl } from '@/lib/document-library/url';
 import { z } from 'zod';
 
 // Placeholder for user authentication - replace with your actual auth logic
@@ -73,7 +73,7 @@ export async function POST(
       return NextResponse.json({ error: 'Document configuration not found' }, { status: 404 });
     }
     console.log(`${logPrefix} Document config found: ${docConfig.name}`);
-    const docUrlBase = getDocumentUrl(
+    const docUrlBase = getDocumentStartUrl(
       effectiveLocale,
       (docConfig.jurisdiction || 'US').toLowerCase(),
       docConfig.id,

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -22,7 +22,7 @@ import {
   getUserPayments,
 } from "@/lib/firestore/dashboardData";
 import { documentLibrary } from "@/lib/document-library";
-import { getDocumentUrl } from "@/lib/document-library/url";
+import { getDocumentStartUrl } from "@/lib/document-library/url";
 
 // Define a more specific type for Firestore Timestamps if that's what you use
 interface FirestoreTimestamp {
@@ -186,7 +186,7 @@ export default function DashboardClientContent({
                       const docConfig = documentLibrary.find(
                         (d) => d.id === (doc.docType || doc.id),
                       );
-                      const href = getDocumentUrl(
+                      const href = getDocumentStartUrl(
                         locale,
                         (docConfig?.jurisdiction || 'US').toLowerCase(),
                         docConfig ? docConfig.id : (doc.docType || doc.id),

--- a/src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[country]/[docId]/DocPageClient.tsx
@@ -17,7 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
 import VehicleBillOfSaleDisplay from '@/components/docs/VehicleBillOfSaleDisplay'; // Import the specific display component
 import PromissoryNoteDisplay from '@/components/docs/PromissoryNoteDisplay';
-import { getDocumentUrl } from '@/lib/document-library/url';
+import { getDocumentUrl, getDocumentStartUrl } from '@/lib/document-library/url';
 
 // Lazy load testimonials section so it's only fetched when this page is viewed
 const TrustAndTestimonialsSection = dynamic(
@@ -88,7 +88,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
       (DocumentDetail as any).preload();
     }
     if (docId && currentLocale) {
-      router.prefetch(getDocumentUrl(currentLocale, currentCountry, docId));
+      router.prefetch(getDocumentStartUrl(currentLocale, currentCountry, docId));
     }
   }, [router, docId, currentLocale, currentCountry]);
 
@@ -131,7 +131,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
       (DocumentDetail as any).preload();
     }
     if (docId && currentLocale) {
-      router.prefetch(getDocumentUrl(currentLocale, currentCountry, docId));
+      router.prefetch(getDocumentStartUrl(currentLocale, currentCountry, docId));
     }
   }, [docId, currentLocale, currentCountry, isHydrated, router]);
 
@@ -144,7 +144,7 @@ export default function DocPageClient({ params: routeParams }: DocPageClientProp
       value: docConfig.basePrice
     });
     router.push(
-      getDocumentUrl(currentLocale, currentCountry, docConfig.id),
+      getDocumentStartUrl(currentLocale, currentCountry, docConfig.id),
     );
   };
 

--- a/src/components/DocumentFlow.tsx
+++ b/src/components/DocumentFlow.tsx
@@ -10,7 +10,7 @@ import { StepThreeInput } from "@/components/StepThreeInput"; // This might be r
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { documentLibrary } from "@/lib/document-library/index"; // Import documentLibrary
-import { getDocumentUrl } from "@/lib/document-library/url";
+import { getDocumentStartUrl } from "@/lib/document-library/url";
 
 interface DocumentFlowProps {
   initialDocId?: string;
@@ -53,7 +53,7 @@ export default function DocumentFlow({
     const docConfig = documentLibrary.find((d) => d.id === templateId);
     const docCountry = docConfig?.jurisdiction?.toLowerCase() || "us";
     const docIdForUrl = docConfig?.id || templateId;
-    const baseUrl = getDocumentUrl(initialLocale, docCountry, docIdForUrl);
+    const baseUrl = getDocumentStartUrl(initialLocale, docCountry, docIdForUrl);
     router.push(
       `${baseUrl}/checkout?data=${encodeURIComponent(JSON.stringify(values))}`,
     );

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -7,7 +7,7 @@ import { Search, FileText, ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useRouter, useParams } from 'next/navigation';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library/index';
-import { getDocumentUrl } from '@/lib/document-library/url';
+import { getDocumentStartUrl } from '@/lib/document-library/url';
 import { getDocTranslation } from '@/lib/i18nUtils';
 
 const SearchBar = React.memo(function SearchBar() {
@@ -82,7 +82,7 @@ const SearchBar = React.memo(function SearchBar() {
     setSearchTerm('');
     setShowSuggestions(false);
     router.push(
-      getDocumentUrl(
+      getDocumentStartUrl(
         locale,
         (doc.jurisdiction || 'US').toLowerCase(),
         doc.id,
@@ -129,7 +129,7 @@ const SearchBar = React.memo(function SearchBar() {
                       onClick={() => handleSuggestionClick(suggestion)}
                       onMouseEnter={() =>
                         router.prefetch(
-                          getDocumentUrl(
+                          getDocumentStartUrl(
                             locale,
                             (suggestion.jurisdiction || 'US').toLowerCase(),
                             suggestion.id,

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useRouter } from 'next/navigation';
 import { Loader2, FileText } from 'lucide-react';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library/index';
-import { getDocumentUrl } from '@/lib/document-library/url';
+import { getDocumentStartUrl } from '@/lib/document-library/url';
 
 // Placeholder data for top docs - in a real app, this would come from Firestore
 const staticTopDocIds: string[] = [
@@ -51,7 +51,7 @@ const TopDocsChips = React.memo(function TopDocsChips() {
     if (!isHydrated || topDocs.length === 0) return;
     topDocs.forEach(doc => {
       router.prefetch(
-        getDocumentUrl(
+        getDocumentStartUrl(
           locale,
           (doc.jurisdiction || 'US').toLowerCase(),
           doc.id,
@@ -99,7 +99,7 @@ const TopDocsChips = React.memo(function TopDocsChips() {
             className="bg-card hover:bg-muted border-border text-card-foreground hover:text-primary transition-colors shadow-sm px-4 py-2 h-auto text-xs sm:text-sm"
           >
             <Link
-              href={getDocumentUrl(
+              href={getDocumentStartUrl(
                 locale,
                 (doc.jurisdiction || 'US').toLowerCase(),
                 doc.id,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
 import { getDocTranslation } from '@/lib/i18nUtils';
-import { getDocumentUrl } from '@/lib/document-library/url';
+import { getDocumentStartUrl } from '@/lib/document-library/url';
 
 const Header = React.memo(function Header() {
   // Scoped translations
@@ -210,7 +210,7 @@ const Header = React.memo(function Header() {
                     return (
                       <li key={doc.id}>
                         <Link
-                          href={getDocumentUrl(
+                          href={getDocumentStartUrl(
                             clientLocale,
                             (doc.jurisdiction || 'US').toLowerCase(),
                             doc.id,
@@ -325,7 +325,7 @@ const Header = React.memo(function Header() {
                     return (
                       <li key={doc.id}>
                         <Link
-                          href={getDocumentUrl(
+                          href={getDocumentStartUrl(
                             clientLocale,
                             (doc.jurisdiction || 'US').toLowerCase(),
                             doc.id,

--- a/src/lib/document-library/index.ts
+++ b/src/lib/document-library/index.ts
@@ -219,5 +219,5 @@ export default defaultDocumentLibrary;
 export { defaultDocumentLibrary as documentLibrary };
 
 export { usStates } from '../usStates'; // Corrected path
-export { getDocumentUrl } from './url';
+export { getDocumentUrl, getDocumentStartUrl } from './url';
 export type { Question, LegalDocument, UpsellClause } from '@/types/documents';

--- a/src/lib/document-library/url.client.ts
+++ b/src/lib/document-library/url.client.ts
@@ -1,5 +1,5 @@
 // src/lib/document-library/url.client.ts
 'use client';
 
-export { getDocumentUrl } from './url';
+export { getDocumentUrl, getDocumentStartUrl } from './url';
 

--- a/src/lib/document-library/url.ts
+++ b/src/lib/document-library/url.ts
@@ -4,8 +4,14 @@ export function getDocumentUrl(
   locale: string,
   country: string,
   docId: string,
-  step: 'start' | 'review' | 'share' = 'start'
 ) {
-  return `/${locale}/docs/${country}/${docId}/${step}`;
+  return `/${locale}/docs/${country}/${docId}`;
 }
 
+export function getDocumentStartUrl(
+  locale: string,
+  country: string,
+  docId: string,
+) {
+  return `${getDocumentUrl(locale, country, docId)}/start`;
+}

--- a/tests/DocumentUrl.test.ts
+++ b/tests/DocumentUrl.test.ts
@@ -1,11 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { promissoryNoteCA } from '../src/lib/documents/ca/promissory-note';
-import { getDocumentUrl } from '../src/lib/document-library/url';
+import { getDocumentStartUrl } from '../src/lib/document-library/url';
 
 // Basic sanity check for URL generation using the CA promissory note document
 
-test('getDocumentUrl builds correct path for Canadian promissory note', () => {
-  const url = getDocumentUrl('en', 'ca', promissoryNoteCA.id, 'start');
+test('getDocumentStartUrl builds correct start path for Canadian promissory note', () => {
+  const url = getDocumentStartUrl('en', 'ca', promissoryNoteCA.id);
   assert.strictEqual(url, '/en/docs/ca/promissory-note-ca/start');
 });

--- a/tests/url/getDocumentUrl.test.ts
+++ b/tests/url/getDocumentUrl.test.ts
@@ -1,15 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { getDocumentUrl } from '../../src/lib/document-library/url';
+import { getDocumentUrl, getDocumentStartUrl } from '../../src/lib/document-library/url';
 import { promissoryNoteCA } from '../../src/lib/documents/ca/promissory-note';
 import { billOfSaleVehicle } from '../../src/lib/documents/us/bill-of-sale-vehicle';
 
-test('builds review URL for Canadian promissory note', () => {
-  const url = getDocumentUrl('en', 'ca', promissoryNoteCA.id, 'review');
-  assert.strictEqual(url, '/en/docs/ca/promissory-note-ca/review');
+test('builds base URL for Canadian promissory note', () => {
+  const url = getDocumentUrl('en', 'ca', promissoryNoteCA.id);
+  assert.strictEqual(url, '/en/docs/ca/promissory-note-ca');
 });
 
-test('builds share URL for US vehicle bill of sale', () => {
-  const url = getDocumentUrl('es', 'us', billOfSaleVehicle.id, 'share');
-  assert.strictEqual(url, '/es/docs/us/bill-of-sale-vehicle/share');
+test('builds start URL for US vehicle bill of sale', () => {
+  const url = getDocumentStartUrl('es', 'us', billOfSaleVehicle.id);
+  assert.strictEqual(url, '/es/docs/us/bill-of-sale-vehicle/start');
 });


### PR DESCRIPTION
## Summary
- add `getDocumentStartUrl` and adjust `getDocumentUrl`
- export new helper functions
- update components and API routes to use start URLs where appropriate
- update tests for new helpers

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND: Cannot find package 'zod')*