### PR TITLE
Fix document library export

### DIFF
--- a/src/lib/document-library/index.ts
+++ b/src/lib/document-library/index.ts
@@ -226,6 +226,9 @@ export async function loadDoc(docId: string, country = 'us'): Promise<LegalDocum
   return getDoc(docId, country); // Fallback to registry if loader doesn't exist
 }
 
+const defaultDocumentLibrary = getDocumentsForCountry('us');
+export default defaultDocumentLibrary;
+export { defaultDocumentLibrary as documentLibrary };
 
 export { usStates } from '../usStates';
 export type { Question as DocumentQuestion, LegalDocument as LegalDocumentConfig, UpsellClause } from '@/types/documents';


### PR DESCRIPTION
## Summary
- export default documentLibrary from index for backward compatibility

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod')*