### PR TITLE
Remove lodash-es usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "i18next": "^23.13.0",
         "i18next-browser-languagedetector": "^8.0.0",
         "i18next-http-backend": "^2.5.2",
-        "lodash-es": "^4.17.21",
         "lucide-react": "^0.475.0",
         "markdown-it": "^13.0.1",
         "nanoid": "^5.0.7",
@@ -81,7 +80,6 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
-        "@types/lodash-es": "^4.17.12",
         "@types/markdown-it": "^12.2.3",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -5641,16 +5639,6 @@
       "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -13501,12 +13489,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "i18next": "^23.13.0",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-http-backend": "^2.5.2",
-    "lodash-es": "^4.17.21",
     "lucide-react": "^0.475.0",
     "markdown-it": "^13.0.1",
     "nanoid": "^5.0.7",
@@ -87,7 +86,6 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@types/lodash-es": "^4.17.12",
     "@types/markdown-it": "^12.2.3",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -15,7 +15,7 @@ import PreviewPane from '@/components/PreviewPane';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import { loadFormProgress, saveFormProgress } from '@/lib/firestore/saveFormProgress';
-import { debounce } from 'lodash-es';
+import { debounce } from '@/lib/debounce';
 import TrustBadges from '@/components/TrustBadges';
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from '@/lib/utils';

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -7,7 +7,7 @@ import remarkGfm from 'remark-gfm';
 import { useFormContext } from 'react-hook-form';
 import { Loader2, AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { debounce } from 'lodash-es';
+import { debounce } from '@/lib/debounce';
 import { documentLibrary } from '@/lib/document-library';
 import { cn } from '@/lib/utils';
 import Image from 'next/image';

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,0 +1,25 @@
+export interface DebouncedFunction<T extends (...args: any[]) => void> {
+  (...args: Parameters<T>): void;
+  cancel(): void;
+}
+
+export function debounce<T extends (...args: any[]) => void>(fn: T, wait: number): DebouncedFunction<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const debounced = ((...args: Parameters<T>) => {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      fn(...args);
+    }, wait);
+  }) as DebouncedFunction<T>;
+
+  debounced.cancel = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+  };
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- drop lodash-es and the `@types` entry
- implement a small debounce helper
- use that helper in PreviewPane and StartWizardPageClient

## Testing
- `npm test`