### PR TITLE
Fix Next page prop types

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import BlogClientContent from './blog-client-content';
 interface BlogPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 
 export async function generateStaticParams() {

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -7,7 +7,7 @@ import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
 interface DocPageProps {
-  params: { locale: string; docId: string } & Record<string, string>;
+  params: { locale: string; docId: string };
 }
 
 // Revalidate this page every hour for fresh content while caching aggressively

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -5,7 +5,7 @@ import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
 interface StartWizardPageProps {
-  params: { locale: 'en' | 'es'; docId: string } & Record<string, string>;
+  params: { locale: 'en' | 'es'; docId: string };
 }
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import FaqClientContent from './faq-client-content';
 interface FaqPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 
 export async function generateStaticParams() {

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PricingClientContent from './pricing-client-content';
 interface PricingPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 
 // Add generateStaticParams for dynamic routes with static export

--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -4,7 +4,7 @@ import SignWellClientContent from './signwell-client-content';
 import type { Metadata } from 'next';
 
 interface SignWellPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 import i18n from '@/lib/i18n'; // Import i18n instance to access translations server-side for metadata
 

--- a/src/app/[locale]/support/page.tsx
+++ b/src/app/[locale]/support/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import SupportClientContent from './support-client-content';
 interface SupportPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 
 export async function generateStaticParams() {


### PR DESCRIPTION
## Summary
- simplify dynamic route page prop definitions

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
