### PR TITLE
Fix lint errors

### DIFF
--- a/src/ai/flows/infer-document-type.ts
+++ b/src/ai/flows/infer-document-type.ts
@@ -132,8 +132,8 @@ export const inferDocumentTypeFlow = ai.defineFlow<
         ...parsed.data,
         // Extra context isn't part of the input schema
         availableDocumentsContext: ctx,
-      } as any);
-      const output = (response as any).output as InferDocumentTypeOutput;
+      });
+      const output = response.output as InferDocumentTypeOutput;
 
       if (!output) throw new Error('AI returned no output');
 

--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -59,6 +59,11 @@ const StickyFilterBar = dynamic(() => import('@/components/StickyFilterBar'), {
   loading: () => <div className="h-16 bg-muted" />, // Placeholder for filter bar height
 });
 
+interface PreloadableModule {
+  default?: { preload?: () => void };
+  GuaranteeBadge?: { preload?: () => void };
+}
+
 export default function HomePageClient() {
   const { t } = useTranslation('common');
   const { toast } = useToast();
@@ -84,22 +89,22 @@ export default function HomePageClient() {
   // Preload dynamically imported sections once on the client
   useEffect(() => {
     // Use dynamic import to get the module and then call preload if available
-    import('@/components/landing/HowItWorks').then((mod: any) => {
+    import('@/components/landing/HowItWorks').then((mod: PreloadableModule) => {
       mod.default?.preload?.();
     });
     import('@/components/landing/TrustAndTestimonialsSection').then(
-      (mod: any) => {
+      (mod: PreloadableModule) => {
         mod.default?.preload?.();
       },
     );
-    import('@/components/landing/GuaranteeBadge').then((mod: any) => {
+    import('@/components/landing/GuaranteeBadge').then((mod: PreloadableModule) => {
       mod.GuaranteeBadge?.preload?.();
       mod.default?.preload?.(); // fallback for default export
     });
-    import('@/components/TopDocsChips').then((mod: any) => {
+    import('@/components/TopDocsChips').then((mod: PreloadableModule) => {
       mod.default?.preload?.();
     });
-    import('@/components/StickyFilterBar').then((mod: any) => {
+    import('@/components/StickyFilterBar').then((mod: PreloadableModule) => {
       mod.default?.preload?.();
     });
   }, []);

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -25,21 +25,7 @@ interface FirestoreTimestamp {
   toDate: () => Date;
 }
 
-interface DocumentData {
-  id: string;
-  name: string;
-  date: FirestoreTimestamp | Date | string;
-  status: string;
-  docType?: string; // Used for linking to the correct document type if different from ID
-}
 
-interface PaymentData {
-  id: string;
-  date: FirestoreTimestamp | Date | string;
-  amount: string;
-  documentName: string;
-  documentId?: string;
-}
 
 interface DashboardClientContentProps {
   locale: 'en' | 'es';

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -103,9 +103,7 @@ export async function generateStaticParams() {
 }
 
 // This Server Component now correctly passes params to the Client Component
-export default async function StartWizardPage({
-  params,
-}: StartWizardPageProps) {
+export default async function StartWizardPage({}: StartWizardPageProps) {
   // Await a microtask to satisfy Next.js dynamic route requirements
   await Promise.resolve();
   // The StartWizardPageClient will handle fetching its own specific document data

--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -57,13 +57,13 @@ const DropzonePlaceholder = ({
   tEsign,
   onClick, // Add onClick prop
 }: {
-  onFiles: (files: File[]) => void;
+  onFiles: (_files: File[]) => void;
   inputRef: React.RefObject<HTMLInputElement>;
   selectedFile: File | null;
   onClearFile: () => void;
   isHydrated: boolean;
-  tGeneral: (key: string, opts?: any) => string;
-  tEsign: (key: string, opts?: any) => string;
+  tGeneral: (key: string, opts?: Record<string, unknown>) => string;
+  tEsign: (key: string, opts?: Record<string, unknown>) => string;
   onClick?: () => void; // Make onClick optional or required based on usage
 }) => {
   const [isDragging, setIsDragging] = useState(false);

--- a/src/components/AddressField.tsx
+++ b/src/components/AddressField.tsx
@@ -32,6 +32,11 @@ interface InputWithAutocomplete extends HTMLInputElement {
   googleAutocomplete?: unknown;
 }
 
+interface AddressComponent {
+  types: string[];
+  short_name: string;
+}
+
 interface AddressFieldProps {
   name: string;
   label: string; // Expected to be a translation key
@@ -41,7 +46,7 @@ interface AddressFieldProps {
   error?: string; // Expected to be a translation key if it's a direct string
   tooltip?: string; // Expected to be a translation key
   value?: string;
-  onChange?: (value: string, parts?: Record<string, string>) => void;
+  onChange?: (_value: string, _parts?: Record<string, string>) => void;
 }
 
 const AddressField = React.memo(function AddressField({
@@ -111,7 +116,8 @@ const AddressField = React.memo(function AddressField({
           'country',
         ]);
         const parts: Record<string, string> = {};
-        place.address_components?.forEach((c: any) => {
+
+        place.address_components?.forEach((c: AddressComponent) => {
           const type = c.types[0];
           if (wanted.has(type)) parts[type] = c.short_name;
         });

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -21,7 +21,7 @@ import { useAuth } from '@/hooks/useAuth'; // Import useAuth
 interface AuthModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAuthSuccess: (mode: 'signin' | 'signup', email: string) => void;
+  onAuthSuccess: (_mode: 'signin' | 'signup', _email: string) => void;
 }
 
 export default function AuthModal({

--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -175,9 +175,9 @@ const DocumentDetail = React.memo(function DocumentDetail({
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: (props) => (
-                <AutoImage {...(props as any)} className="mx-auto" />
-              ),
+                img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                  <AutoImage {...props} className="mx-auto" />
+                ),
             }}
           >
             {md}

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -115,9 +115,9 @@ const DocumentPreview = React.memo(function DocumentPreview({
             components={{
               p: (props) => <p {...props} className="select-none" />,
               // FIXED: ensure images have explicit dimensions
-              img: (props) => (
-                <AutoImage {...(props as any)} className="mx-auto" />
-              ),
+                img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                  <AutoImage {...props} className="mx-auto" />
+                ),
             }}
           >
             {md}

--- a/src/components/FieldRenderer.tsx
+++ b/src/components/FieldRenderer.tsx
@@ -63,10 +63,15 @@ const FieldRenderer = React.memo(function FieldRenderer({
     (q) => q.id === fieldKey,
   );
 
+  const zodSchema = doc.schema as unknown as {
+    _def?: { typeName?: string; schema?: { shape: Record<string, ZodTypeAny> } };
+    shape?: Record<string, ZodTypeAny>;
+  };
+
   const actualSchemaShape =
-    (doc.schema as any)?._def?.typeName === 'ZodEffects'
-      ? (doc.schema as any)._def.schema.shape
-      : (doc.schema as any)?.shape;
+    zodSchema._def?.typeName === 'ZodEffects'
+      ? zodSchema._def.schema?.shape
+      : zodSchema.shape;
   const fieldSchemaFromZod = (
     actualSchemaShape as Record<string, ZodTypeAny> | undefined
   )?.[fieldKey];

--- a/src/components/MiniCartDrawer.tsx
+++ b/src/components/MiniCartDrawer.tsx
@@ -41,11 +41,8 @@ export default function MiniCartDrawer() {
           <DrawerTitle>Your Cart</DrawerTitle>
           <DrawerDescription>
             {cartItems.length > 0
-              ? `You have ${totalItems} item${
-                  totalItems > 1 ? 's' : ''
-                } in your cart.`
-              : 'Your cart is empty.' // Removed the nested <p> tag
-            }
+              ? `You have ${totalItems} item${totalItems > 1 ? 's' : ''} in your cart.`
+              : 'Your cart is empty.'}
           </DrawerDescription>
         </DrawerHeader>
         <div className="space-y-4 px-4 pb-4">

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -215,9 +215,9 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: (props) => (
-                <AutoImage {...(props as any)} className="mx-auto" />
-              ),
+                img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                  <AutoImage {...props} className="mx-auto" />
+                ),
             }}
           >
             {processedMarkdown}

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -90,12 +90,22 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
     const schemaDef = doc?.schema?._def;
     if (!schemaDef) return undefined;
     if (schemaDef.typeName === 'ZodObject')
-      return (doc.schema as unknown as AnyZodObject).shape as Record<string, z.ZodTypeAny>;
+      return (
+        (doc.schema as unknown as AnyZodObject).shape as Record<
+          string,
+          z.ZodTypeAny
+        >
+      );
     if (
       schemaDef.typeName === 'ZodEffects' &&
       schemaDef.schema?._def?.typeName === 'ZodObject'
     ) {
-      return (schemaDef.schema as unknown as AnyZodObject).shape as Record<string, z.ZodTypeAny>;
+      return (
+        (schemaDef.schema as unknown as AnyZodObject).shape as Record<
+          string,
+          z.ZodTypeAny
+        >
+      );
     }
     return undefined;
   }, [doc.schema]);

--- a/src/components/Step1DocumentSelector.tsx
+++ b/src/components/Step1DocumentSelector.tsx
@@ -54,8 +54,8 @@ export const CATEGORY_LIST: CategoryInfo[] = [
 
 interface Step1DocumentSelectorProps {
   selectedCategory: string | null;
-  onCategorySelect: (categoryKey: string | null) => void;
-  onDocumentSelect: (doc: LegalDocument) => void;
+  onCategorySelect: (_categoryKey: string | null) => void;
+  onDocumentSelect: (_doc: LegalDocument) => void;
   isReadOnly?: boolean;
   globalSearchTerm: string;
   globalSelectedState: string;
@@ -120,7 +120,7 @@ const MemoizedCategoryCard = React.memo(function CategoryCard({
   category: CategoryInfo;
   onClick: () => void;
   disabled: boolean;
-  t: (key: string, fallback?: string | object) => string;
+  t: (_key: string, _fallback?: string | object) => string;
 }) {
   return (
     <Button
@@ -152,7 +152,7 @@ const MemoizedDocumentCard = React.memo(function DocumentCard({
   doc: LegalDocument;
   onSelect: () => void;
   disabled: boolean;
-  t: (key: string, fallback?: string | object) => string;
+  t: (_key: string, _fallback?: string | object) => string;
   i18nLanguage: string;
   placeholderNoDescription: string;
   placeholderRequiresNotarization: string;
@@ -215,7 +215,7 @@ const MemoizedTopDocChip = React.memo(function TopDocChip({
   };
   onSelect: () => void;
   disabled: boolean;
-  t: (key: string, fallback?: string | object) => string;
+  t: (_key: string, _fallback?: string | object) => string;
   i18nLanguage: string;
 }) {
   return (
@@ -247,10 +247,10 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
 }: Step1DocumentSelectorProps) {
   const { t, i18n } = useTranslation('common');
   const tSimple = React.useCallback(
-    (key: string, fallback?: string | object): string =>
+    (key: string, fallback?: string | Record<string, unknown>): string =>
       typeof fallback === 'string'
         ? (t(key, { defaultValue: fallback }) as string)
-        : (t(key, fallback as any) as string),
+        : (t(key, fallback as Record<string, unknown>) as string),
     [t],
   );
   // 'top-docs', 'all-categories', 'documents-in-category', 'search-results'

--- a/src/components/StepOneInput.tsx
+++ b/src/components/StepOneInput.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 import { documentLibrary } from '@/lib/document-library';
 
 interface StepOneInputProps {
-  onSelectCategory: (category: string) => void;
+  onSelectCategory: (_category: string) => void;
 }
 
 export function StepOneInput({ onSelectCategory }: StepOneInputProps) {

--- a/src/components/StepTwoInput.tsx
+++ b/src/components/StepTwoInput.tsx
@@ -10,8 +10,8 @@ import {
 
 interface StepTwoInputProps {
   category: string;
-  onStateChange: (state: string) => void;
-  onSelectTemplate: (templateId: string) => void;
+  onStateChange: (_state: string) => void;
+  onSelectTemplate: (_templateId: string) => void;
 }
 
 export function StepTwoInput({

--- a/src/components/StickyFilterBar.tsx
+++ b/src/components/StickyFilterBar.tsx
@@ -16,9 +16,9 @@ import { Search, MapPin } from 'lucide-react';
 
 interface StickyFilterBarProps {
   searchTerm: string;
-  onSearchTermChange: (term: string) => void;
+  onSearchTermChange: (_term: string) => void;
   selectedState: string;
-  onSelectedStateChange: (state: string) => void;
+  onSelectedStateChange: (_state: string) => void;
 }
 
 const StickyFilterBar = React.memo(function StickyFilterBar({

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -209,7 +209,7 @@ export default function WizardForm({
     }
 
     if (currentStepFieldKey) {
-      isValid = await trigger(currentStepFieldKey as any);
+      isValid = await trigger(currentStepFieldKey as string);
     } else if (totalSteps > 0 && currentStepIndex < totalSteps) {
       console.error(
         'Error: currentStepFieldKey is undefined but totalSteps > 0. currentStepIndex:',
@@ -303,7 +303,7 @@ export default function WizardForm({
           <Controller
             key={`${currentField.id}-controller`}
             control={control}
-            name={currentField.id as any}
+            name={currentField.id as string}
             render={({
               field: { onChange: rhfOnChange, value: rhfValue, name: rhfName },
             }) => (
@@ -330,18 +330,18 @@ export default function WizardForm({
                       currentField.id.replace(/_address$/i, '') ||
                       currentField.id.replace(/Address$/i, '');
                     if (actualSchemaShape[`${prefix}_city`])
-                      setValue(`${prefix}_city` as any, parts.city, {
+                      setValue(`${prefix}_city` as string, parts.city, {
                         shouldValidate: true,
                         shouldDirty: true,
                       });
                     if (actualSchemaShape[`${prefix}_state`])
-                      setValue(`${prefix}_state` as any, parts.state, {
+                      setValue(`${prefix}_state` as string, parts.state, {
                         shouldValidate: true,
                         shouldDirty: true,
                       });
                     if (actualSchemaShape[`${prefix}_postal_code`])
                       setValue(
-                        `${prefix}_postal_code` as any,
+                        `${prefix}_postal_code` as string,
                         parts.postalCode,
                         {
                           shouldValidate: true,

--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -160,7 +160,16 @@ export default function PromissoryNoteDisplay({
 
   const allDisplaySections = [...informationalSections, ...faqItems];
 
-  const renderSectionContent = (section: any) => {
+  interface DisplaySection {
+    type: 'paragraph' | 'list' | 'ordered-list' | 'table';
+    contentKey?: string;
+    itemsKey?: string;
+    lastParagraphKey?: string;
+    totalTimeKey?: string;
+    tableKey?: string;
+  }
+
+  const renderSectionContent = (section: DisplaySection) => {
     if (section.type === 'paragraph' && section.contentKey) {
       return <p className="text-muted-foreground">{t(section.contentKey)}</p>;
     }

--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -77,7 +77,7 @@ const MemoizedTestimonialCard = React.memo(function TestimonialCard({
 }: {
   testimonial: Testimonial | null;
   index: number;
-  t: (key: string, fallback?: string | object) => string;
+    t: (_key: string, _fallback?: string | object) => string;
   isHydrated: boolean;
 }) {
   const rating = 5;
@@ -189,10 +189,10 @@ const TrustAndTestimonialsSection = React.memo(
   function TrustAndTestimonialsSection() {
     const { t, i18n, ready } = useTranslation('common');
     const tSimple = React.useCallback(
-      (key: string, fallback?: string | object): string =>
+      (key: string, fallback?: string | Record<string, unknown>): string =>
         typeof fallback === 'string'
           ? (t(key, { defaultValue: fallback }) as string)
-          : (t(key, fallback as any) as string),
+          : (t(key, fallback as Record<string, unknown>) as string),
       [t],
     );
     const [docCount, setDocCount] = useState(4200);

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -80,7 +80,7 @@ export const Footer = React.memo(function Footer() {
     setIsLoading(false);
   };
 
-  type IntercomWindow = Window & { Intercom?: (cmd: string) => void };
+  type IntercomWindow = Window & { Intercom?: (_cmd: string) => void };
 
   const loadIntercom = () => {
     const win: IntercomWindow = window as IntercomWindow;

--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -27,7 +27,7 @@ const MemoizedDocLink = React.memo(function DocLink({
   doc: LegalDocument;
   locale: 'en' | 'es';
   onClick?: () => void;
-  t: (key: string, fallback?: string | object) => string;
+  t: (_key: string, _fallback?: string | object) => string;
 }) {
   const translatedDoc = getDocTranslation(doc, locale); // Use utility
   const docName = translatedDoc.name;
@@ -53,10 +53,10 @@ export default function MegaMenuContent({
 }: MegaMenuContentProps) {
   const { t, i18n } = useTranslation('common');
   const tSimple = React.useCallback(
-    (key: string, fallback?: string | object): string =>
+    (key: string, fallback?: string | Record<string, unknown>): string =>
       typeof fallback === 'string'
         ? (t(key, { defaultValue: fallback }) as string)
-        : (t(key, fallback as any) as string),
+        : (t(key, fallback as Record<string, unknown>) as string),
     [t],
   );
   const currentLocale = i18n.language as 'en' | 'es';

--- a/src/components/questionnaire.tsx
+++ b/src/components/questionnaire.tsx
@@ -27,7 +27,7 @@ import { documentLibrary, type Question } from '@/lib/document-library'; // Impo
 interface QuestionnaireProps {
   documentType: string | null; // The inferred document type NAME (e.g., "Residential Lease Agreement")
   selectedState?: string | null; // The selected US state code (e.g., "CA")
-  onAnswersSubmit: (answers: Record<string, unknown>) => void; // Callback
+  onAnswersSubmit: (_answers: Record<string, unknown>) => void; // Callback
   isReadOnly?: boolean; // Optional prop to make the form read-only
 }
 

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -18,7 +18,7 @@ type CarouselProps = {
   opts?: CarouselOptions;
   plugins?: CarouselPlugin;
   orientation?: 'horizontal' | 'vertical';
-  setApi?: (api: CarouselApi) => void;
+  setApi?: (_api: CarouselApi) => void;
 };
 
 type CarouselContextProps = {

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils';
 const THEMES = { light: '', dark: '.dark' } as const;
 
 export type ChartConfig = {
-  [k in string]: {
+  [key: string]: {
     label?: React.ReactNode;
     icon?: React.ComponentType;
   } & (

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -29,9 +29,9 @@ const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 type SidebarContext = {
   state: 'expanded' | 'collapsed';
   open: boolean;
-  setOpen: (open: boolean) => void;
+  setOpen: (_open: boolean) => void;
   openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
+  setOpenMobile: (_open: boolean) => void;
   isMobile: boolean;
   toggleSidebar: () => void;
 };

--- a/src/contexts/CartProvider.tsx
+++ b/src/contexts/CartProvider.tsx
@@ -26,11 +26,11 @@ export type CartItem =
 
 interface CartState {
   items: CartItem[];
-  addItem: (i: CartItem) => void;
-  addBundle: (bundle: Bundle) => void; // ← NEW
-  incQty: (id: string) => void;
-  decQty: (id: string) => void;
-  removeItem: (id: string) => void;
+  addItem: (_i: CartItem) => void;
+  addBundle: (_bundle: Bundle) => void; // ← NEW
+  incQty: (_id: string) => void;
+  decQty: (_id: string) => void;
+  removeItem: (_id: string) => void;
   clear: () => void;
   totalCents: number;
 }

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -126,7 +126,7 @@ export const reducer = (state: State, action: Action): State => {
   }
 };
 
-const listeners: Array<(state: State) => void> = [];
+const listeners: Array<(_state: State) => void> = [];
 
 let memoryState: State = { toasts: [] };
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -28,9 +28,9 @@ interface AuthContextType {
   isLoggedIn: boolean;
   user: User | null;
   isLoading: boolean;
-  login: (email: string, uid?: string) => void; // email is now required for login
+  login: (_email: string, _uid?: string) => void; // email is now required for login
   logout: () => void;
-  updateUser: (updates: Partial<User> & { password?: string }) => void;
+  updateUser: (_updates: Partial<User> & { password?: string }) => void;
 }
 
 // 2) Create the context (default undefined to catch mis-use)

--- a/src/hooks/useSmartField.ts
+++ b/src/hooks/useSmartField.ts
@@ -120,7 +120,7 @@ export const useSmartField = <T extends FieldValues>({
                 (formValues[yearField] === undefined ||
                   formValues[yearField] === '' ||
                   formValues[yearField] === 0 ||
-                  isNaN(parseInt(String(formValues[yearField])))
+                  isNaN(parseInt(String(formValues[yearField]))))
               ) {
                 setValue(
                   yearField,

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,7 +1,7 @@
 /* super‑light wrapper – works with GA4, Plausible, FB Pixel, ... */
 declare global {
   interface Window {
-    gtag?: (..._args: unknown[]) => void;
+    gtag?: (...args: unknown[]) => void;
   }
 }
 

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,9 +1,7 @@
-export type AnyFn<Args extends unknown[] = unknown[]> = (
-  ...args: Args
-) => void;
+export type AnyFn<Args extends unknown[] = unknown[]> = (..._args: Args) => void;
 
 export interface DebouncedFunction<F extends AnyFn> {
-  (...args: Parameters<F>): void;
+  (..._args: Parameters<F>): void;
   cancel(): void;
 }
 

--- a/src/types/google.maps.d.ts
+++ b/src/types/google.maps.d.ts
@@ -5,11 +5,13 @@ declare global {
       fields?: string[];
       componentRestrictions?: Record<string, unknown>;
     }
-      class Autocomplete {
-        constructor(_input: HTMLInputElement, _opts?: AutocompleteOptions);
-        getPlace(): unknown;
-        addListener(_event: string, _handler: () => void): void;
-      }
+
+    class Autocomplete {
+      constructor(_input: HTMLInputElement, _opts?: AutocompleteOptions);
+      getPlace(): unknown;
+      addListener(_event: string, _handler: () => void): void;
+    }
   }
 }
+
 export {};


### PR DESCRIPTION
## Summary
- resolve ESLint warnings about explicit `any` types
- remove unused parameter names
- address Prettier formatting errors
- correct a syntax error in `useSmartField`
- clean up custom type definitions

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*