### PR TITLE
Fix typecheck issues

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import BlogClientContent from './blog-client-content';
 interface BlogPageProps {
-  params: { locale: 'en' | 'es' };
+  params: { locale: 'en' | 'es' } & Record<string, string>;
 }
 
 export async function generateStaticParams() {

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -7,7 +7,7 @@ import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
 interface DocPageProps {
-  params: { locale: string; docId: string };
+  params: { locale: string; docId: string } & Record<string, string>;
 }
 
 // Revalidate this page every hour for fresh content while caching aggressively

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -5,7 +5,7 @@ import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
 interface StartWizardPageProps {
-  params: { locale: 'en' | 'es'; docId: string };
+  params: { locale: 'en' | 'es'; docId: string } & Record<string, string>;
 }
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import FaqClientContent from './faq-client-content';
 interface FaqPageProps {
-  params: { locale: 'en' | 'es' };
+  params: { locale: 'en' | 'es' } & Record<string, string>;
 }
 
 export async function generateStaticParams() {

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PricingClientContent from './pricing-client-content';
 interface PricingPageProps {
-  params: { locale: 'en' | 'es' };
+  params: { locale: 'en' | 'es' } & Record<string, string>;
 }
 
 // Add generateStaticParams for dynamic routes with static export

--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -4,7 +4,7 @@ import SignWellClientContent from './signwell-client-content';
 import type { Metadata } from 'next';
 
 interface SignWellPageProps {
-  params: { locale: 'en' | 'es' };
+  params: { locale: 'en' | 'es' } & Record<string, string>;
 }
 import i18n from '@/lib/i18n'; // Import i18n instance to access translations server-side for metadata
 

--- a/src/app/[locale]/support/page.tsx
+++ b/src/app/[locale]/support/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import SupportClientContent from './support-client-content';
 interface SupportPageProps {
-  params: { locale: 'en' | 'es' };
+  params: { locale: 'en' | 'es' } & Record<string, string>;
 }
 
 export async function generateStaticParams() {

--- a/src/components/AddressField.tsx
+++ b/src/components/AddressField.tsx
@@ -97,7 +97,7 @@ const AddressField = React.memo(function AddressField({
           'postal_code', 'postal_code_suffix', 'country'
         ]);
         const parts: Record<string, string> = {};
-        place.address_components?.forEach(c => {
+        place.address_components?.forEach((c: any) => {
           const type = c.types[0];
           if (wanted.has(type)) parts[type] = c.short_name;
         });

--- a/src/types/google.maps.d.ts
+++ b/src/types/google.maps.d.ts
@@ -1,0 +1,15 @@
+declare global {
+  namespace google.maps.places {
+    interface AutocompleteOptions {
+      types?: string[];
+      fields?: string[];
+      componentRestrictions?: Record<string, unknown>;
+    }
+    class Autocomplete {
+      constructor(input: HTMLInputElement, opts?: AutocompleteOptions);
+      getPlace(): any;
+      addListener(event: string, handler: () => void): void;
+    }
+  }
+}
+export {};


### PR DESCRIPTION
## Summary
- extend page prop types with a string index
- declare minimal typings for Google Maps
- fix `AddressField` autocomplete handler parameter type

## Testing
- `npm install --ignore-scripts` *(fails: ENOTFOUND)*