### PR TITLE
Fix lint warnings in TrustAndTestimonialsSection and Footer

### DIFF
--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -1,12 +1,11 @@
 // src/components/landing/TrustAndTestimonialsSection.tsx
 'use client'
 
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { ChevronLeft, ChevronRight, FileText, Lock, ShieldCheck, Star } from 'lucide-react';
+import { ChevronLeft, ChevronRight, FileText, ShieldCheck, Star } from 'lucide-react';
 import Image from 'next/image';
-import { motion } from 'framer-motion';
 import Autoplay from 'embla-carousel-autoplay';
 import useEmblaCarousel from 'embla-carousel-react';
 import { cn } from '@/lib/utils';
@@ -96,7 +95,7 @@ const MemoizedTestimonialCard = React.memo(function TestimonialCard({ testimonia
             ))}
           </div>
           <p className="italic text-foreground/90 mb-4 leading-relaxed text-sm flex-grow">
-            "{quoteText}"
+            &ldquo;{quoteText}&rdquo;
           </p>
           {outcomeText && (
             <p className="text-xs text-primary font-semibold mb-3 text-center p-1 bg-primary/10 rounded">
@@ -155,8 +154,18 @@ const TrustAndTestimonialsSection = React.memo(function TrustAndTestimonialsSect
 
   useEffect(() => {
     if (isHydrated && ready) {
-      const rawTestimonials = t('home.testimonials', { returnObjects: true, ns: 'common' }) as any;
-      let loadedTestimonials: Testimonial[] = [];
+      interface TranslatedTestimonial {
+        quote: string;
+        name: string;
+        title: string;
+        outcome?: string;
+        avatarSeed?: number;
+        avatarUrl?: string;
+      }
+      type TranslatedTestimonials = Record<string, TranslatedTestimonial>;
+
+      const rawTestimonials = t('home.testimonials', { returnObjects: true, ns: 'common' }) as unknown as TranslatedTestimonials;
+      const loadedTestimonials: Testimonial[] = [];
       let allTranslationsValid = true;
 
       if (typeof rawTestimonials === 'object' && rawTestimonials !== null && !Array.isArray(rawTestimonials)) {

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -35,7 +35,7 @@ export const Footer = React.memo(function Footer() {
   const [email, setEmail] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
-  const { t, i18n } = useTranslation("common"); // Ensure "common" namespace
+  const { t } = useTranslation("common"); // Ensure "common" namespace
   const params = useParams();
   const locale = (params.locale as 'en' | 'es') || 'en';
   const [isHydrated, setIsHydrated] = useState(false);
@@ -65,9 +65,14 @@ export const Footer = React.memo(function Footer() {
     setIsLoading(false);
   };
 
+  type IntercomWindow = Window & { Intercom?: (cmd: string) => void };
+
   const loadIntercom = () => {
+    const win: IntercomWindow = window as IntercomWindow;
     if (intercomLoaded) {
-      (window as any).Intercom && (window as any).Intercom('show');
+      if (win.Intercom) {
+        win.Intercom('show');
+      }
       return;
     }
 
@@ -82,7 +87,9 @@ export const Footer = React.memo(function Footer() {
     script.defer = true;
     script.onload = () => {
       setIntercomLoaded(true);
-      (window as any).Intercom && (window as any).Intercom('show');
+      if (win.Intercom) {
+        win.Intercom('show');
+      }
     };
     document.body.appendChild(script);
   };


### PR DESCRIPTION
## Summary
- remove unused imports and fix quote rendering in TrustAndTestimonialsSection
- add explicit types when loading translated testimonials
- use const for loadedTestimonials array
- clean up Footer component and type Intercom window usage

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test`