### PR TITLE
Fix typed page props

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,9 +1,10 @@
 // src/app/[locale]/blog/page.tsx
 import React from 'react';
-import type { PageProps } from 'next';
 import BlogClientContent from './blog-client-content';
 
-type BlogPageProps = PageProps<{ locale: 'en' | 'es' }>;
+interface BlogPageProps {
+  params: { locale: 'en' | 'es' };
+}
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -6,9 +6,9 @@ import path from 'node:path';
 import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
-import type { PageProps } from 'next';
-
-type DocPageProps = PageProps<{ locale: string; docId: string }>;
+interface DocPageProps {
+  params: { locale: string; docId: string };
+}
 
 // Revalidate this page every hour for fresh content while caching aggressively
 export const revalidate = 3600;

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -4,9 +4,9 @@
 import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
-import type { PageProps } from 'next';
-
-type StartWizardPageProps = PageProps<{ locale: 'en' | 'es'; docId: string }>;
+interface StartWizardPageProps {
+  params: { locale: 'en' | 'es'; docId: string };
+}
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly
 export const revalidate = 3600;

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import FaqClientContent from './faq-client-content';
 interface FaqPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 
 export async function generateStaticParams() {

--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PricingClientContent from './pricing-client-content';
 interface PricingPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 
 // Add generateStaticParams for dynamic routes with static export

--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -4,7 +4,7 @@ import SignWellClientContent from './signwell-client-content';
 import type { Metadata } from 'next';
 
 interface SignWellPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 import i18n from '@/lib/i18n'; // Import i18n instance to access translations server-side for metadata
 

--- a/src/app/[locale]/support/page.tsx
+++ b/src/app/[locale]/support/page.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import SupportClientContent from './support-client-content';
 interface SupportPageProps {
-  params: { locale: 'en' | 'es' } & Record<string, string>;
+  params: { locale: 'en' | 'es' };
 }
 
 export async function generateStaticParams() {


### PR DESCRIPTION
## Summary
- update typed props for FAQ, Pricing, Support and Signwell pages
- remove `PageProps` import from blog and docs pages
- define explicit interfaces for page params

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*