### PR TITLE
Simplify document registry and preview support

### DIFF
--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -40,7 +40,8 @@ export default function PreviewPane({ locale, docId, country }: PreviewPaneProps
   }, [docConfig, locale, country]);
 
   const watermarkText = t('preview.watermark', { ns: 'translation', defaultValue: 'PREVIEW' });
-  const imgSrc = `/images/previews/${locale}/${docId}.png`;
+  const imgSrc = `/previews/${docId}.png`;
+  const fallbackImg = '/images/hero-placeholder.png';
 
   useEffect(() => {
     setIsHydrated(true);
@@ -196,13 +197,25 @@ export default function PreviewPane({ locale, docId, country }: PreviewPaneProps
     );
   }
   
-  if (error || imageError || (!templatePath && !rawMarkdown && !isLoading)) {
+  if (imageError && !error) {
+    return (
+      <div
+        id="live-preview"
+        data-watermark={watermarkText}
+        className="relative w-full h-full bg-card text-card-foreground rounded-lg overflow-hidden"
+        style={{ userSelect: 'none' }}
+      >
+        <Image src={fallbackImg} alt="preview unavailable" width={850} height={1100} className="object-contain w-full h-full" loading="lazy" />
+      </div>
+    );
+  }
+
+  if (error || (!templatePath && !rawMarkdown && !isLoading)) {
      return (
         <div className="flex flex-col items-center justify-center h-full text-destructive p-4 text-center bg-destructive/5 rounded-lg">
           <AlertTriangle className="h-8 w-8 mb-2" />
-          <p className="font-semibold">{error ? t('Error loading preview', { ns: 'translation', defaultValue: 'Error loading preview' }) : t('Preview Unavailable', { ns: 'translation', defaultValue: 'Preview Unavailable'})}</p>
+          <p className="font-semibold">{t('Error loading preview', { ns: 'translation', defaultValue: 'Error loading preview' })}</p>
           {error && <p className="text-xs mt-1">{error}</p>}
-          {imageError && !error && <p className="text-xs mt-1">{t('Image preview could not be loaded.', { ns: 'translation', defaultValue: 'Image preview could not be loaded.' })}</p>}
         </div>
      );
   }

--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -3,6 +3,8 @@
 
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import dynamic from 'next/dynamic';
+import { Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from "@/components/ui/button";
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
@@ -13,6 +15,14 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { documentLibrary } from '@/lib/document-library/index';
 import { getDocumentUrl } from '@/lib/document-library/url';
+
+const PreviewPane = dynamic(() => import('../PreviewPane'), {
+  loading: () => (
+    <div className="flex items-center justify-center border rounded-lg bg-muted p-4 aspect-[8.5/11] max-h-[500px] w-full shadow-lg">
+      <Loader2 className="h-6 w-6 animate-spin text-primary" />
+    </div>
+  ),
+});
 
 interface PromissoryNoteDisplayProps {
   locale: "en" | "es";
@@ -189,7 +199,11 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
         <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-3">{t('pageTitle')}</h1>
         <p className="text-lg text-muted-foreground">{t('pageSubtitle')}</p>
       </header>
-      
+
+      <div className="max-w-md mx-auto mb-10">
+        <PreviewPane locale={locale} docId="promissory-note" country="us" />
+      </div>
+
       <Accordion type="single" collapsible className="w-full space-y-4 mb-10">
         {allDisplaySections.map((section) => (
           <AccordionItem

--- a/src/components/docs/VehicleBillOfSaleDisplay.tsx
+++ b/src/components/docs/VehicleBillOfSaleDisplay.tsx
@@ -4,6 +4,8 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import { Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
@@ -11,6 +13,14 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { track } from '@/lib/analytics';
 import { useCart } from '@/contexts/CartProvider';
 import { cn } from '@/lib/utils';
+
+const PreviewPane = dynamic(() => import('../PreviewPane'), {
+  loading: () => (
+    <div className="flex items-center justify-center border rounded-lg bg-muted p-4 aspect-[8.5/11] max-h-[500px] w-full shadow-lg">
+      <Loader2 className="h-6 w-6 animate-spin text-primary" />
+    </div>
+  ),
+});
 
 interface VehicleBillOfSaleDisplayProps {
   locale: 'en' | 'es';
@@ -181,7 +191,11 @@ export default function VehicleBillOfSaleDisplay({ locale }: VehicleBillOfSaleDi
         <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-3">{t('pageTitle')}</h1>
         <p className="text-lg text-muted-foreground">{t('pageSubtitle')}</p>
       </header>
-      
+
+      <div className="max-w-md mx-auto mb-10">
+        <PreviewPane locale={locale} docId="bill-of-sale-vehicle" country="us" />
+      </div>
+
       <Accordion type="single" collapsible className="w-full space-y-4 mb-10">
         {allSections.map((section) => (
           <AccordionItem

--- a/src/lib/document-library/index.ts
+++ b/src/lib/document-library/index.ts
@@ -1,285 +1,45 @@
-
 // src/lib/document-library/index.ts
-import { z } from 'zod';
-import type { LegalDocument, LocalizedText, Question } from '@/types/documents'; // Ensure Question is imported
-import * as us_docs_barrel from '../documents/us';
-import * as ca_docs_barrel from '../documents/ca';
-import { documentLibraryAdditions } from '../document-library-additions';
-import { docLoaders } from '../document-loaders'; // Ensure docLoaders is imported
+import type { LegalDocument } from '@/types/documents';
+import registry from './registry.json';
+import { docLoaders } from '../document-loaders';
+import { usStates, caProvinces } from './utils';
+import { getDocumentUrl, getDocumentStartUrl } from './url';
 
-// Helper to ensure basic translations structure exists for name checking
-const ensureBasicTranslations = (doc: any): LegalDocument => {
-  if (!doc) {
-    // console.warn('[ensureBasicTranslations] Received undefined/null doc');
-    // Return a minimal fallback or throw, depending on desired strictness
-    return { id: 'unknown', name: 'Unknown Document', category: 'Miscellaneous', schema: z.object({}), questions: [], languageSupport: ['en'], basePrice: 0, requiresNotarization: false, canBeRecorded: false, offerNotarization: false, offerRecordingHelp: false, translations: { en: { name: 'Unknown Document', description: '', aliases: [] }, es: { name: 'Documento Desconocido', description: '', aliases: [] } } } as unknown as LegalDocument;
-  }
-  if (!doc.translations) {
-    doc.translations = { en: {}, es: {} };
-  }
-  if (!doc.translations.en) {
-    doc.translations.en = {};
-  }
-  if (!doc.translations.es) {
-    doc.translations.es = {};
-  }
-  if (doc.name && !doc.translations.en.name) {
-    doc.translations.en.name = doc.name;
-  }
-  if (doc.name_es && !doc.translations.es.name) {
-    doc.translations.es.name = doc.name_es;
-  }
-  // Ensure aliases are arrays
-  if (doc.translations.en.aliases && !Array.isArray(doc.translations.en.aliases)) {
-    doc.translations.en.aliases = [String(doc.translations.en.aliases)];
-  } else if (!doc.translations.en.aliases) {
-    doc.translations.en.aliases = [];
-  }
-  if (doc.translations.es.aliases && !Array.isArray(doc.translations.es.aliases)) {
-    doc.translations.es.aliases = [String(doc.translations.es.aliases)];
-  } else if (!doc.translations.es.aliases) {
-    doc.translations.es.aliases = [];
-  }
-  return doc as LegalDocument;
-};
+export const documentLibrary: LegalDocument[] = registry as unknown as LegalDocument[];
 
-
-const isValidDocument = (doc: any): doc is LegalDocument => {
-  if (!doc || typeof doc !== 'object') {
-    // console.warn('[isValidDocument] Invalid document object:', doc);
-    return false;
-  }
-  const hasEnglishName = doc.translations?.en?.name || doc.name;
-
-  if (!doc.id || doc.id === 'unknown' || doc.id === 'error-doc') {
-    // console.warn(`[isValidDocument] Invalid or missing ID for doc:`, doc.id || 'NO ID');
-    return false;
-  }
-  if (!hasEnglishName) {
-    // console.warn(`[isValidDocument] Missing English name for doc: ${doc.id}`);
-    return false;
-  }
-  if (!doc.category) {
-    // console.warn(`[isValidDocument] Missing category for doc: ${doc.id}`);
-    return false;
-  }
-  // Schema check removed here; will be defaulted later if missing.
-  // if (!doc.schema) {
-  //   console.warn(`[isValidDocument] Missing schema for doc: ${doc.id}`);
-  //   return false;
-  // }
-  return true;
-};
-
-function processBarrel(barrel: any, countryCode: string): LegalDocument[] {
-  const docs: LegalDocument[] = [];
-  if (!barrel || typeof barrel !== 'object') {
-    console.warn(`[processBarrel] Barrel for ${countryCode} is invalid or empty.`);
-    return docs;
-  }
-  // console.log(`[processBarrel] Processing barrel for ${countryCode}. Raw entries found: ${Object.keys(barrel).length}`);
-
-  for (const key in barrel) {
-    if (Object.prototype.hasOwnProperty.call(barrel, key)) {
-      let docCandidate = barrel[key];
-      if (typeof docCandidate === 'object' && docCandidate !== null) {
-        docCandidate = ensureBasicTranslations(docCandidate);
-        if (isValidDocument(docCandidate)) {
-          // Ensure country is set if not present in metadata
-          if (!docCandidate.jurisdiction) {
-            docCandidate.jurisdiction = countryCode.toUpperCase();
-          }
-          docs.push(docCandidate);
-        } else {
-          // console.warn(`[processBarrel] Invalid document skipped from ${countryCode} barrel (key: ${key}):`, docCandidate?.id || 'No ID');
-        }
-      } else {
-        // console.warn(`[processBarrel] Non-object entry skipped from ${countryCode} barrel (key: ${key}).`);
-      }
-    }
-  }
-  // console.log(`[processBarrel] Valid documents extracted from ${countryCode} barrel: ${docs.length}`);
-  return docs;
+export const documentLibraryByCountry: Record<string, LegalDocument[]> = {};
+for (const doc of documentLibrary) {
+  const c = doc.jurisdiction?.toLowerCase() || 'us';
+  if (!documentLibraryByCountry[c]) documentLibraryByCountry[c] = [];
+  documentLibraryByCountry[c].push(doc);
 }
 
-const usDocsArray = processBarrel(us_docs_barrel, 'us');
-const caDocsArray = processBarrel(ca_docs_barrel, 'ca');
-
-const additionsArray = Array.isArray(documentLibraryAdditions)
-  ? documentLibraryAdditions.map(ensureBasicTranslations).filter(isValidDocument)
-  : [];
-// console.log(`[document-library] Valid additions found: ${additionsArray.length}`);
-
-const combinedDocs = [...usDocsArray, ...caDocsArray, ...additionsArray];
-// console.log(`[document-library] Total combined documents before de-duplication: ${combinedDocs.length}`);
-
-// De-duplicate based on id
-const uniqueDocumentsMap = new Map<string, LegalDocument>();
-combinedDocs.forEach(doc => {
-  if (doc && doc.id) { // Ensure doc and doc.id are defined
-    uniqueDocumentsMap.set(doc.id, doc);
-  }
-});
-const uniqueDocuments = Array.from(uniqueDocumentsMap.values());
-// console.log(`[document-library] Total unique documents: ${uniqueDocuments.length}`);
-// console.log(`[document-library] Unique document IDs: ${uniqueDocuments.map(d => d.id).join(', ')}`);
-
-
-const defaultSchema = z.object({
-  __placeholder: z.string().optional().describe("This is a placeholder schema if none is provided for a document."),
-});
-
-// Final processing: ensure all documents have default schema, questions, and full translations
-export const allDocuments: LegalDocument[] = uniqueDocuments.map(doc => {
-  const baseTranslations = doc.translations || { en: {}, es: {} };
-  if (!baseTranslations.en) baseTranslations.en = {};
-  if (!baseTranslations.es) baseTranslations.es = {};
-
-  const enName = baseTranslations.en.name || doc.name || doc.id;
-  const esName = baseTranslations.es.name || doc.name_es || enName; // Fallback to English name if Spanish name is missing
-
-  const finalDoc = {
-    ...doc,
-    name: enName, // Ensure top-level name is English name
-    name_es: esName, // Ensure top-level name_es is Spanish name
-    schema: doc.schema || defaultSchema,
-    questions: doc.questions || [],
-    languageSupport: doc.languageSupport || ['en'],
-    basePrice: typeof doc.basePrice === 'number' ? doc.basePrice : 0,
-    requiresNotarization: !!doc.requiresNotarization,
-    canBeRecorded: !!doc.canBeRecorded,
-    offerNotarization: !!doc.offerNotarization,
-    offerRecordingHelp: !!doc.offerRecordingHelp,
-    states: doc.states || 'all',
-    translations: {
-      en: {
-        name: enName,
-        description: baseTranslations.en.description || doc.description || '',
-        aliases: Array.isArray(baseTranslations.en.aliases) ? baseTranslations.en.aliases : (doc.aliases || []),
-      },
-      es: {
-        name: esName,
-        description: baseTranslations.es.description || doc.description_es || baseTranslations.en.description || doc.description || '',
-        aliases: Array.isArray(baseTranslations.es.aliases) ? baseTranslations.es.aliases : (doc.aliases_es || doc.aliases || []),
-      },
-      // Preserve other language translations if they exist
-      ...Object.fromEntries(Object.entries(baseTranslations).filter(([lang]) => lang !== 'en' && lang !== 'es'))
-    },
-    upsellClauses: doc.upsellClauses || [],
-    compliance: doc.compliance || {},
-  };
-  // If (doc.id === 'bill-of-sale-vehicle' || doc.id === 'promissory-note') {
-  //   console.log(`[document-library] Final processed doc ${doc.id}:`, {
-  //       id: finalDoc.id,
-  //       name: finalDoc.name,
-  //       name_es: finalDoc.name_es,
-  //       category: finalDoc.category,
-  //       questionsLength: finalDoc.questions.length,
-  //       schemaKeys: finalDoc.schema?.shape ? Object.keys(finalDoc.schema.shape) : 'N/A',
-  //       enNameInTranslations: finalDoc.translations?.en?.name,
-  //   });
-  // }
-  return finalDoc;
-});
-
-// console.log(`[document-library] Final allDocuments count: ${allDocuments.length}`);
-// console.log(`[document-library] Final allDocuments IDs: ${allDocuments.map(d => d.id).join(', ')}`);
-
-export const documentLibrary = allDocuments; // This is the main export used by components
-
-// Group documents by country
-export const documentLibraryByCountry: Record<string, LegalDocument[]> = {};
-allDocuments.forEach(doc => {
-  const country = doc.jurisdiction?.toLowerCase() || 'us'; // Default to 'us' if no jurisdiction
-  if (!documentLibraryByCountry[country]) {
-    documentLibraryByCountry[country] = [];
-  }
-  documentLibraryByCountry[country].push(doc);
-});
-
-// List of all country codes present
 export const supportedCountries = Object.keys(documentLibraryByCountry);
 
-// Helper to get docs by country
 export function getDocumentsForCountry(country: string): LegalDocument[] {
   return documentLibraryByCountry[country.toLowerCase()] || [];
 }
 
-// Helper to get a single document by ID, optionally by country
 export function getDocumentById(id: string, country?: string): LegalDocument | undefined {
-  if (country) {
-    return (documentLibraryByCountry[country.toLowerCase()] || []).find(doc => doc.id === id);
-  }
-  return allDocuments.find(doc => doc.id === id);
+  if (country) return getDocumentsForCountry(country).find(d => d.id === id);
+  return documentLibrary.find(d => d.id === id);
 }
 
-// Lazy loader for full document modules (server-side use for DocPageClient)
-export async function loadDoc(docId: string, country = 'us'): Promise<LegalDocument | undefined> {
-  const loaderKey = `${country.toLowerCase()}/${docId}`;
-  // console.log(`[loadDoc] Attempting to load doc for key: ${loaderKey}`);
-  // console.log(`[loadDoc] Available loaders:`, Object.keys(docLoaders));
+export async function loadDoc(id: string, country = 'us'): Promise<LegalDocument | undefined> {
+  const loader = docLoaders[`${country.toLowerCase()}/${id}`];
+  return loader ? loader() : undefined;
+}
 
-  const loader = docLoaders[loaderKey];
-  if (loader) {
-    // console.log(`[loadDoc] Found loader for ${loaderKey}. Executing...`);
-    try {
-      const module = await loader();
-      // console.log(`[loadDoc] Module loaded for ${loaderKey}. Module keys:`, Object.keys(module));
-
-      // Attempt to extract the document config from the module
-      // It could be a named export (e.g., billOfSaleVehicle) or default
-      let docConfig: LegalDocument | undefined = undefined;
-      const camelCasedId = docId.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
-
-      if (module[camelCasedId] && typeof module[camelCasedId] === 'object') {
-        docConfig = module[camelCasedId];
-        // console.log(`[loadDoc] Found docConfig via camelCasedId ('${camelCasedId}') for ${loaderKey}`);
-      } else if (module.default && typeof module.default === 'object') {
-        docConfig = module.default;
-        // console.log(`[loadDoc] Found docConfig via default export for ${loaderKey}`);
-      } else if (Object.keys(module).length === 1 && typeof Object.values(module)[0] === 'object') {
-        // Fallback: if module has only one export, assume it's the document
-        docConfig = Object.values(module)[0] as LegalDocument;
-        // console.log(`[loadDoc] Found docConfig via single export for ${loaderKey}`);
-      } else {
-        // Check for common export patterns like `{ id: 'doc-id', metadata: {...} }`
-        // The script `generate-doc-loaders.js` was updated to try `m.docIdCamelCase || m.default || Object.values(m)[0]`
-        // so one of these should ideally hit.
-        // If still not found, iterate through module keys for a potential match
-        for (const key in module) {
-          if (typeof module[key] === 'object' && module[key] !== null && module[key].id === docId) {
-            docConfig = module[key];
-            // console.log(`[loadDoc] Found docConfig via iterating module keys (key: '${key}') for ${loaderKey}`);
-            break;
-          }
-        }
-      }
-      
-      if (docConfig && typeof docConfig === 'object' && docConfig.id === docId) {
-        // console.log(`[loadDoc] Successfully loaded and validated docConfig for ${loaderKey}:`, docConfig.id);
-        return docConfig;
-      } else {
-        // console.error(`[loadDoc] Document config object not found or invalid structure in module for key: ${loaderKey}. Module content:`, module);
-      }
-    } catch (error) {
-      // console.error(`[loadDoc] Error executing loader for ${loaderKey}:`, error);
+export function findMatchingDocuments(query: string, locale: 'en' | 'es', state?: string): LegalDocument[] {
+  const q = query.trim().toLowerCase();
+  return documentLibrary.filter(doc => {
+    if (state && doc.states !== 'all' && Array.isArray(doc.states) && !doc.states.includes(state)) {
+      return false;
     }
-  } else {
-    // console.warn(`[loadDoc] No loader found for key: ${loaderKey}`);
-  }
-  return undefined;
+    const t = doc.translations?.[locale] ?? doc.translations?.en ?? { name: doc.name, aliases: [] };
+    const haystack = [doc.id, doc.name, t.name, ...(t.aliases || [])].join(' ').toLowerCase();
+    return haystack.includes(q);
+  });
 }
 
-// Fallback for legacy components or direct use
-export const docs = allDocuments;
-export { usStates } from '../usStates';
-
-export { docLoaders }; // Make docLoaders available if needed elsewhere, though primarily used by loadDoc
-
-// Log a summary at the end of module evaluation
-// console.log(`[document-library] Initialization complete. Total documents loaded: ${allDocuments.length}. Supported countries: ${supportedCountries.join(', ')}.`);
-// const billOfSaleInLib = allDocuments.find(d => d.id === 'bill-of-sale-vehicle');
-// console.log('[document-library] Bill of Sale in final allDocuments:', billOfSaleInLib ? { id: billOfSaleInLib.id, name: billOfSaleInLib.name, questions: billOfSaleInLib.questions?.length } : 'NOT FOUND');
-
-// const promissoryNoteInLib = allDocuments.find(d => d.id === 'promissory-note');
-// console.log('[document-library] Promissory Note in final allDocuments:', promissoryNoteInLib ? { id: promissoryNoteInLib.id, name: promissoryNoteInLib.name, questions: promissoryNoteInLib.questions?.length } : 'NOT FOUND');
+export { usStates, caProvinces, getDocumentUrl, getDocumentStartUrl };

--- a/src/lib/document-library/registry.json
+++ b/src/lib/document-library/registry.json
@@ -1,1 +1,56 @@
-[]
+[
+  {
+    "id": "bill-of-sale-vehicle",
+    "country": "us",
+    "name": "Vehicle Bill of Sale",
+    "category": "Finance",
+    "languageSupport": ["en", "es"],
+    "basePrice": 19.95,
+    "requiresNotarization": true,
+    "canBeRecorded": false,
+    "offerNotarization": true,
+    "offerRecordingHelp": false,
+    "states": "all",
+    "templatePath": "/templates/en/us/bill-of-sale-vehicle.md",
+    "templatePath_es": "/templates/es/us/bill-of-sale-vehicle.md",
+    "translations": {
+      "en": {
+        "name": "Vehicle Bill of Sale",
+        "description": "Document the sale and transfer of ownership for a vehicle, compliant with state requirements.",
+        "aliases": ["sell car", "used item sale", "vehicle transfer", "car sale contract"]
+      },
+      "es": {
+        "name": "Contrato de Compraventa de Vehículo",
+        "description": "Documentar la venta y transferencia de propiedad de un vehículo, conforme a los requisitos estatales.",
+        "aliases": ["venta de coche", "venta de artículo usado", "transferencia de vehículo", "contrato de venta de auto"]
+      }
+    }
+  },
+  {
+    "id": "promissory-note",
+    "country": "us",
+    "name": "Promissory Note",
+    "category": "Finance",
+    "languageSupport": ["en", "es"],
+    "basePrice": 5,
+    "requiresNotarization": false,
+    "canBeRecorded": false,
+    "offerNotarization": false,
+    "offerRecordingHelp": false,
+    "states": "all",
+    "templatePath": "/templates/en/promissory-note.md",
+    "templatePath_es": "/templates/es/promissory-note.md",
+    "translations": {
+      "en": {
+        "name": "Promissory Note",
+        "description": "Formalize a promise to repay a loan, with terms for principal, interest, and repayment schedule.",
+        "aliases": ["iou", "loan paper", "promise to pay", "loan document"]
+      },
+      "es": {
+        "name": "Pagaré",
+        "description": "Formalizar una promesa de pago de un préstamo, con plazos para el capital, intereses y calendario de pagos.",
+        "aliases": ["pagaré", "documento de préstamo", "promesa de pago"]
+      }
+    }
+  }
+]

--- a/src/lib/documents/us/index.ts
+++ b/src/lib/documents/us/index.ts
@@ -4,8 +4,8 @@
 export { billOfSaleVehicle } from './bill-of-sale-vehicle';
 // Explicitly reference the folder index to avoid picking up the legacy
 // promissory-note.ts file which lacks the full schema and question set.
-export { promissoryNote } from './promissory-note/index';
-// TODO: promissoryNote should probably be promissoryNoteMeta
+// promissory-note barrel exports `promissoryNoteMeta`; re-export under the same name
+export { promissoryNoteMeta } from './promissory-note';
 // Assuming these documents are now or will be structured similarly under ./us/
 export { affidavitGeneral } from './affidavit-general';
 export { articlesOfIncorporationBiz } from './articles-of-incorporation-biz';


### PR DESCRIPTION
## Summary
- rewrite registry generator in ESM and load document metadata
- simplify document library API to use generated registry
- export `promissoryNoteMeta` from US document barrel
- update PreviewPane preview path and fallback image
- show PreviewPane on Vehicle Bill of Sale and Promissory Note pages

## Testing
- `npm run prebuild` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ts-node')*