### PR TITLE
Remove Online Notary from nav bar

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -44,7 +44,6 @@ const Nav = React.memo(function Nav() {
   const navLinks = [
     { href: "/pricing", labelKey: "nav.pricing", defaultLabel: "Pricing" },
     { href: "/features", labelKey: "nav.features", defaultLabel: "Features" },
-    { href: "/online-notary", labelKey: "nav.onlineNotary", defaultLabel: "Online Notary" },
     { href: "/blog", labelKey: "nav.blog", defaultLabel: "Blog" },
     { href: "/faq", labelKey: "nav.faq", defaultLabel: "FAQ" },
     { href: "/support", labelKey: "nav.support", defaultLabel: "Support" },

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -380,7 +380,6 @@ const Header = React.memo(function Header() {
               { href: '/pricing', labelKey: 'nav.pricing', defaultLabel: 'Pricing' },
               { href: '/features', labelKey: 'nav.features', defaultLabel: 'Features' },
               { href: '/signwell', labelKey: 'nav.sign', defaultLabel: 'Sign' },
-              { href: '/online-notary', labelKey: 'nav.onlineNotary', defaultLabel: 'Online Notary' },
               { href: '/blog', labelKey: 'nav.blog', defaultLabel: 'Blog' },
               { href: '/faq', labelKey: 'nav.faq', defaultLabel: 'FAQ' },
               { href: '/support', labelKey: 'nav.support', defaultLabel: 'Support' },


### PR DESCRIPTION
## Summary
- remove Online Notary link from desktop/mobile navigation

## Testing
- `npm test` *(fails: Cannot find package 'zod')*