### PR TITLE
Fix header translation namespace

### DIFF
--- a/src/components/landing/Logo.tsx
+++ b/src/components/landing/Logo.tsx
@@ -11,8 +11,8 @@ interface LogoProps {
 }
 
 const Logo = React.memo(function Logo({ wrapperClassName, svgClassName, textClassName, ...props }: LogoProps) {
-   // Use the 'common' namespace for logo translations
-   const { t } = useTranslation("common");
+   // Use the 'header' namespace for logo translations
+   const { t } = useTranslation("header");
 
   return (
     <Link

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,7 +25,7 @@ import { getDocTranslation } from '@/lib/i18nUtils';
 
 const Header = React.memo(function Header() {
   // Scoped translations
-  const { t: tHeader } = useTranslation("common");
+  const { t: tHeader } = useTranslation("header");
   const router = useRouter();
   const params = useParams();
   const { isLoggedIn, logout, user } = useAuth(); // Added user from useAuth

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -11,7 +11,7 @@ interface LogoProps {
 }
 
 export function Logo({ wrapperClassName, svgClassName, textClassName, ...props }: LogoProps) {
-   const { t } = useTranslation("common");
+   const { t } = useTranslation("header");
 
   return (
     <Link


### PR DESCRIPTION
## Summary
- use `header` namespace for header translations so Spanish text shows up

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `npm test`
