### PR TITLE
Fix typecheck errors in React components

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -74,7 +74,7 @@ const LanguageSwitcher = React.memo(function LanguageSwitcher() {
       ? pathname.replace(`/${currentRouteLocale}`, `/${newLocale}`)
       : `/${newLocale}${pathname === '/' ? '' : pathname}`;
 
-    const query = searchParams.toString();
+    const query = searchParams ? searchParams.toString() : '';
     if (query) newPath += `?${query}`;
 
     router.push(newPath);

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -12,7 +12,7 @@ import { getDocTranslation } from '@/lib/i18nUtils';
 const SearchBar = React.memo(function SearchBar() {
   const { t: tHeader } = useTranslation("common");
   const router = useRouter();
-  const params = useParams<{ locale?: string }>();
+  const params = (useParams<{ locale?: string }>() ?? {}) as { locale?: string };
   const locale = (params.locale as 'en' | 'es') || 'en';
   
   const [searchTerm, setSearchTerm] = useState('');

--- a/src/components/Step1DocumentSelector.tsx
+++ b/src/components/Step1DocumentSelector.tsx
@@ -59,7 +59,7 @@ const MemoizedCategoryCard = React.memo(function CategoryCard({ category, onClic
       className="category-card h-auto min-h-[90px] p-4 border-border shadow-sm hover:shadow-md transition text-center flex flex-col justify-center items-center bg-card hover:bg-muted active:scale-95 active:transition-transform active:duration-100"
     >
       {React.createElement(category.icon || FileText, { className: "h-6 w-6 mb-2 text-primary/80" })}
-      <span className="font-medium text-card-foreground text-sm">{t(category.labelKey, category.key)}</span>
+      <span className="font-medium text-card-foreground text-sm">{t(category.labelKey, { defaultValue: category.key })}</span>
     </Button>
   );
 });
@@ -70,7 +70,7 @@ const MemoizedDocumentCard = React.memo(function DocumentCard({ doc, onSelect, d
       onClick={onSelect}
       tabIndex={disabled ? -1 : 0}
       role="button"
-      aria-label={t(doc.name ?? '', doc.name)}
+      aria-label={t(doc.name ?? '', { defaultValue: doc.name ?? '' })}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
@@ -84,11 +84,11 @@ const MemoizedDocumentCard = React.memo(function DocumentCard({ doc, onSelect, d
     >
       <CardHeader className="pb-2 pt-4 px-4">
         <CardTitle className="text-base font-semibold text-card-foreground">
-          {i18nLanguage === 'es' && doc.name_es ? t(doc.name_es, doc.name_es) : t(doc.name ?? '', doc.name)}
+          {i18nLanguage === 'es' && doc.name_es ? t(doc.name_es, { defaultValue: doc.name_es }) : t(doc.name ?? '', { defaultValue: doc.name ?? '' })}
         </CardTitle>
       </CardHeader>
       <CardContent className="text-xs text-muted-foreground flex-grow px-4">
-        {i18nLanguage === 'es' && doc.description_es ? t(doc.description_es, doc.description_es) : t(doc.description ?? '', doc.description) || placeholderNoDescription}
+        {i18nLanguage === 'es' && doc.description_es ? t(doc.description_es, { defaultValue: doc.description_es }) : t(doc.description ?? '', { defaultValue: doc.description ?? '' }) || placeholderNoDescription}
       </CardContent>
       <CardFooter className="pt-2 pb-3 px-4 text-xs text-muted-foreground flex justify-between items-center border-t border-border mt-auto">
         <span>💲{doc.basePrice}</span>
@@ -111,7 +111,7 @@ const MemoizedTopDocChip = React.memo(function TopDocChip({ doc, onSelect, disab
             className="category-card h-auto min-h-[50px] p-3 border-border shadow-sm hover:shadow-md transition text-center flex items-center justify-center gap-2 bg-card hover:bg-muted active:scale-95 active:transition-transform active:duration-100"
         >
             {doc.icon && React.createElement(doc.icon, { className: "h-4 w-4 text-primary/80" })}
-            <span className="font-medium text-card-foreground text-xs">{i18nLanguage === 'es' && doc.name_es ? t(doc.name_es, doc.name_es) : t(doc.name ?? '', doc.name)}</span>
+            <span className="font-medium text-card-foreground text-xs">{i18nLanguage === 'es' && doc.name_es ? t(doc.name_es, { defaultValue: doc.name_es }) : t(doc.name ?? '', { defaultValue: doc.name ?? '' })}</span>
         </Button>
     );
 });
@@ -126,6 +126,13 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
   globalSelectedState
 }: Step1DocumentSelectorProps) {
   const { t, i18n } = useTranslation("common");
+  const tSimple = React.useCallback(
+    (key: string, fallback?: string | object) =>
+      typeof fallback === 'string'
+        ? t(key, { defaultValue: fallback })
+        : t(key, fallback as any),
+    [t]
+  );
   // 'top-docs', 'all-categories', 'documents-in-category', 'search-results'
   const [currentView, setCurrentView] = useState<'top-docs' | 'all-categories' | 'documents-in-category' | 'search-results'>(
     initialSelectedCategory ? 'documents-in-category' : 'top-docs'
@@ -188,24 +195,24 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
     if (currentView === 'search-results' && globalSearchTerm.trim() !== '') {
       const lowerGlobalSearch = globalSearchTerm.toLowerCase();
       docs = docs.filter(doc =>
-        (t(doc.name ?? '', doc.name)).toLowerCase().includes(lowerGlobalSearch) ||
+        (t(doc.name ?? '', { defaultValue: doc.name ?? '' })).toLowerCase().includes(lowerGlobalSearch) ||
         (doc.aliases?.some(alias => alias.toLowerCase().includes(lowerGlobalSearch))) ||
         (languageSupportsSpanish(doc.languageSupport) && doc.aliases_es?.some(alias => alias.toLowerCase().includes(lowerGlobalSearch))) ||
-        (languageSupportsSpanish(doc.languageSupport) && doc.name_es && t(doc.name_es, doc.name_es).toLowerCase().includes(lowerGlobalSearch)) ||
-        (t(doc.description ?? '', doc.description)).toLowerCase().includes(lowerGlobalSearch) ||
-        (languageSupportsSpanish(doc.languageSupport) && doc.description_es && t(doc.description_es, doc.description_es).toLowerCase().includes(lowerGlobalSearch))
+        (languageSupportsSpanish(doc.languageSupport) && doc.name_es && t(doc.name_es, { defaultValue: doc.name_es }).toLowerCase().includes(lowerGlobalSearch)) ||
+        (t(doc.description ?? '', { defaultValue: doc.description ?? '' })).toLowerCase().includes(lowerGlobalSearch) ||
+        (languageSupportsSpanish(doc.languageSupport) && doc.description_es && t(doc.description_es, { defaultValue: doc.description_es }).toLowerCase().includes(lowerGlobalSearch))
       );
     } else if (currentView === 'documents-in-category' && selectedCategoryInternal) {
         docs = docs.filter(doc => doc.category === selectedCategoryInternal);
         if (docSearch.trim() !== '') {
             const lowerDocSearch = docSearch.toLowerCase();
             docs = docs.filter(doc =>
-                (t(doc.name ?? '', doc.name)).toLowerCase().includes(lowerDocSearch) ||
+                (t(doc.name ?? '', { defaultValue: doc.name ?? '' })).toLowerCase().includes(lowerDocSearch) ||
                 (doc.aliases?.some(alias => alias.toLowerCase().includes(lowerDocSearch))) ||
                 (languageSupportsSpanish(doc.languageSupport) && doc.aliases_es?.some(alias => alias.toLowerCase().includes(lowerDocSearch))) ||
-                (languageSupportsSpanish(doc.languageSupport) && doc.name_es && t(doc.name_es, doc.name_es).toLowerCase().includes(lowerDocSearch)) ||
-                (t(doc.description ?? '', doc.description)).toLowerCase().includes(lowerDocSearch) ||
-                (languageSupportsSpanish(doc.languageSupport) && doc.description_es && t(doc.description_es, doc.description_es).toLowerCase().includes(lowerDocSearch))
+                (languageSupportsSpanish(doc.languageSupport) && doc.name_es && t(doc.name_es, { defaultValue: doc.name_es }).toLowerCase().includes(lowerDocSearch)) ||
+                (t(doc.description ?? '', { defaultValue: doc.description ?? '' })).toLowerCase().includes(lowerDocSearch) ||
+                (languageSupportsSpanish(doc.languageSupport) && doc.description_es && t(doc.description_es, { defaultValue: doc.description_es }).toLowerCase().includes(lowerDocSearch))
             );
         }
     } else {
@@ -361,7 +368,7 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
                                       doc={doc}
                                       onSelect={() => handleDocSelect(doc)}
                                       disabled={isReadOnly || !isHydrated}
-                                      t={t}
+                                      t={tSimple}
                                       i18nLanguage={i18n.language}
                                       placeholderNoDescription={placeholderNoDescription}
                                       placeholderRequiresNotarization={placeholderRequiresNotarization}
@@ -386,7 +393,7 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
                               doc={doc}
                               onSelect={() => handleDocSelect(doc)}
                               disabled={isReadOnly || !isHydrated}
-                              t={t}
+                              t={tSimple}
                               i18nLanguage={i18n.language}
                           />
                       ))}
@@ -405,7 +412,7 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
                                     category={cat}
                                     onClick={() => handleCategoryClick(cat.key)}
                                     disabled={isReadOnly || !isHydrated}
-                                    t={t}
+                                    t={tSimple}
                                />
                            ))}
                        </div>
@@ -437,7 +444,7 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
                                     doc={doc}
                                     onSelect={() => handleDocSelect(doc)}
                                     disabled={isReadOnly || !isHydrated}
-                                    t={t}
+                                    t={tSimple}
                                     i18nLanguage={i18n.language}
                                     placeholderNoDescription={placeholderNoDescription}
                                     placeholderRequiresNotarization={placeholderRequiresNotarization}

--- a/src/components/StepThreeInput.tsx
+++ b/src/components/StepThreeInput.tsx
@@ -28,12 +28,12 @@ export function StepThreeInput({ templateId }: Props) {
     setIsReviewing(true);
     try {
       // Call the corrected function name
-      const response = await analyzeFormData({ 
+      const response = await analyzeFormData({
         documentType: template.name || '',
-        // schema: template.questions || [], // Pass the schema if your analyzeFormData expects it
+        schema: template.questions || [],
         answers: formData,
-        // state: stateCode, // Pass state if analyzeFormData expects it
-        // language: 'en', // Pass language if analyzeFormData expects it
+        // state: stateCode,
+        // language: 'en',
       });
       // Assuming analyzeFormData returns an array of suggestions/issues objects
       // Adjust this based on the actual return type of analyzeFormData

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -22,7 +22,7 @@ const staticTopDocIds: string[] = [
 const TopDocsChips = React.memo(function TopDocsChips() {
   // Use 'common' namespace for shared UI text
   const { t: tCommon } = useTranslation("common");
-  const params = useParams<{ locale?: string }>();
+  const params = (useParams<{ locale?: string }>() ?? {}) as { locale?: string };
   const router = useRouter();
   const locale = (params.locale as 'en' | 'es') || 'en';
   

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -320,9 +320,8 @@ export default function WizardForm({
                   )?.required
                 }
                 error={
-                  errors[
-                    currentField.id as keyof z.infer<typeof doc.schema>
-                  ]?.message as string | undefined
+                  (errors as Record<string, { message?: string }>)?.[currentField.id]?.message as
+                    string | undefined
                 }
                 placeholder={t("Enter address...")}
                 value={rhfValue || ""}

--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -70,7 +70,9 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
         return (
           <>
             <ul className="list-disc list-outside pl-5 space-y-1 text-muted-foreground">
-              {items.map((item: string, i: number) => <li key={i}>{item}</li>)}
+              {items.map((item, i) => (
+                <li key={i}>{String(item)}</li>
+              ))}
             </ul>
             {lastParagraph && <p className="text-muted-foreground mt-2">{lastParagraph}</p>}
           </>

--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -133,6 +133,13 @@ const MemoizedTestimonialCard = React.memo(function TestimonialCard({ testimonia
 
 const TrustAndTestimonialsSection = React.memo(function TrustAndTestimonialsSection() {
   const { t, i18n, ready } = useTranslation("common");
+  const tSimple = React.useCallback(
+    (key: string, fallback?: string | object) =>
+      typeof fallback === 'string'
+        ? t(key, { defaultValue: fallback })
+        : t(key, fallback as any),
+    [t]
+  );
   const [docCount, setDocCount] = useState(4200);
   const [isHydrated, setIsHydrated] = useState(false);
   const [testimonialsData, setTestimonialsData] = useState<Testimonial[]>([]);
@@ -201,7 +208,14 @@ const TrustAndTestimonialsSection = React.memo(function TrustAndTestimonialsSect
         <div className="flex flex-col sm:flex-row flex-wrap justify-center items-center gap-x-6 gap-y-3 text-foreground/90 text-sm font-medium">
           <div className="flex items-center gap-2">
             <FileText className="h-5 w-5 text-primary" />
-            <span>{isHydrated ? t('home.trustStrip.badge1', { count: formattedCount, defaultValue: `Over ${formattedCount} documents generated` }) : placeholderText}</span>
+            <span>
+              {isHydrated
+                ? (t('home.trustStrip.badge1', {
+                    count: formattedCount,
+                    defaultValue: `Over ${formattedCount} documents generated`,
+                  }) as string)
+                : placeholderText}
+            </span>
           </div>
           <div className="hidden sm:block w-px h-4 bg-border"></div>
           <div className="flex items-center gap-2">
@@ -238,7 +252,7 @@ const TrustAndTestimonialsSection = React.memo(function TrustAndTestimonialsSect
                 <MemoizedTestimonialCard
                   testimonial={testimonial}
                   index={i}
-                  t={t}
+                  t={tSimple}
                   isHydrated={isHydrated}
                 />
               </div>

--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -38,6 +38,13 @@ const MemoizedDocLink = React.memo(function DocLink({ doc, locale, onClick, t }:
 
 export default function MegaMenuContent({ categories, documents, onLinkClick }: MegaMenuContentProps) {
   const { t, i18n } = useTranslation("common");
+  const tSimple = React.useCallback(
+    (key: string, fallback?: string | object) =>
+      typeof fallback === 'string'
+        ? t(key, { defaultValue: fallback })
+        : t(key, fallback as any),
+    [t]
+  );
   const currentLocale = i18n.language as 'en' | 'es';
 
   const getDocumentsForCategory = (categoryKey: string) => {
@@ -69,7 +76,7 @@ export default function MegaMenuContent({ categories, documents, onLinkClick }: 
                         doc={doc}
                         locale={currentLocale}
                         onClick={onLinkClick}
-                        t={t}
+                        t={tSimple}
                       />
                     ))}
                     {categoryDocs.length > MAX_DOCS_PER_CATEGORY_INITIAL && (

--- a/src/components/motion/SlideFade.tsx
+++ b/src/components/motion/SlideFade.tsx
@@ -1,11 +1,10 @@
 
 "use client";
 
-import { motion } from "framer-motion";
+import { motion, type HTMLMotionProps } from "framer-motion";
 import React from "react";
 
-interface SlideFadeProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+interface SlideFadeProps extends HTMLMotionProps<"div"> {
   children: React.ReactNode;
   delay?: number;
 }

--- a/src/components/pdf-preview.tsx
+++ b/src/components/pdf-preview.tsx
@@ -49,8 +49,7 @@ const PdfPreview = React.memo(function PdfPreview({ documentDataUrl, documentNam
     }
 
     try {
-      const options = { signer: "User", reason: "Agreed to terms" }; 
-      const result = await signPdfDocument(dummyPdfData, options);
+      const result = await signPdfDocument(dummyPdfData, { fileName: documentName });
       setSignatureResult(result);
 
       if (result.success) {

--- a/src/components/questionnaire.tsx
+++ b/src/components/questionnaire.tsx
@@ -231,7 +231,7 @@ export function Questionnaire({ documentType, selectedState, onAnswersSubmit, is
                {q.type === 'textarea' ? (
                    <Textarea
                        id={q.id}
-                       value={answers[q.id] || ''}
+                       value={String(answers[q.id] ?? '')}
                        onChange={(e) => handleInputChange(q.id, e.target.value)}
                        required={q.required}
                        readOnly={!isEditing[q.id] || isReadOnly || isLoading}
@@ -242,7 +242,7 @@ export function Questionnaire({ documentType, selectedState, onAnswersSubmit, is
                    />
                ) : q.type === 'select' && q.options ? (
                    <Select
-                       value={answers[q.id] || ''}
+                       value={String(answers[q.id] ?? '')}
                        onValueChange={(value) => handleInputChange(q.id, value)}
                        disabled={!isEditing[q.id] || isReadOnly || isLoading}
                        required={q.required}
@@ -268,7 +268,7 @@ export function Questionnaire({ documentType, selectedState, onAnswersSubmit, is
                    <Input
                        id={q.id}
                        type={q.type === 'number' ? 'number' : q.type === 'date' ? 'date' : 'text'}
-                       value={answers[q.id] || ''}
+                       value={String(answers[q.id] ?? '')}
                        onChange={(e) => handleInputChange(q.id, e.target.value)}
                        required={q.required}
                        readOnly={!isEditing[q.id] || isReadOnly || isLoading}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -30,7 +30,7 @@ interface AuthContextType {
   isLoading: boolean;
   login: (email: string, uid?: string) => void; // email is now required for login
   logout: () => void;
-  updateUser: (updates: Partial<User>) => void;
+  updateUser: (updates: Partial<User> & { password?: string }) => void;
 }
 
 // 2) Create the context (default undefined to catch mis-use)
@@ -95,7 +95,7 @@ function useAuthHook(): AuthContextType {
     setUser(null);
   }, []);
 
-  const updateUser = useCallback((updates: Partial<User>) => {
+  const updateUser = useCallback((updates: Partial<User> & { password?: string }) => {
     setUser(prevUser => {
       if (!prevUser) return null; // Should not happen if logged in
       const updatedUser = { ...prevUser, ...updates };

--- a/src/lib/document-library.ts
+++ b/src/lib/document-library.ts
@@ -1,7 +1,7 @@
 // src/lib/document-library.ts
 import { z } from 'zod';
 import { documentLibraryAdditions } from './document-library-additions';
-import type { LegalDocument } from '@/types/documents'
+import type { LegalDocument, LocalizedText } from '@/types/documents'
 import * as us_docs_barrel from './documents/us';
 import * as ca_docs_barrel from './documents/ca';
 // …other countries…
@@ -14,13 +14,14 @@ const isValidDocument = (doc: unknown): doc is LegalDocument => {
 
   // Check for English translation name as the primary indicator of a valid name structure
   // OR fallback to top-level name if translations are not yet populated by the forEach loop
-  const hasValidTranslationsOrName = doc &&
-                                   ( (doc.translations &&
-                                      doc.translations.en &&
-                                      typeof doc.translations.en.name === 'string' &&
-                                      doc.translations.en.name.trim() !== '') ||
-                                     (typeof doc.name === 'string' && doc.name.trim() !== '')
-                                   );
+  const dAny = doc as any;
+  const hasValidTranslationsOrName =
+    dAny &&
+    ((dAny.translations &&
+      dAny.translations.en &&
+      typeof dAny.translations.en.name === 'string' &&
+      dAny.translations.en.name.trim() !== '') ||
+      (typeof dAny.name === 'string' && dAny.name.trim() !== ''));
 
   return hasId && hasCategory && hasSchema && hasValidTranslationsOrName;
 };
@@ -78,7 +79,7 @@ allDocuments.forEach(doc => {
   }
 
   // Ensure translations object and its properties exist, and populate from top-level if necessary
-  const baseTranslations = doc.translations || { en: {}, es: {} };
+  const baseTranslations: { en?: LocalizedText; es?: LocalizedText } = doc.translations || {};
   doc.translations = {
     en: {
       name: baseTranslations.en?.name || doc.name || doc.id,


### PR DESCRIPTION
## Summary
- fix nullable searchParams and useParams
- support password updates in useAuth
- adjust translation helper usage in Step1DocumentSelector
- add simple translation wrappers for other components
- pass required schema to analyzeFormData
- clean up PDF signing options
- fix typing in WizardForm and Questionnaire
- update SlideFade motion props
- correct document library type checks

## Testing
- `npm run typecheck` *(fails: Cannot find module type declarations)*