### PR TITLE
Fix document library export conflict

### DIFF
--- a/src/lib/document-library/index.ts
+++ b/src/lib/document-library/index.ts
@@ -232,10 +232,6 @@ export async function loadDoc(docId: string, country = 'us'): Promise<LegalDocum
   return getDoc(docId, country); // Fallback to registry if loader doesn't exist
 }
 
-const defaultDocumentLibrary = getDocumentsForCountry('us');
-export default defaultDocumentLibrary;
-export { defaultDocumentLibrary as documentLibrary };
-
 export { usStates } from '../usStates';
 export type { Question as DocumentQuestion, LegalDocument as LegalDocumentConfig, UpsellClause } from '@/types/documents';
 export { docLoaders }; // Also export docLoaders itself if needed elsewhere


### PR DESCRIPTION
## Summary
- remove duplicate export from `document-library/index.ts`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module errors)*
- `npm test` *(fails: ERR_MODULE_NOT_FOUND for zod)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run size` *(fails: size-limit not found)*