### PR TITLE
Fix vehicle bill of sale document configuration

### DIFF
--- a/src/lib/documents/us/bill-of-sale-vehicle/metadata.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle/metadata.ts
@@ -1,9 +1,7 @@
 // src/lib/documents/us/bill-of-sale-vehicle/metadata.ts
-import { z } from 'zod';
-import { BillOfSaleSchema } from '@/schemas/billOfSale';
 import type { LegalDocument } from '@/types/documents';
-import { usStates } from '@/lib/document-library/utils';
-import { vehicleBillOfSaleQuestions } from './questions'; // Import questions
+import { BillOfSaleVehicleSchema } from './schema';
+import { vehicleBillOfSaleQuestions } from './questions';
 import { rules as stateRules } from '@/lib/compliance';
 
 export const vehicleBillOfSaleMeta: LegalDocument = {
@@ -36,11 +34,11 @@ export const vehicleBillOfSaleMeta: LegalDocument = {
       aliases: ["venta de coche", "venta de artículo usado", "transferencia de vehículo", "contrato de venta de auto"]
     }
   },
-  templatePath: '/templates/en/bill-of-sale-vehicle.md',
-  templatePath_es: '/templates/es/bill-of-sale-vehicle.md',
+  templatePath: '/templates/en/us/bill-of-sale-vehicle.md',
+  templatePath_es: '/templates/es/us/bill-of-sale-vehicle.md',
   requiresNotarizationStates: ['AZ','KY','LA','MT','NV','OH','OK','PA','WV','WY'],
   compliance: stateRules,
-  schema: BillOfSaleSchema,
+  schema: BillOfSaleVehicleSchema,
   questions: vehicleBillOfSaleQuestions, // Assign imported questions
   upsellClauses: []
 };

--- a/src/lib/documents/us/bill-of-sale-vehicle/questions.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle/questions.ts
@@ -1,2 +1,49 @@
-import { billOfSaleVehicle } from './metadata';
-export const billOfSaleVehicleQuestions = billOfSaleVehicle.questions;
+import { usStates } from '@/lib/document-library/utils';
+import type { Question } from '@/types/documents';
+
+export const vehicleBillOfSaleQuestions: Question[] = [
+  { id: 'sellers', label: 'Seller Information', type: 'group', required: true },
+  { id: 'buyers', label: 'Buyer Information', type: 'group', required: true },
+  { id: 'vin', label: 'Vehicle Identification Number (VIN)', type: 'text', required: true },
+  { id: 'year', label: 'Vehicle Year', type: 'number', required: true },
+  { id: 'make', label: 'Vehicle Make', type: 'text', required: true },
+  { id: 'model', label: 'Vehicle Model', type: 'text', required: true },
+  { id: 'color', label: 'Vehicle Color', type: 'text', required: true },
+  { id: 'odometer', label: 'Odometer Reading (miles)', type: 'number', required: true },
+  {
+    id: 'odo_status',
+    label: 'Odometer Status',
+    type: 'select',
+    required: true,
+    options: [
+      { value: 'ACTUAL', label: 'Actual' },
+      { value: 'EXCEEDS', label: 'Exceeds' },
+      { value: 'NOT_ACTUAL', label: 'Not Actual' }
+    ]
+  },
+  { id: 'sale_date', label: 'Date of Sale', type: 'date', required: true },
+  { id: 'price', label: 'Sale Price ($)', type: 'number', required: true },
+  {
+    id: 'payment_method',
+    label: 'Payment Method',
+    type: 'select',
+    options: [
+      { value: 'cash', label: 'Cash' },
+      { value: 'check', label: 'Check' },
+      { value: 'wire', label: 'Wire' },
+      { value: 'paypal', label: 'PayPal' },
+      { value: 'credit_card', label: 'Credit Card' }
+    ]
+  },
+  { id: 'existing_liens', label: 'Existing Liens (if any, otherwise leave blank or "None")', type: 'text' },
+  { id: 'as_is', label: 'Is the vehicle sold "as-is"?', type: 'boolean' },
+  { id: 'warranty_text', label: 'Warranty Details (if not "as-is")', type: 'textarea' },
+  {
+    id: 'state',
+    label: 'State of Sale (Governing Law & Notary)',
+    type: 'select',
+    required: true,
+    options: usStates.map(s => ({ value: s.value, label: s.label }))
+  },
+  { id: 'county', label: 'County (for Notary Acknowledgment)', type: 'text' }
+];

--- a/src/lib/documents/us/bill-of-sale-vehicle/schema.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle/schema.ts
@@ -1,2 +1,2 @@
-import { billOfSaleVehicle } from './metadata';
-export const BillOfSaleVehicleSchema = billOfSaleVehicle.schema;
+import { BillOfSaleSchema } from '@/schemas/billOfSale';
+export const BillOfSaleVehicleSchema = BillOfSaleSchema;


### PR DESCRIPTION
## Summary
- correct template paths for vehicle bill of sale document
- export schema directly from billOfSaleVehicle schema file
- define questions within the bill-of-sale-vehicle module to avoid circular deps

## Testing
- `npm test` *(fails: Cannot find package 'zod')*