### PR TITLE
Fix ts errors

### DIFF
--- a/src/ai/flows/infer-document-type.ts
+++ b/src/ai/flows/infer-document-type.ts
@@ -111,12 +111,12 @@ async (input) => {
   const ctx = getAvailableDocumentsContext();
 
   try {
-    const response: GenerateResponseData<InferDocumentTypeOutput> = await prompt({
+    const response: GenerateResponseData = await prompt({
       ...parsed.data,
       // Extra context isn't part of the input schema
       availableDocumentsContext: ctx,
     } as any);
-    const output = response.output;
+    const output = response.output as InferDocumentTypeOutput;
 
     if (!output) throw new Error('AI returned no output');
 

--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -70,22 +70,21 @@ export default function HomePageClient() {
   // Preload dynamically imported sections once on the client
   useEffect(() => {
     // Use dynamic import to get the module and then call preload if available
-    import('@/components/landing/HowItWorks').then(mod => {
-      if (mod.default && mod.default.preload) mod.default.preload();
+    import('@/components/landing/HowItWorks').then((mod: any) => {
+      mod.default?.preload?.();
     });
-    import('@/components/landing/TrustAndTestimonialsSection').then(mod => {
-      if (mod.default && mod.default.preload) mod.default.preload();
+    import('@/components/landing/TrustAndTestimonialsSection').then((mod: any) => {
+      mod.default?.preload?.();
     });
-    import('@/components/landing/GuaranteeBadge').then(mod => {
-      // Note: GuaranteeBadge might be a named export
-      if (mod.GuaranteeBadge && mod.GuaranteeBadge.preload) mod.GuaranteeBadge.preload();
-      else if (mod.default && mod.default.preload) mod.default.preload(); // fallback for default export
+    import('@/components/landing/GuaranteeBadge').then((mod: any) => {
+      mod.GuaranteeBadge?.preload?.();
+      mod.default?.preload?.(); // fallback for default export
     });
-    import('@/components/TopDocsChips').then(mod => {
-      if (mod.default && mod.default.preload) mod.default.preload();
+    import('@/components/TopDocsChips').then((mod: any) => {
+      mod.default?.preload?.();
     });
-    import('@/components/StickyFilterBar').then(mod => {
-      if (mod.default && mod.default.preload) mod.default.preload();
+    import('@/components/StickyFilterBar').then((mod: any) => {
+      mod.default?.preload?.();
     });
 
 

--- a/src/app/[locale]/api/wizard/[docId]/submit/route.ts
+++ b/src/app/[locale]/api/wizard/[docId]/submit/route.ts
@@ -120,15 +120,15 @@ export async function POST(
       const documentDisplayName = docConfig.name_es && effectiveLocale === 'es' ? docConfig.name_es : docConfig.name;
       const documentDisplayDescription = docConfig.description_es && effectiveLocale === 'es' ? docConfig.description_es : docConfig.description;
 
-      session = await stripe.checkout.sessions.create({
+      const sessionParams: Stripe.Checkout.SessionCreateParams = {
         mode: 'payment',
         payment_method_types: ['card'],
-        customer_email: user.email || undefined, 
+        ...(user.email ? { customer_email: user.email } : {}),
         line_items: [
           {
             price_data: {
               currency: 'usd',
-              unit_amount: FIXED_DOCUMENT_PRICE_CENTS, 
+              unit_amount: FIXED_DOCUMENT_PRICE_CENTS,
               product_data: {
                 name: documentDisplayName,
                 description: documentDisplayDescription,
@@ -142,10 +142,12 @@ export async function POST(
         metadata: {
           userId: user.uid,
           docId: params.docId,
-          documentInstanceId: documentInstanceId, 
+          documentInstanceId: documentInstanceId,
           locale: effectiveLocale,
         },
-      });
+      };
+
+      session = await stripe.checkout.sessions.create(sessionParams);
       console.log(`${logPrefix} Stripe Checkout session created: ${session.id}`);
     } catch (stripeError) {
       console.error(`${logPrefix} Stripe session creation failed:`, stripeError);

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,18 +1,13 @@
 // src/app/[locale]/blog/page.tsx
 import React from 'react';
 import BlogClientContent from './blog-client-content';
+import type { PageProps } from 'next';
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
 }
 
-interface BlogPageProps {
-  params: {
-    locale: 'en' | 'es';
-  };
-}
-
-export default function BlogPage({ params }: BlogPageProps) {
+export default function BlogPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
   const { locale } = params;
   return <BlogClientContent locale={locale} />;
 }

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -6,6 +6,7 @@ import path from 'node:path';
 import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
+import type { PageProps } from 'next';
 
 // Revalidate this page every hour for fresh content while caching aggressively
 export const revalidate = 3600;
@@ -37,15 +38,13 @@ export async function generateStaticParams() {
   return params;
 }
 
-interface DocPageProps { // Renamed from DocPageContainerProps for clarity
-  params: {
-    locale: string;
-    docId: string;
-  };
+interface DocParams {
+  locale: string;
+  docId: string;
 }
 
 // This Server Component now correctly passes params to the Client Component
-export default async function DocPage({ params }: DocPageProps) {
+export default async function DocPage({ params }: PageProps<DocParams>) {
   // Await a microtask to comply with Next.js dynamic param handling
   await Promise.resolve();
 

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -4,6 +4,7 @@
 import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
+import type { PageProps } from 'next';
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly
 export const revalidate = 3600;
@@ -69,15 +70,13 @@ export async function generateStaticParams() {
   return params;
 }
 
-interface StartWizardPageProps {
-  params: {
-    locale: 'en' | 'es';
-    docId: string;
-  };
+interface StartWizardParams {
+  locale: 'en' | 'es';
+  docId: string;
 }
 
 // This Server Component now correctly passes params to the Client Component
-export default async function StartWizardPage({ params }: StartWizardPageProps) {
+export default async function StartWizardPage({ params }: PageProps<StartWizardParams>) {
   // Await a microtask to satisfy Next.js dynamic route requirements
   await Promise.resolve();
   // The StartWizardPageClient will handle fetching its own specific document data

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -1,18 +1,13 @@
 // src/app/[locale]/faq/page.tsx
 import React from 'react';
 import FaqClientContent from './faq-client-content';
+import type { PageProps } from 'next';
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
 }
 
-interface FaqPageProps {
-  params: {
-    locale: 'en' | 'es';
-  };
-}
-
-export default function FAQPage({ params }: FaqPageProps) {
+export default function FAQPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
   const { locale } = params;
   return <FaqClientContent locale={locale} />;
 }

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -1,19 +1,14 @@
 // src/app/[locale]/pricing/page.tsx
 import React from 'react';
 import PricingClientContent from './pricing-client-content';
+import type { PageProps } from 'next';
 
 // Add generateStaticParams for dynamic routes with static export
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
 }
 
-interface PricingPageProps {
-  params: {
-    locale: 'en' | 'es';
-  };
-}
-
-export default function PricingPage({ params }: PricingPageProps) {
+export default function PricingPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
   const { locale } = params;
   // The rest of the page content including client-side hooks and logic
   // is now in PricingClientContent.tsx

--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -1,7 +1,7 @@
 // src/app/[locale]/signwell/page.tsx
 import React from 'react';
 import SignWellClientContent from './signwell-client-content';
-import type { Metadata } from 'next';
+import type { Metadata, PageProps } from 'next';
 import i18n from '@/lib/i18n'; // Import i18n instance to access translations server-side for metadata
 
 export async function generateStaticParams() {
@@ -30,10 +30,6 @@ export async function generateMetadata({ params }: { params: { locale: 'en' | 'e
 }
 
 
-interface SignWellPageProps {
-  params: { locale: 'en' | 'es' };
-}
-
-export default function SignWellPage({ params }: SignWellPageProps) {
+export default function SignWellPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
   return <SignWellClientContent params={params} />;
 }

--- a/src/app/[locale]/support/page.tsx
+++ b/src/app/[locale]/support/page.tsx
@@ -1,18 +1,13 @@
 // src/app/[locale]/support/page.tsx
 import React from 'react';
 import SupportClientContent from './support-client-content';
+import type { PageProps } from 'next';
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
 }
 
-interface SupportPageProps {
-  params: {
-    locale: 'en' | 'es';
-  };
-}
-
-export default function SupportPage({ params }: SupportPageProps) {
+export default function SupportPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
   const { locale } = params;
   return <SupportClientContent locale={locale} />;
 }


### PR DESCRIPTION
## Notes
- npm run typecheck fails because the container lacks packages

## Summary
- adjust AI flow response typing
- avoid preload typing errors on HomePageClient
- update locale pages to use Next's `PageProps`
- fix Stripe session creation typing

## Testing
- `npm run typecheck` *(fails: Cannot find name 'Buffer')*
- `npm test`