### PR TITLE
Fix lint errors

### DIFF
--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -36,7 +36,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { Label } from '@/components/ui/label';
-import type { z } from 'zod';
+import { z, type AnyZodObject } from 'zod';
 
 interface ReviewStepProps {
   doc: LegalDocument;
@@ -90,12 +90,12 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
     const schemaDef = doc?.schema?._def;
     if (!schemaDef) return undefined;
     if (schemaDef.typeName === 'ZodObject')
-      return (doc.schema as any).shape as Record<string, z.ZodTypeAny>;
+      return (doc.schema as unknown as AnyZodObject).shape as Record<string, z.ZodTypeAny>;
     if (
       schemaDef.typeName === 'ZodEffects' &&
       schemaDef.schema?._def?.typeName === 'ZodObject'
     ) {
-      return (schemaDef.schema as any).shape as Record<string, z.ZodTypeAny>;
+      return (schemaDef.schema as unknown as AnyZodObject).shape as Record<string, z.ZodTypeAny>;
     }
     return undefined;
   }, [doc.schema]);

--- a/src/pages/api/generate-pdf.ts
+++ b/src/pages/api/generate-pdf.ts
@@ -38,12 +38,10 @@ export default async function handler(
   if (req.method !== 'POST') {
     console.warn(`${logPrefix} Method Not Allowed: ${req.method}`);
     res.setHeader('Allow', ['POST']);
-    return res
-      .status(405)
-      .json({
-        error: `Method ${req.method} Not Allowed`,
-        code: 'METHOD_NOT_ALLOWED_PDF',
-      });
+    return res.status(405).json({
+      error: `Method ${req.method} Not Allowed`,
+      code: 'METHOD_NOT_ALLOWED_PDF',
+    });
   }
 
   try {

--- a/src/pages/api/infer-document-type.ts
+++ b/src/pages/api/infer-document-type.ts
@@ -37,12 +37,10 @@ export default async function handler(
   if (req.method !== 'POST') {
     console.warn(`${logPrefix} Method Not Allowed: ${req.method}`);
     res.setHeader('Allow', ['POST']);
-    return res
-      .status(405)
-      .json({
-        error: `Method ${req.method} Not Allowed`,
-        code: 'METHOD_NOT_ALLOWED_INFERENCE',
-      });
+    return res.status(405).json({
+      error: `Method ${req.method} Not Allowed`,
+      code: 'METHOD_NOT_ALLOWED_INFERENCE',
+    });
   }
 
   try {


### PR DESCRIPTION
## Summary
- fix lint warnings on ReviewStep by avoiding `any`
- fix Prettier lint for API routes

## Testing
- `npm run lint` *(fails: next not found)*