### PR TITLE
Fix unescaped quotes in privacy policy

### DIFF
--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -9,10 +9,10 @@ export default function PrivacyPolicyPage() {
         <p>Effective Date: [Insert Date]</p>
 
         <p>
-          Welcome to 123LegalDoc ("we," "us," or "our"). We are committed to
+          Welcome to 123LegalDoc (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;). We are committed to
           protecting your privacy. This Privacy Policy explains how we collect,
           use, disclose, and safeguard your information when you use our
-          website and services (collectively, the "Service"). Please read this
+          website and services (collectively, the &quot;Service&quot;). Please read this
           privacy policy carefully. If you do not agree with the terms of this
           privacy policy, please do not access the site.
         </p>


### PR DESCRIPTION
## Summary
- escape quote characters in privacy-policy page to satisfy lint

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*