### PR TITLE
Fix vehicle bill of sale loader

### DIFF
--- a/src/lib/document-loaders.ts
+++ b/src/lib/document-loaders.ts
@@ -5,7 +5,8 @@ export const docLoaders: Record<string, () => Promise<LegalDocument>> = {
   'ca/promissory-note': () => import( /* webpackChunkName: "doc-ca-promissory-note" */ './documents/ca/promissory-note' ).then(m => m.promissoryNote),
   'us/affidavit-general': () => import( /* webpackChunkName: "doc-us-affidavit-general" */ './documents/us/affidavit-general' ).then(m => m.affidavitGeneral),
   'us/articles-of-incorporation-biz': () => import( /* webpackChunkName: "doc-us-articles-of-incorporation-biz" */ './documents/us/articles-of-incorporation-biz' ).then(m => m.articlesOfIncorporationBiz),
-  'us/bill-of-sale-vehicle': () => import( /* webpackChunkName: "doc-us-bill-of-sale-vehicle" */ './documents/us/bill-of-sale-vehicle' ).then(m => m.billOfSaleVehicle),
+  // Load the vehicle bill of sale using the new folder name but keep the legacy id
+  'us/bill-of-sale-vehicle': () => import( /* webpackChunkName: "doc-us-bill-of-sale-vehicle" */ './documents/us/vehicle-bill-of-sale' ).then(m => m.vehicleBillOfSale),
   'us/child-custody-agreement': () => import( /* webpackChunkName: "doc-us-child-custody-agreement" */ './documents/us/child-custody-agreement' ).then(m => m.childCustodyAgreement),
   'us/child-medical-consent': () => import( /* webpackChunkName: "doc-us-child-medical-consent" */ './documents/us/child-medical-consent' ).then(m => m.childMedicalConsent),
   'us/commercial-lease-agreement': () => import( /* webpackChunkName: "doc-us-commercial-lease-agreement" */ './documents/us/commercial-lease-agreement' ).then(m => m.commercialLeaseAgreement),

--- a/src/lib/documents/us/bill-of-sale-vehicle/index.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle/index.ts
@@ -1,3 +1,4 @@
-export { billOfSaleVehicle } from './metadata';
+// Re-export with the expected name so doc loaders can resolve correctly
+export { vehicleBillOfSaleMeta as billOfSaleVehicle } from './metadata';
 export * from './schema';
 export * from './questions';

--- a/src/lib/documents/us/bill-of-sale-vehicle/metadata.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle/metadata.ts
@@ -36,8 +36,9 @@ export const vehicleBillOfSaleMeta: LegalDocument = {
       aliases: ["venta de coche", "venta de artículo usado", "transferencia de vehículo", "contrato de venta de auto"]
     }
   },
-  templatePath: '/templates/en/bill-of-sale-vehicle.md',
-  templatePath_es: '/templates/es/bill-of-sale-vehicle.md',
+  // Updated to new document template structure under /{lang}/{country}/{docId}
+  templatePath: '/templates/en/us/bill-of-sale-vehicle.md',
+  templatePath_es: '/templates/es/us/bill-of-sale-vehicle.md',
   requiresNotarizationStates: ['AZ','KY','LA','MT','NV','OH','OK','PA','WV','WY'],
   compliance: stateRules,
   schema: BillOfSaleSchema,


### PR DESCRIPTION
## Summary
- fix dynamic loader path for `bill-of-sale-vehicle`
- re-export correct metadata in doc index
- update template paths to new directory structure

## Testing
- `npm test` *(fails: cannot find module 'zod')*