### PR TITLE
Fix unused variables found by lint

### DIFF
--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -10,7 +10,6 @@ import { Loader2, AlertTriangle } from 'lucide-react';
 import Image from 'next/image';
 import AutoImage from './AutoImage';
 import { cn } from '@/lib/utils';
-import { getTemplatePath } from '@/lib/templateUtils'; // Centralized util
 
 export interface DocumentDetailProps {
   docId: string;
@@ -133,12 +132,10 @@ const DocumentDetail = React.memo(function DocumentDetail({ docId, locale, altTe
            <ReactMarkdown
              remarkPlugins={[remarkGfm]}
            components={{
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              p: ({node, ...props}) => <p {...props} className="select-none" />,
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              h1: ({node, ...props}) => <h1 {...props} className="text-center" />,
+              p: (props) => <p {...props} className="select-none" />,
+              h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: ({node, ...props}) => <AutoImage {...props} className="mx-auto" />,
+              img: (props) => <AutoImage {...props} className="mx-auto" />,
             }}
           >
             {md}
@@ -155,7 +152,7 @@ const DocumentDetail = React.memo(function DocumentDetail({ docId, locale, altTe
               className="object-contain w-full h-full"
               data-ai-hint="document template screenshot"
               loading="lazy"
-              onError={(e) => {
+              onError={() => {
                   console.warn(`[DocumentDetail] Image failed to load: ${imgSrc}.`);
               }}
             />

--- a/src/components/DocumentFlow.tsx
+++ b/src/components/DocumentFlow.tsx
@@ -22,7 +22,7 @@ export default function DocumentFlow({
   initialLocale = 'en',
 }: DocumentFlowProps = {}) { 
   const router = useRouter();
-  const { t } = useTranslation("common");
+  useTranslation("common");
 
   const [templateId, setTemplateId] = useState<string>(initialDocId ?? '');
   const [step, setStep] = useState(initialDocId ? 2 : 1); 
@@ -49,13 +49,6 @@ export default function DocumentFlow({
     }
   };
 
-  const handleWizardComplete = (values: Record<string, any>) => {
-    console.log("DocumentFlow: Wizard complete with values:", values);
-    // For a flow embedded on the homepage, this might trigger a modal or summary
-    // For the dedicated /start page, WizardLayout's onComplete will handle redirection
-    // Redirect to a checkout or review page.
-    router.push(`/${initialLocale}/docs/${templateId}/checkout?data=${encodeURIComponent(JSON.stringify(values))}`); 
-  };
 
 
   return (

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -97,10 +97,9 @@ const DocumentPreview = React.memo(function DocumentPreview({
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              p: ({ node, ...props }) => <p {...props} className="select-none" />,
+              p: (props) => <p {...props} className="select-none" />,
               // FIXED: ensure images have explicit dimensions
-              img: ({ node, ...props }) => (
+              img: (props) => (
                 <AutoImage {...props} className="mx-auto" />
               ),
             }}

--- a/src/components/DocumentTypeSelector.tsx
+++ b/src/components/DocumentTypeSelector.tsx
@@ -21,7 +21,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useTranslation } from 'react-i18next';
-import { documentLibrary, usStates, LegalDocument, findMatchingDocuments } from '@/lib/document-library';
+import { documentLibrary, usStates, findMatchingDocuments } from '@/lib/document-library';
 
 
 interface Props {


### PR DESCRIPTION
## Summary
- remove unused imports and variables in DocumentDetail
- remove unused vars from DocumentPreview
- clean up unused code in DocumentFlow
- drop unused LegalDocument import from DocumentTypeSelector

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*