### PR TITLE
Fix linting issue by typing ai instance

### DIFF
--- a/src/ai/ai-instance.ts
+++ b/src/ai/ai-instance.ts
@@ -19,7 +19,7 @@ if (!googleApiKey || googleApiKey.trim() === '') {
     console.log(`[ai-instance.ts] SUCCESS: GOOGLE_GENAI_API_KEY environment variable found (Preview: ${keyPreview}, Length: ${googleApiKey.length}). Attempting Genkit initialization.`);
 }
 
-let ai: any;
+let ai: ReturnType<typeof genkit> | undefined;
 
 try {
   console.log('[ai-instance.ts] Initializing Genkit with googleAI plugin...');


### PR DESCRIPTION
## Summary
- specify the type of the `ai` instance when initializing genkit

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test`