### PR TITLE
Fix TypeScript type errors

### DIFF
--- a/src/ai/flows/infer-document-type.ts
+++ b/src/ai/flows/infer-document-type.ts
@@ -7,7 +7,6 @@
 
 import { ai } from '@/ai/ai-instance';
 import { z } from 'genkit';
-import type { GenerateResponseData } from 'genkit';
 import { documentLibrary } from '@/lib/document-library';
 
 // Input Schema
@@ -111,12 +110,12 @@ async (input) => {
   const ctx = getAvailableDocumentsContext();
 
   try {
-    const response: GenerateResponseData = await prompt({
+    const response = await prompt({
       ...parsed.data,
       // Extra context isn't part of the input schema
       availableDocumentsContext: ctx,
     } as any);
-    const output = response.output as InferDocumentTypeOutput;
+    const output = (response as any).output as InferDocumentTypeOutput;
 
     if (!output) throw new Error('AI returned no output');
 

--- a/src/app/[locale]/api/wizard/[docId]/submit/route.ts
+++ b/src/app/[locale]/api/wizard/[docId]/submit/route.ts
@@ -117,8 +117,14 @@ export async function POST(
 
     let session;
     try {
-      const documentDisplayName = docConfig.name_es && effectiveLocale === 'es' ? docConfig.name_es : docConfig.name;
-      const documentDisplayDescription = docConfig.description_es && effectiveLocale === 'es' ? docConfig.description_es : docConfig.description;
+      const documentDisplayName =
+        docConfig.name_es && effectiveLocale === 'es'
+          ? docConfig.name_es
+          : docConfig.name || docConfig.id;
+      const documentDisplayDescription =
+        docConfig.description_es && effectiveLocale === 'es'
+          ? docConfig.description_es
+          : docConfig.description || '';
 
       const sessionParams: Stripe.Checkout.SessionCreateParams = {
         mode: 'payment',

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,13 +1,15 @@
 // src/app/[locale]/blog/page.tsx
 import React from 'react';
 import BlogClientContent from './blog-client-content';
-import type { PageProps } from 'next';
+interface BlogPageProps {
+  params: { locale: 'en' | 'es' };
+}
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
 }
 
-export default function BlogPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
+export default function BlogPage({ params }: BlogPageProps) {
   const { locale } = params;
   return <BlogClientContent locale={locale} />;
 }

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -6,7 +6,9 @@ import path from 'node:path';
 import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
-import type { PageProps } from 'next';
+interface DocPageProps {
+  params: { locale: string; docId: string };
+}
 
 // Revalidate this page every hour for fresh content while caching aggressively
 export const revalidate = 3600;
@@ -38,13 +40,8 @@ export async function generateStaticParams() {
   return params;
 }
 
-interface DocParams {
-  locale: string;
-  docId: string;
-}
-
 // This Server Component now correctly passes params to the Client Component
-export default async function DocPage({ params }: PageProps<DocParams>) {
+export default async function DocPage({ params }: DocPageProps) {
   // Await a microtask to comply with Next.js dynamic param handling
   await Promise.resolve();
 

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -4,7 +4,9 @@
 import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
-import type { PageProps } from 'next';
+interface StartWizardPageProps {
+  params: { locale: 'en' | 'es'; docId: string };
+}
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly
 export const revalidate = 3600;
@@ -70,13 +72,8 @@ export async function generateStaticParams() {
   return params;
 }
 
-interface StartWizardParams {
-  locale: 'en' | 'es';
-  docId: string;
-}
-
 // This Server Component now correctly passes params to the Client Component
-export default async function StartWizardPage({ params }: PageProps<StartWizardParams>) {
+export default async function StartWizardPage({ params }: StartWizardPageProps) {
   // Await a microtask to satisfy Next.js dynamic route requirements
   await Promise.resolve();
   // The StartWizardPageClient will handle fetching its own specific document data

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -1,13 +1,15 @@
 // src/app/[locale]/faq/page.tsx
 import React from 'react';
 import FaqClientContent from './faq-client-content';
-import type { PageProps } from 'next';
+interface FaqPageProps {
+  params: { locale: 'en' | 'es' };
+}
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
 }
 
-export default function FAQPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
+export default function FAQPage({ params }: FaqPageProps) {
   const { locale } = params;
   return <FaqClientContent locale={locale} />;
 }

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -1,14 +1,16 @@
 // src/app/[locale]/pricing/page.tsx
 import React from 'react';
 import PricingClientContent from './pricing-client-content';
-import type { PageProps } from 'next';
+interface PricingPageProps {
+  params: { locale: 'en' | 'es' };
+}
 
 // Add generateStaticParams for dynamic routes with static export
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
 }
 
-export default function PricingPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
+export default function PricingPage({ params }: PricingPageProps) {
   const { locale } = params;
   // The rest of the page content including client-side hooks and logic
   // is now in PricingClientContent.tsx

--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -1,7 +1,11 @@
 // src/app/[locale]/signwell/page.tsx
 import React from 'react';
 import SignWellClientContent from './signwell-client-content';
-import type { Metadata, PageProps } from 'next';
+import type { Metadata } from 'next';
+
+interface SignWellPageProps {
+  params: { locale: 'en' | 'es' };
+}
 import i18n from '@/lib/i18n'; // Import i18n instance to access translations server-side for metadata
 
 export async function generateStaticParams() {
@@ -30,6 +34,6 @@ export async function generateMetadata({ params }: { params: { locale: 'en' | 'e
 }
 
 
-export default function SignWellPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
+export default function SignWellPage({ params }: SignWellPageProps) {
   return <SignWellClientContent params={params} />;
 }

--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -368,8 +368,8 @@ export default function SignWellClientContent({ params }: SignWellClientContentP
               selectedFile={selectedFile}
               onClearFile={handleClearFile}
               isHydrated={isHydrated}
-              tGeneral={(key, opts) => t(key, { ...(opts ?? {}), ns: 'common' })}
-              tEsign={(key, opts) => t(key, { ...(opts ?? {}), ns: 'electronic-signature' })}
+              tGeneral={(key, opts) => t(key, { ...(opts ?? {}), ns: 'common' }) as string}
+              tEsign={(key, opts) => t(key, { ...(opts ?? {}), ns: 'electronic-signature' }) as string}
               onClick={handleHeroUploadAttempt} // Gated file input trigger
             />
             {!selectedFile && (

--- a/src/app/[locale]/support/page.tsx
+++ b/src/app/[locale]/support/page.tsx
@@ -1,13 +1,15 @@
 // src/app/[locale]/support/page.tsx
 import React from 'react';
 import SupportClientContent from './support-client-content';
-import type { PageProps } from 'next';
+interface SupportPageProps {
+  params: { locale: 'en' | 'es' };
+}
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
 }
 
-export default function SupportPage({ params }: PageProps<{ locale: 'en' | 'es' }>) {
+export default function SupportPage({ params }: SupportPageProps) {
   const { locale } = params;
   return <SupportClientContent locale={locale} />;
 }

--- a/src/components/DocumentTypeSelector.tsx
+++ b/src/components/DocumentTypeSelector.tsx
@@ -96,7 +96,7 @@ export default function DocumentTypeSelector({ onSelect, selectedDocument }: Pro
                       key={doc.id}
                       tabIndex={0}
                       role="button"
-                      aria-label={t(doc.name ?? '', doc.name)}
+                      aria-label={t(doc.name ?? '', doc.name ?? '')}
                       className={`cursor-pointer hover:shadow-lg transition-all duration-200 ${selectedDocument === doc.id ? 'border-2 border-primary' : ''}`}
                       onClick={() => onSelect(doc.id)}
                       onKeyDown={(e) => {

--- a/src/components/Step1DocumentSelector.tsx
+++ b/src/components/Step1DocumentSelector.tsx
@@ -127,10 +127,10 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
 }: Step1DocumentSelectorProps) {
   const { t, i18n } = useTranslation("common");
   const tSimple = React.useCallback(
-    (key: string, fallback?: string | object) =>
+    (key: string, fallback?: string | object): string =>
       typeof fallback === 'string'
-        ? t(key, { defaultValue: fallback })
-        : t(key, fallback as any),
+        ? (t(key, { defaultValue: fallback }) as string)
+        : (t(key, fallback as any) as string),
     [t]
   );
   // 'top-docs', 'all-categories', 'documents-in-category', 'search-results'

--- a/src/components/StepThreeInput.tsx
+++ b/src/components/StepThreeInput.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import { documentLibrary } from '@/lib/document-library';
 import { analyzeFormData } from '@/ai/flows/analyze-form-data'; // Corrected import
+import type { FormField } from '@/data/formSchemas';
 
 interface Props {
   templateId: string;
@@ -30,7 +31,7 @@ export function StepThreeInput({ templateId }: Props) {
       // Call the corrected function name
       const response = await analyzeFormData({
         documentType: template.name || '',
-        schema: template.questions || [],
+        schema: (template.questions as unknown as FormField[]) || [],
         answers: formData,
         // state: stateCode,
         // language: 'en',

--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -142,7 +142,7 @@ export default function PromissoryNoteDisplay({ locale }: PromissoryNoteDisplayP
       );
     }
      if (section.type === 'list-cta' && section.itemsKey && section.ctaKey) {
-      const items = t(section.itemsKey, { returnObjects: true });
+      const items = t(section.itemsKey, { returnObjects: true }) as string[];
       if (Array.isArray(items)) {
         return (
           <>

--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -134,10 +134,10 @@ const MemoizedTestimonialCard = React.memo(function TestimonialCard({ testimonia
 const TrustAndTestimonialsSection = React.memo(function TrustAndTestimonialsSection() {
   const { t, i18n, ready } = useTranslation("common");
   const tSimple = React.useCallback(
-    (key: string, fallback?: string | object) =>
+    (key: string, fallback?: string | object): string =>
       typeof fallback === 'string'
-        ? t(key, { defaultValue: fallback })
-        : t(key, fallback as any),
+        ? (t(key, { defaultValue: fallback }) as string)
+        : (t(key, fallback as any) as string),
     [t]
   );
   const [docCount, setDocCount] = useState(4200);
@@ -210,10 +210,10 @@ const TrustAndTestimonialsSection = React.memo(function TrustAndTestimonialsSect
             <FileText className="h-5 w-5 text-primary" />
             <span>
               {isHydrated
-                ? (t('home.trustStrip.badge1', {
+                ? tSimple('home.trustStrip.badge1', {
                     count: formattedCount,
                     defaultValue: `Over ${formattedCount} documents generated`,
-                  }) as string)
+                  })
                 : placeholderText}
             </span>
           </div>

--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -39,10 +39,10 @@ const MemoizedDocLink = React.memo(function DocLink({ doc, locale, onClick, t }:
 export default function MegaMenuContent({ categories, documents, onLinkClick }: MegaMenuContentProps) {
   const { t, i18n } = useTranslation("common");
   const tSimple = React.useCallback(
-    (key: string, fallback?: string | object) =>
+    (key: string, fallback?: string | object): string =>
       typeof fallback === 'string'
-        ? t(key, { defaultValue: fallback })
-        : t(key, fallback as any),
+        ? (t(key, { defaultValue: fallback }) as string)
+        : (t(key, fallback as any) as string),
     [t]
   );
   const currentLocale = i18n.language as 'en' | 'es';

--- a/src/data/formSchemas.ts
+++ b/src/data/formSchemas.ts
@@ -6,7 +6,7 @@ export type FormField = {
   label: string
   placeholder?: string
   required?: boolean
-  type: 'text' | 'select' | 'date' | 'number' | 'textarea' | 'boolean' | 'address'
+  type: 'text' | 'select' | 'date' | 'number' | 'textarea' | 'boolean' | 'address' | 'tel'
   options?: { value: string; label: string }[]
   tooltip?: string
   helperText?: string


### PR DESCRIPTION
## Summary
- fix type annotations in server pages
- correct wizard submit info and AI flow typing
- refine translation helpers to return strings
- align `FormField` type with Question type
- clean up component translation calls

## Testing
- `npm run typecheck` *(fails: Cannot find module '@types/node', etc.)*