### PR TITLE
Fix lint errors in utilities

### DIFF
--- a/src/hooks/useSmartField.ts
+++ b/src/hooks/useSmartField.ts
@@ -7,6 +7,7 @@ import type {
   UseFormGetValues,
   FieldValues,
   Path,
+  FieldPathValue,
 } from 'react-hook-form';
 
 type HookProps<T extends FieldValues> = {
@@ -37,7 +38,7 @@ export const useSmartField = <T extends FieldValues>({
       const stringVal = String(currentVal);
       const sanitized = stringVal.replace(/\D/g, '').slice(0, 4);
       if (sanitized !== stringVal) {
-        setValue(name as Path<T>, sanitized as any, {
+        setValue(name as Path<T>, sanitized as unknown as FieldPathValue<T, Path<T>>, {
           shouldValidate: true,
           shouldDirty: true,
         });
@@ -52,7 +53,7 @@ export const useSmartField = <T extends FieldValues>({
       if (typeof currentVal !== 'string') return; // Only process if it's a string
       const sanitized = currentVal.replace(/[^a-zA-Z\s]/gi, '');
       if (sanitized !== currentVal) {
-        setValue(name as Path<T>, sanitized as any, {
+        setValue(name as Path<T>, sanitized as unknown as FieldPathValue<T, Path<T>>, {
           shouldValidate: true,
           shouldDirty: true,
         });
@@ -91,32 +92,44 @@ export const useSmartField = <T extends FieldValues>({
                 (formValues[makeField] === undefined ||
                   formValues[makeField] === '')
               ) {
-                setValue(makeField, result.Make as any, {
-                  shouldValidate: true,
-                  shouldDirty: true,
-                });
+                setValue(
+                  makeField,
+                  result.Make as unknown as FieldPathValue<T, typeof makeField>,
+                  {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  },
+                );
               }
               if (
                 result.Model &&
                 (formValues[modelField] === undefined ||
                   formValues[modelField] === '')
               ) {
-                setValue(modelField, result.Model as any, {
-                  shouldValidate: true,
-                  shouldDirty: true,
-                });
+                setValue(
+                  modelField,
+                  result.Model as unknown as FieldPathValue<T, typeof modelField>,
+                  {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  },
+                );
               }
               if (
                 result.ModelYear &&
                 (formValues[yearField] === undefined ||
                   formValues[yearField] === '' ||
                   formValues[yearField] === 0 ||
-                  isNaN(parseInt(formValues[yearField] as any)))
+                  isNaN(parseInt(String(formValues[yearField])))
               ) {
-                setValue(yearField, Number(result.ModelYear) as any, {
-                  shouldValidate: true,
-                  shouldDirty: true,
-                });
+                setValue(
+                  yearField,
+                  Number(result.ModelYear) as unknown as FieldPathValue<T, typeof yearField>,
+                  {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  },
+                );
               }
             }
           })

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,7 +1,7 @@
 /* super‑light wrapper – works with GA4, Plausible, FB Pixel, ... */
 declare global {
   interface Window {
-    gtag?: (...args: unknown[]) => void;
+    gtag?: (..._args: unknown[]) => void;
   }
 }
 

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,22 +1,26 @@
-export interface DebouncedFunction<T extends (...args: any[]) => void> {
-  (...args: Parameters<T>): void;
+export type AnyFn<Args extends unknown[] = unknown[]> = (
+  ...args: Args
+) => void;
+
+export interface DebouncedFunction<F extends AnyFn> {
+  (...args: Parameters<F>): void;
   cancel(): void;
 }
 
-export function debounce<T extends (...args: any[]) => void>(
-  fn: T,
+export function debounce<F extends AnyFn>(
+  fn: F,
   wait: number,
-): DebouncedFunction<T> {
+): DebouncedFunction<F> {
   let timer: ReturnType<typeof setTimeout> | null = null;
 
-  const debounced = ((...args: Parameters<T>) => {
+  const debounced = ((...args: Parameters<F>) => {
     if (timer !== null) {
       clearTimeout(timer);
     }
     timer = setTimeout(() => {
       fn(...args);
     }, wait);
-  }) as DebouncedFunction<T>;
+  }) as DebouncedFunction<F>;
 
   debounced.cancel = () => {
     if (timer !== null) {

--- a/src/lib/document-library.ts
+++ b/src/lib/document-library.ts
@@ -15,14 +15,17 @@ const isValidDocument = (doc: unknown): doc is LegalDocument => {
 
   // Check for English translation name as the primary indicator of a valid name structure
   // OR fallback to top-level name if translations are not yet populated by the forEach loop
-  const dAny = doc as any;
+  const dRecord = doc as {
+    translations?: { en?: { name?: string } };
+    name?: string;
+  };
   const hasValidTranslationsOrName =
-    dAny &&
-    ((dAny.translations &&
-      dAny.translations.en &&
-      typeof dAny.translations.en.name === 'string' &&
-      dAny.translations.en.name.trim() !== '') ||
-      (typeof dAny.name === 'string' && dAny.name.trim() !== ''));
+    dRecord &&
+    ((dRecord.translations &&
+      dRecord.translations.en &&
+      typeof dRecord.translations.en.name === 'string' &&
+      dRecord.translations.en.name.trim() !== '') ||
+      (typeof dRecord.name === 'string' && dRecord.name.trim() !== ''));
 
   return hasId && hasCategory && hasSchema && hasValidTranslationsOrName;
 };

--- a/src/types/google.maps.d.ts
+++ b/src/types/google.maps.d.ts
@@ -5,11 +5,11 @@ declare global {
       fields?: string[];
       componentRestrictions?: Record<string, unknown>;
     }
-    class Autocomplete {
-      constructor(input: HTMLInputElement, opts?: AutocompleteOptions);
-      getPlace(): any;
-      addListener(event: string, handler: () => void): void;
-    }
+      class Autocomplete {
+        constructor(_input: HTMLInputElement, _opts?: AutocompleteOptions);
+        getPlace(): unknown;
+        addListener(_event: string, _handler: () => void): void;
+      }
   }
 }
 export {};


### PR DESCRIPTION
## Summary
- improve generic typing for `debounce`
- remove `any` usage in document library validation
- add strong types in `useSmartField`
- tweak analytics window declaration
- refine google maps ambient type

## Testing
- `npm run lint` *(fails: `next` not found)*