### PR TITLE
Fix PageProps typing for Next.js

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,9 +1,9 @@
 // src/app/[locale]/blog/page.tsx
 import React from 'react';
+import type { PageProps } from 'next';
 import BlogClientContent from './blog-client-content';
-interface BlogPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
-}
+
+type BlogPageProps = PageProps<{ locale: 'en' | 'es' }>;
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -6,9 +6,9 @@ import path from 'node:path';
 import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
-interface DocPageProps {
-  params: { locale: string; docId: string } & Record<string, string>;
-}
+import type { PageProps } from 'next';
+
+type DocPageProps = PageProps<{ locale: string; docId: string }>;
 
 // Revalidate this page every hour for fresh content while caching aggressively
 export const revalidate = 3600;

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -4,9 +4,9 @@
 import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
-interface StartWizardPageProps {
-  params: { locale: 'en' | 'es'; docId: string } & Record<string, string>;
-}
+import type { PageProps } from 'next';
+
+type StartWizardPageProps = PageProps<{ locale: 'en' | 'es'; docId: string }>;
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly
 export const revalidate = 3600;


### PR DESCRIPTION
## Summary
- use `PageProps` from Next.js for blog page
- use `PageProps` from Next.js for docs pages

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test`