### PR TITLE
Fix type errors by defining page prop interfaces

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,9 +1,12 @@
 // src/app/[locale]/blog/page.tsx
 import React from 'react';
-import type { PageProps } from 'next';
 import BlogClientContent from './blog-client-content';
-
-type BlogPageProps = PageProps<{ locale: 'en' | 'es' }>;
+// Define the shape of params expected for this page
+interface BlogPageProps {
+  params: {
+    locale: 'en' | 'es';
+  };
+}
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -6,9 +6,13 @@ import path from 'node:path';
 import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
-import type { PageProps } from 'next';
-
-type DocPageProps = PageProps<{ locale: string; docId: string }>;
+// Define the shape of params expected for this page
+interface DocPageProps {
+  params: {
+    locale: string;
+    docId: string;
+  };
+}
 
 // Revalidate this page every hour for fresh content while caching aggressively
 export const revalidate = 3600;

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -4,9 +4,13 @@
 import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
-import type { PageProps } from 'next';
-
-type StartWizardPageProps = PageProps<{ locale: 'en' | 'es'; docId: string }>;
+// Define the shape of params expected for this page
+interface StartWizardPageProps {
+  params: {
+    locale: 'en' | 'es';
+    docId: string;
+  };
+}
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly
 export const revalidate = 3600;


### PR DESCRIPTION
## Summary
- define local page prop interfaces instead of importing `PageProps` from Next.js

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*