### PR TITLE
Fix missing types and schema handling

### DIFF
--- a/src/data/formSchemas.ts
+++ b/src/data/formSchemas.ts
@@ -1,0 +1,72 @@
+// src/data/formSchemas.ts
+// Basic form schema types and shared option sets
+
+export type FormField = {
+  id: string
+  label: string
+  placeholder?: string
+  required?: boolean
+  type: 'text' | 'select' | 'date' | 'number' | 'textarea' | 'boolean' | 'address'
+  options?: { value: string; label: string }[]
+  tooltip?: string
+  helperText?: string
+}
+
+export type FormSchema = {
+  [docType: string]: FormField[]
+}
+
+export const usStatesOptions: { value: string; label: string }[] = [
+  { value: 'AL', label: 'Alabama' },
+  { value: 'AK', label: 'Alaska' },
+  { value: 'AZ', label: 'Arizona' },
+  { value: 'AR', label: 'Arkansas' },
+  { value: 'CA', label: 'California' },
+  { value: 'CO', label: 'Colorado' },
+  { value: 'CT', label: 'Connecticut' },
+  { value: 'DE', label: 'Delaware' },
+  { value: 'FL', label: 'Florida' },
+  { value: 'GA', label: 'Georgia' },
+  { value: 'HI', label: 'Hawaii' },
+  { value: 'ID', label: 'Idaho' },
+  { value: 'IL', label: 'Illinois' },
+  { value: 'IN', label: 'Indiana' },
+  { value: 'IA', label: 'Iowa' },
+  { value: 'KS', label: 'Kansas' },
+  { value: 'KY', label: 'Kentucky' },
+  { value: 'LA', label: 'Louisiana' },
+  { value: 'ME', label: 'Maine' },
+  { value: 'MD', label: 'Maryland' },
+  { value: 'MA', label: 'Massachusetts' },
+  { value: 'MI', label: 'Michigan' },
+  { value: 'MN', label: 'Minnesota' },
+  { value: 'MS', label: 'Mississippi' },
+  { value: 'MO', label: 'Missouri' },
+  { value: 'MT', label: 'Montana' },
+  { value: 'NE', label: 'Nebraska' },
+  { value: 'NV', label: 'Nevada' },
+  { value: 'NH', label: 'New Hampshire' },
+  { value: 'NJ', label: 'New Jersey' },
+  { value: 'NM', label: 'New Mexico' },
+  { value: 'NY', label: 'New York' },
+  { value: 'NC', label: 'North Carolina' },
+  { value: 'ND', label: 'North Dakota' },
+  { value: 'OH', label: 'Ohio' },
+  { value: 'OK', label: 'Oklahoma' },
+  { value: 'OR', label: 'Oregon' },
+  { value: 'PA', label: 'Pennsylvania' },
+  { value: 'RI', label: 'Rhode Island' },
+  { value: 'SC', label: 'South Carolina' },
+  { value: 'SD', label: 'South Dakota' },
+  { value: 'TN', label: 'Tennessee' },
+  { value: 'TX', label: 'Texas' },
+  { value: 'UT', label: 'Utah' },
+  { value: 'VT', label: 'Vermont' },
+  { value: 'VA', label: 'Virginia' },
+  { value: 'WA', label: 'Washington' },
+  { value: 'WV', label: 'West Virginia' },
+  { value: 'WI', label: 'Wisconsin' },
+  { value: 'WY', label: 'Wyoming' },
+  { value: 'DC', label: 'District of Columbia' },
+  { value: 'Other', label: 'Other/Not Applicable' }
+];

--- a/src/lib/documents/us/promissory-note/questions.ts
+++ b/src/lib/documents/us/promissory-note/questions.ts
@@ -1,6 +1,7 @@
 import { usStates } from '@/lib/usStates';
+import type { Question } from '@/types/documents';
 
