### PR TITLE
Fix generic types for SmartField and documents

### DIFF
--- a/src/hooks/useSmartField.ts
+++ b/src/hooks/useSmartField.ts
@@ -1,10 +1,10 @@
 // src/hooks/useSmartField.ts
 'use client';
 import { useEffect } from 'react';
-import type { UseFormWatch, UseFormSetValue, UseFormGetValues } from 'react-hook-form';
+import type { UseFormWatch, UseFormSetValue, UseFormGetValues, Path } from 'react-hook-form';
 
-type HookProps<T> = {
-  name: keyof T & string
+type HookProps<T extends Record<string, unknown>> = {
+  name: Path<T>
   watch: UseFormWatch<T>
   setValue: UseFormSetValue<T>
   getValues: UseFormGetValues<T>
@@ -67,13 +67,13 @@ export const useSmartField = <T extends Record<string, unknown>>({
 
 
               if (result.Make && (formValues[makeField] === undefined || formValues[makeField] === '')) {
-                setValue(makeField, result.Make, { shouldValidate: true, shouldDirty: true });
+                setValue(makeField as Path<T>, result.Make, { shouldValidate: true, shouldDirty: true });
               }
               if (result.Model && (formValues[modelField] === undefined || formValues[modelField] === '')) {
-                setValue(modelField, result.Model, { shouldValidate: true, shouldDirty: true });
+                setValue(modelField as Path<T>, result.Model, { shouldValidate: true, shouldDirty: true });
               }
-              if (result.ModelYear && (formValues[yearField] === undefined || formValues[yearField] === '' || formValues[yearField] === 0 || isNaN(parseInt(formValues[yearField])) ) ) {
-                setValue(yearField, Number(result.ModelYear), { shouldValidate: true, shouldDirty: true });
+              if (result.ModelYear && (formValues[yearField] === undefined || formValues[yearField] === '' || formValues[yearField] === 0 || isNaN(parseInt(formValues[yearField] as unknown as string)) ) ) {
+                setValue(yearField as Path<T>, Number(result.ModelYear), { shouldValidate: true, shouldDirty: true });
               }
             }
           })

--- a/src/lib/document-library.ts
+++ b/src/lib/document-library.ts
@@ -1,7 +1,7 @@
 // src/lib/document-library.ts
 import { z } from 'zod';
 import { documentLibraryAdditions } from './document-library-additions';
-import type { LegalDocument } from '@/types/documents'
+import type { LegalDocument, LocalizedText } from '@/types/documents'
 import * as us_docs_barrel from './documents/us';
 import * as ca_docs_barrel from './documents/ca';
 // …other countries…
@@ -14,12 +14,12 @@ const isValidDocument = (doc: unknown): doc is LegalDocument => {
 
   // Check for English translation name as the primary indicator of a valid name structure
   // OR fallback to top-level name if translations are not yet populated by the forEach loop
-  const hasValidTranslationsOrName = doc &&
-                                   ( (doc.translations &&
-                                      doc.translations.en &&
-                                      typeof doc.translations.en.name === 'string' &&
-                                      doc.translations.en.name.trim() !== '') ||
-                                     (typeof doc.name === 'string' && doc.name.trim() !== '')
+  const hasValidTranslationsOrName = d &&
+                                   ( (d.translations &&
+                                      d.translations.en &&
+                                      typeof d.translations.en.name === 'string' &&
+                                      d.translations.en.name.trim() !== '') ||
+                                     (typeof d.name === 'string' && d.name.trim() !== '')
                                    );
 
   return hasId && hasCategory && hasSchema && hasValidTranslationsOrName;
@@ -78,7 +78,10 @@ allDocuments.forEach(doc => {
   }
 
   // Ensure translations object and its properties exist, and populate from top-level if necessary
-  const baseTranslations = doc.translations || { en: {}, es: {} };
+  const baseTranslations = (doc.translations || {}) as {
+    en?: Partial<LocalizedText>;
+    es?: Partial<LocalizedText>;
+  };
   doc.translations = {
     en: {
       name: baseTranslations.en?.name || doc.name || doc.id,

--- a/src/lib/documents/ca/promissory-note.ts
+++ b/src/lib/documents/ca/promissory-note.ts
@@ -6,6 +6,8 @@ export const promissoryNoteCA: LegalDocument = {
   id: 'promissory-note-ca',
   jurisdiction: 'CA',
   category: 'Finance',
+  name: 'Promissory Note (Canada)',
+  description: 'Formal promise to repay a loan in compliance with Canadian federal and provincial law.',
   languageSupport: ['en', 'fr'],
   basePrice: 7,
   requiresNotarization: false,

--- a/src/lib/documents/us/affidavit-general.ts
+++ b/src/lib/documents/us/affidavit-general.ts
@@ -7,6 +7,8 @@ export const affidavitGeneral: LegalDocument = {
   id: 'affidavit-general',
   jurisdiction: 'US',
   category: 'Personal',
+  name: 'Affidavit (General)',
+  description: 'A sworn written statement confirmed by oath, often used as evidence.',
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: false,

--- a/src/lib/documents/us/articles-of-incorporation-biz.ts
+++ b/src/lib/documents/us/articles-of-incorporation-biz.ts
@@ -5,6 +5,8 @@ export const articlesOfIncorporationBiz: LegalDocument = {
   id: 'articles-of-incorporation-biz',
   jurisdiction: 'US',
   category: 'Business',
+  name: 'Articles of Incorporation',
+  description: 'Formal document filed with the state to create a corporation.',
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: true,

--- a/src/lib/documents/us/child-custody-agreement.ts
+++ b/src/lib/documents/us/child-custody-agreement.ts
@@ -5,6 +5,8 @@ export const childCustodyAgreement: LegalDocument = {
   id: 'child-custody-agreement',
   jurisdiction: 'US',
   category: 'Family',
+  name: 'Child Custody Agreement',
+  description: 'Outline legal/physical custody, visitation schedule for children.',
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: true,

--- a/src/types/documents.ts
+++ b/src/types/documents.ts
@@ -43,7 +43,7 @@ export type LegalDocument = {
   jurisdiction?: string; // e.g., 'US', 'CA'
   category: string;
   states?: string[] | 'all'; // Applies to the jurisdiction
-  schema: z.AnyZodObject; // Use AnyZodObject for broader compatibility
+  schema: z.ZodTypeAny; // Allow any Zod schema including effects
   questions?: Question[];
 
   // Core display text (can be direct or i18n keys)


### PR DESCRIPTION
## Summary
- update `useSmartField` generic typing to use `Path` and cast dynamic fields
- ensure `document-library` type guards use typed partials and handle translations safely
- provide base `name` and `description` fields for several document configs
- loosen `LegalDocument.schema` typing to accept any Zod schema

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*