### PR TITLE
Fix lint warnings

### DIFF
--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -112,7 +112,7 @@ export default function DashboardClientContent({ locale }: DashboardClientConten
         if (isNaN(dateObj.getTime())) { 
             return String(dateInput); 
         }
-      } catch (_err) {
+      } catch {
         return String(dateInput);
       }
     }

--- a/src/app/[locale]/templates/templates-client-content.tsx
+++ b/src/app/[locale]/templates/templates-client-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import SearchBar from '@/components/SearchBar';
 import { CATEGORY_LIST } from '@/components/Step1DocumentSelector';

--- a/src/components/AutoImage.tsx
+++ b/src/components/AutoImage.tsx
@@ -9,7 +9,12 @@ interface AutoImageProps extends Omit<ImageProps, 'width' | 'height'> {
   height?: number;
 }
 
-const AutoImage: React.FC<AutoImageProps> = ({ width, height, ...props }) => {
+const AutoImage: React.FC<AutoImageProps> = ({
+  width,
+  height,
+  alt = '',
+  ...props
+}) => {
   const [dims, setDims] = useState<{ width: number; height: number } | null>(null);
 
   useEffect(() => {
@@ -26,7 +31,7 @@ const AutoImage: React.FC<AutoImageProps> = ({ width, height, ...props }) => {
   const finalWidth = width ?? dims?.width ?? 1;
   const finalHeight = height ?? dims?.height ?? 1;
 
-  return <Image width={finalWidth} height={finalHeight} {...props} />;
+  return <Image width={finalWidth} height={finalHeight} alt={alt} {...props} />;
 };
 
 export default AutoImage;

--- a/src/components/DocumentFlow.tsx
+++ b/src/components/DocumentFlow.tsx
@@ -8,20 +8,16 @@ import { StepOneInput } from '@/components/StepOneInput'; // This might be repla
 import SlideFade from '@/components/motion/SlideFade';
 import { StepTwoInput } from '@/components/StepTwoInput'; // This might be replaced or refactored
 import { StepThreeInput } from '@/components/StepThreeInput'; // This might be replaced or refactored
-import { useRouter } from 'next/navigation'; 
-import { useTranslation } from 'react-i18next'; 
+import { useTranslation } from 'react-i18next';
 import { documentLibrary } from '@/lib/document-library'; // Import documentLibrary
 
 interface DocumentFlowProps {
   initialDocId?: string;
-  initialLocale?: 'en' | 'es';
 }
 
 export default function DocumentFlow({
   initialDocId,
-  initialLocale = 'en',
-}: DocumentFlowProps = {}) { 
-  const router = useRouter();
+}: DocumentFlowProps = {}) {
   useTranslation("common");
 
   const [templateId, setTemplateId] = useState<string>(initialDocId ?? '');

--- a/src/components/DynamicFormRenderer.tsx
+++ b/src/components/DynamicFormRenderer.tsx
@@ -40,7 +40,7 @@ import { analyzeFormData, type FieldSuggestion } from '@/ai/flows/analyze-form-d
 interface Props {
   documentType: string;
   schema: FormField[];
-  onSubmit: (values: Record<string, any>) => void;
+  onSubmit: (values: Record<string, unknown>) => void;
   isReadOnly?: boolean;
   userId?: string;
   stateCode?: string;
@@ -76,7 +76,7 @@ export default function DynamicFormRenderer({
   const { t } = useTranslation('common');
 
   /* ---------------- state ------------------ */
-  const [values, setValues] = useState<Record<string, any>>({});
+  const [values, setValues] = useState<Record<string, unknown>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(isReadOnly);
   const [isHydrated, setIsHydrated] = useState(false);
@@ -99,7 +99,7 @@ export default function DynamicFormRenderer({
   }, [userId, documentType]);
 
   /* -------------- on change ---------------- */
-  const handleChange = (id: string, value: any) => {
+  const handleChange = (id: string, value: unknown) => {
     if (isReadOnly) return;
 
     const isUpsellField = /notarize|upsell|add(?:_)?on|extra/i.test(id);
@@ -142,7 +142,7 @@ export default function DynamicFormRenderer({
   const analyzeThenSubmit = async () => {
     if (isReadOnly || isLoading || hasSubmitted) return;
 
-    const missing = schema.some(f => f.required && !values[f.id]);
+    const missing = schema.some(f => f.required && !Boolean(values[f.id]));
     if (missing) {
       alert(t('dynamicForm.errorMissingRequired'));
       return;

--- a/src/components/GooglePlacesLoader.tsx
+++ b/src/components/GooglePlacesLoader.tsx
@@ -3,12 +3,22 @@
 import Script from 'next/script';
 import React, { useState, useEffect } from 'react';
 
+declare global {
+  interface Window {
+    google?: {
+      maps?: {
+        places?: unknown;
+      };
+    };
+  }
+}
+
 export default function GooglePlacesLoader() {
   const [loaded, setLoaded] = useState(false);
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
 
   useEffect(() => {
-    if ((window as any).google?.maps?.places) {
+    if (window.google?.maps?.places) {
       setLoaded(true);
     }
   }, []);

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -21,7 +21,7 @@ const staticTopDocIds: string[] = [
 
 const TopDocsChips = React.memo(function TopDocsChips() {
   // Use 'common' namespace for shared UI text
-  const { t: tCommon, i18n } = useTranslation("common");
+  const { t: tCommon } = useTranslation("common");
   const params = useParams();
   const router = useRouter();
   const locale = (params.locale as 'en' | 'es') || 'en';

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -258,7 +258,7 @@ export default function WizardForm({
     isLoggedIn,
     trigger,
     locale,
-    doc.id,
+    doc,
     getValues,
     onComplete,
     toast,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 // src/components/layout/Header.tsx
 'use client';
 
-import React, { useState, useEffect, useRef, useCallback } from 'react'; 
+import React, { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter, useParams } from 'next/navigation';
 import { Logo } from '@/components/layout/Logo';
@@ -12,7 +12,7 @@ import Nav from '@/components/Nav';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Button } from '@/components/ui/button';
-import { Check, ChevronDown, Globe, UserPlus, LogIn, Search as SearchIcon, ExternalLink, FileText, Menu as MenuIcon, X as CloseIcon, LayoutGrid, ChevronUp, LogOut, UserCircle, Loader2 } from 'lucide-react';
+import { ChevronDown, UserPlus, LogIn, Search as SearchIcon, ExternalLink, FileText, Menu as MenuIcon, X as CloseIcon, LayoutGrid, ChevronUp, LogOut, UserCircle } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import type { LegalDocument } from '@/lib/document-library';
 import { CATEGORY_LIST } from '@/components/Step1DocumentSelector';
@@ -25,8 +25,7 @@ import { getDocTranslation } from '@/lib/i18nUtils';
 
 const Header = React.memo(function Header() {
   // Scoped translations
-  const { i18n, t: tHeader } = useTranslation("common");
-  const { t: tCommon } = useTranslation("common"); // For general common keys if needed
+  const { t: tHeader } = useTranslation("common");
   const router = useRouter();
   const params = useParams();
   const { isLoggedIn, logout, user } = useAuth(); // Added user from useAuth

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -66,7 +66,7 @@ const addToRemoveQueue = (toastId: string) => {
   const timeout = setTimeout(() => {
     toastTimeouts.delete(toastId)
     dispatch({
-      type: "REMOVE_TOAST",
+      type: actionTypes.REMOVE_TOAST,
       toastId: toastId,
     })
   }, TOAST_REMOVE_DELAY)
@@ -76,13 +76,13 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case "ADD_TOAST":
+    case actionTypes.ADD_TOAST:
       return {
         ...state,
         toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
       }
 
-    case "UPDATE_TOAST":
+    case actionTypes.UPDATE_TOAST:
       return {
         ...state,
         toasts: state.toasts.map((t) =>
@@ -90,7 +90,7 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
 
-    case "DISMISS_TOAST": {
+    case actionTypes.DISMISS_TOAST: {
       const { toastId } = action
 
       // ! Side effects ! - This could be extracted into a dismissToast() action,
@@ -115,7 +115,7 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
     }
-    case "REMOVE_TOAST":
+    case actionTypes.REMOVE_TOAST:
       if (action.toastId === undefined) {
         return {
           ...state,
@@ -147,13 +147,13 @@ function toast({ ...props }: Toast) {
 
   const update = (props: ToasterToast) =>
     dispatch({
-      type: "UPDATE_TOAST",
+      type: actionTypes.UPDATE_TOAST,
       toast: { ...props, id },
     })
-  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+  const dismiss = () => dispatch({ type: actionTypes.DISMISS_TOAST, toastId: id })
 
   dispatch({
-    type: "ADD_TOAST",
+    type: actionTypes.ADD_TOAST,
     toast: {
       ...props,
       id,
@@ -187,7 +187,7 @@ function useToast() {
   return {
     ...state,
     toast,
-    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    dismiss: (toastId?: string) => dispatch({ type: actionTypes.DISMISS_TOAST, toastId }),
   }
 }
 

--- a/src/lib/document-library.ts
+++ b/src/lib/document-library.ts
@@ -10,7 +10,7 @@ const isValidDocument = (doc: unknown): doc is LegalDocument => {
   const d = doc as Partial<LegalDocument>
   const hasId = d && typeof d.id === 'string' && d.id.trim() !== ''
   const hasCategory = d && typeof d.category === 'string' && d.category.trim() !== ''
-  const hasSchema = d && (d as any).schema && typeof (d as any).schema.parse === 'function'
+  const hasSchema = d && d.schema && typeof d.schema.parse === 'function'
 
   // Check for English translation name as the primary indicator of a valid name structure
   // OR fallback to top-level name if translations are not yet populated by the forEach loop


### PR DESCRIPTION
## Summary
- fix unused catch parameter
- remove unused React hooks and imports
- ensure AutoImage always gets an `alt` attribute
- clean up unused variables in DocumentFlow and TopDocsChips
- tighten types in DynamicFormRenderer and GooglePlacesLoader
- fix WizardForm callback dependency
- remove unused imports from Header
- reference actionTypes in use-toast
- remove `any` casts in document-library

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find modules)*