-export const promissoryNoteQuestions = [
+export const promissoryNoteQuestions: Question[] = [
   { id: 'date',             label: 'Date of Note',           type: 'date',    required: true },
   { id: 'placeOfExecution', label: 'Place of Execution',     type: 'text',    required: true, placeholder: 'City, State' },
   { id: 'lenderName',       label: 'Lender Name',            type: 'text',    required: true },

--- a/src/lib/documents/us/vehicle-bill-of-sale/questions.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/questions.ts
@@ -1,6 +1,7 @@
 import { usStates } from '@/lib/usStates';
+import type { Question } from '@/types/documents';
 
-export const vehicleBillOfSaleQuestions = [
+export const vehicleBillOfSaleQuestions: Question[] = [
   { 
     id: "seller_name", 
     label: "Seller's Full Name", 

--- a/src/lib/firestore/dashboardData.ts
+++ b/src/lib/firestore/dashboardData.ts
@@ -26,14 +26,14 @@ export async function getUserDocuments(
   const q = query(col, orderBy('createdAt', 'desc'), limit(max));
   const snap = await getDocs(q);
   return snap.docs.map(d => {
-    const data = d.data() as Record<string, unknown>
-    const docType = data.originalDocId || data.docType || d.id;
+    const data = d.data() as Record<string, unknown>;
+    const docType = (data.originalDocId || data.docType || d.id) as string;
     const docConfig = documentLibrary.find((doc) => doc.id === docType);
     return {
       id: d.id,
-      name: docConfig ? docConfig.name : docType,
-      date: data.createdAt,
-      status: data.status || 'Draft',
+      name: docConfig?.name || docConfig?.translations?.en?.name || docType,
+      date: data.createdAt as Timestamp | Date | string,
+      status: (data.status as string) || 'Draft',
       docType,
     };
   });

--- a/src/lib/firestore/saveFormProgress.ts
+++ b/src/lib/firestore/saveFormProgress.ts
@@ -15,7 +15,8 @@ import {
   query,
   serverTimestamp,
   setDoc,
-  type Timestamp // Import Timestamp type
+  type Timestamp,
+  type Firestore
 } from 'firebase/firestore';
 import { getDb } from '@/lib/firebase'; // lazily obtain Firestore instance
 

--- a/src/pages/api/generate-pdf.ts
+++ b/src/pages/api/generate-pdf.ts
@@ -118,7 +118,7 @@ export default async function handler(
     const responsePayload: ErrorResponse = {
       error: clientErrorMessage,
       code: errorCode,
-      details: process.env.NODE_ENV === 'development' ? errorDetails : undefined, // Full details in dev
+      details: process.env.NODE_ENV === 'development' ? JSON.stringify(errorDetails) : undefined, // Full details in dev
     };
     
     if (!res.headersSent) {

--- a/src/pages/api/infer-document-type.ts
+++ b/src/pages/api/infer-document-type.ts
@@ -1,6 +1,6 @@
 
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { inferDocumentTypeFlow, InferDocumentTypeInputSchema, InferDocumentTypeOutput } from '@/ai/flows/infer-document-type';
+import { inferDocumentTypeFlow, InferDocumentTypeInputSchema, InferDocumentTypeOutput, InferDocumentTypeOutputSchema } from '@/ai/flows/infer-document-type';
 import { z } from 'zod';
 
 type ErrorResponse = {
@@ -84,7 +84,7 @@ export default async function handler(
     let statusCode = 500;
     let clientErrorMessage = 'An internal server error occurred during document type inference.';
     let errorCode = 'INFERENCE_INTERNAL_SERVER_ERROR';
-    const errorDetails =
+    let errorDetails: unknown =
       error instanceof Error
         ? { name: error.name, message: error.message, stack: error.stack }
         : { message: String(error) };

--- a/src/types/documents.ts
+++ b/src/types/documents.ts
@@ -43,13 +43,13 @@ export type LegalDocument = {
   jurisdiction?: string; // e.g., 'US', 'CA'
   category: string;
   states?: string[] | 'all'; // Applies to the jurisdiction
-  schema: z.AnyZodObject; // Use AnyZodObject for broader compatibility
+  schema: z.ZodTypeAny; // Allow raw objects or schemas with effects
   questions?: Question[];
 
   // Core display text (can be direct or i18n keys)
   // Prefer using the 'translations' object below for better organization
-  name: string;
-  description: string;
+  name?: string;
+  description?: string;
   name_es?: string; // Deprecated in favor of translations object
   description_es?: string; // Deprecated in favor of translations object
   aliases?: string[]; // Deprecated in favor of translations object


### PR DESCRIPTION
## Summary
- allow `LegalDocument.schema` to use any Zod type
- make `name` and `description` optional in `LegalDocument`
- add basic form-schema types and US state options
- update question arrays to use `Question[]`
- improve dashboard data typing
- fix Firestore type import
- stringify error details in API handlers
- import correct schema in inference API

## Testing
- `npm run test`