### PR TITLE
Add ESLint and Prettier setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,18 @@
 {
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "prettier"],
   "extends": [
     "next/core-web-vitals",
-    "next/typescript"
-  ]
+    "next/typescript",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/strict-type-checked",
+    "plugin:prettier/recommended"
+  ],
+  "rules": {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/strict-boolean-expressions": "error"
+  }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "npm run gen:previews && next build",
     "start": "NODE_ENV=production node server.mjs",
     "lint": "next lint",
+    "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "test": "node --test tests/prettify.test.js",
     "gen:previews": "node --experimental-modules scripts/generate-previews.js",
@@ -100,7 +101,12 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
-    "webpack": "^5.99.8"
+    "webpack": "^5.99.8",
+    "@typescript-eslint/eslint-plugin": "^7.7.0",
+    "@typescript-eslint/parser": "^7.7.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.0",
+    "prettier": "^3.2.5"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Summary
- add `format` script and Prettier config
- extend ESLint config with TypeScript and Prettier rules
- install eslint/prettier dependencies

## Testing
- `npm test`
- `npx eslint` *(fails: couldn't find an eslint.config file)*
- `npx next lint` *(fails: network access needed to install deps)*