### PR TITLE
Fix unused imports and explicit any in FieldRenderer

### DIFF
--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -376,7 +376,6 @@ export default function WizardForm({
           <FieldRenderer
             key={currentField.id}
             fieldKey={currentField.id}
-            locale={locale}
             doc={doc}
           />
         )}


### PR DESCRIPTION
## Summary
- tidy FieldRenderer imports and props
- remove explicit `any` by typing address handlers
- drop unused locale prop
- update WizardForm usage

## Testing
- `npm run lint` *(fails: `next` not found)*