### PR TITLE
Fix tsconfig to include Node types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "baseUrl": ".",
+    "types": [
+      "node"
+    ],
     "paths": {
       "@/*": [
         "src/*"


### PR DESCRIPTION
## Summary
- include `@types/node` definitions in the TypeScript config

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
