### PR TITLE
Fix ts lint warnings

### DIFF
--- a/src/components/motion/SlideFade.tsx
+++ b/src/components/motion/SlideFade.tsx
@@ -4,10 +4,10 @@
 import { motion } from "framer-motion";
 import React from "react";
 
-interface SlideFadeProps {
+interface SlideFadeProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   delay?: number;
-  [key: string]: any;
 }
 
 const SlideFade: React.FC<SlideFadeProps> = ({

--- a/src/components/questionnaire.tsx
+++ b/src/components/questionnaire.tsx
@@ -10,12 +10,12 @@ import { Textarea } from '@/components/ui/textarea'; // Import Textarea
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select" // Import Select
 import { Loader2, Edit2, Lock, Check } from 'lucide-react'; // Updated icons
 import { useToast } from '@/hooks/use-toast';
-import { documentLibrary, usStates, type Question } from '@/lib/document-library'; // Import library and Question type
+import { documentLibrary, type Question } from '@/lib/document-library'; // Import library and Question type
 
 interface QuestionnaireProps {
   documentType: string | null; // The inferred document type NAME (e.g., "Residential Lease Agreement")
   selectedState?: string | null; // The selected US state code (e.g., "CA")
-  onAnswersSubmit: (answers: Record<string, any>) => void; // Callback
+  onAnswersSubmit: (answers: Record<string, unknown>) => void; // Callback
   isReadOnly?: boolean; // Optional prop to make the form read-only
 }
 
@@ -25,7 +25,7 @@ const QuestionnaireIcon = () => (
 );
 
 export function Questionnaire({ documentType, selectedState, onAnswersSubmit, isReadOnly = false }: QuestionnaireProps) {
-  const [answers, setAnswers] = useState<Record<string, any>>({});
+  const [answers, setAnswers] = useState<Record<string, unknown>>({});
   const [isEditing, setIsEditing] = useState<Record<string, boolean>>({}); // Track editing state per field
   const [isLoading, setIsLoading] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false); // Track if submitted
@@ -71,7 +71,7 @@ export function Questionnaire({ documentType, selectedState, onAnswersSubmit, is
   }, [documentType, selectedDocument, selectedState, isReadOnly]); // Re-run when these change
 
 
-  const handleInputChange = (id: string, value: any) => {
+  const handleInputChange = (id: string, value: unknown) => {
     if (isReadOnly || !isEditing[id]) return; // Prevent changes if read-only or not editing this field
     setAnswers(prev => ({ ...prev, [id]: value }));
   };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -8,10 +8,7 @@ import { cn } from "@/lib/utils";
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => {
-  const restProps: Record<string, any> = { ...props };
-  const ariaLabel = restProps["aria-label"] ?? "Progress";
-  delete restProps["aria-label"];
+>(({ className, value, "aria-label": ariaLabel = "Progress", ...restProps }, ref) => {
   return (
     <ProgressPrimitive.Root
       ref={ref}

--- a/src/components/wizard/SmartInput.tsx
+++ b/src/components/wizard/SmartInput.tsx
@@ -54,7 +54,7 @@ const SmartInput = React.memo(React.forwardRef<HTMLInputElement, SmartInputProps
     }, [watchedRHFValue, type, displayValue]); 
 
     const handleInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-      let currentValue = event.target.value;
+      const currentValue = event.target.value;
       let valueToSetInRHF = currentValue;
 
       if (type === 'tel') {
@@ -66,7 +66,10 @@ const SmartInput = React.memo(React.forwardRef<HTMLInputElement, SmartInputProps
       }
       
       setValue(rhfName, valueToSetInRHF, { shouldValidate: true, shouldDirty: true });
-    }, [type, rhfName, setValue]);
+      if (rhfInternalOnChangeFromProps) {
+        rhfInternalOnChangeFromProps(event);
+      }
+    }, [type, rhfName, setValue, rhfInternalOnChangeFromProps]);
 
 
     const handleBlur = useCallback((event: React.FocusEvent<HTMLInputElement>) => {

--- a/src/components/wizard/useSmartField.ts
+++ b/src/components/wizard/useSmartField.ts
@@ -3,17 +3,19 @@
 import { useEffect } from 'react';
 import type { UseFormWatch, UseFormSetValue, UseFormGetValues } from 'react-hook-form'; // Added GetValues
 
-type HookProps = {
+type HookProps<TFieldValues = Record<string, unknown>> = {
   name: string;
-  watch: UseFormWatch<any>;
-  setValue: UseFormSetValue<any>;
-  getValues: UseFormGetValues<any>; // Added getValues
+  watch: UseFormWatch<TFieldValues>;
+  setValue: UseFormSetValue<TFieldValues>;
+  getValues: UseFormGetValues<TFieldValues>; // Added getValues
 };
 
 /** Autocomplete + masking for VIN, color, year … 
  * Phone masking is handled directly in SmartInput.
 */
-export const useSmartField = ({ name, watch, setValue, getValues }: HookProps): void => {
+export const useSmartField = <TFieldValues = Record<string, unknown>>(
+  { name, watch, setValue, getValues }: HookProps<TFieldValues>,
+): void => {
   const currentValue = watch(name); 
 
   // Year – numeric only, 4 digits


### PR DESCRIPTION
## Summary
- address `any` types in questionnaire, progress bar, and SlideFade components
- ensure SmartInput triggers the RHF change handler
- add generics for useSmartField hook

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*