### PR TITLE
Fix bill-of-sale-vehicle export

### DIFF
--- a/src/lib/documents/us/bill-of-sale-vehicle/metadata.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle/metadata.ts
@@ -44,3 +44,6 @@ export const vehicleBillOfSaleMeta: LegalDocument = {
   questions: vehicleBillOfSaleQuestions, // Assign imported questions
   upsellClauses: []
 };
+
+// Maintain expected named export used across the app
+export { vehicleBillOfSaleMeta as billOfSaleVehicle };


### PR DESCRIPTION
## Summary
- expose the `billOfSaleVehicle` alias from metadata

## Testing
- `npm test` *(fails: Cannot find package 'zod')*