### PR TITLE
Fix lint formatting issues

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -97,10 +97,12 @@ export default function HomePageClient() {
         mod.default?.preload?.();
       },
     );
-    import('@/components/landing/GuaranteeBadge').then((mod: PreloadableModule) => {
-      mod.GuaranteeBadge?.preload?.();
-      mod.default?.preload?.(); // fallback for default export
-    });
+    import('@/components/landing/GuaranteeBadge').then(
+      (mod: PreloadableModule) => {
+        mod.GuaranteeBadge?.preload?.();
+        mod.default?.preload?.(); // fallback for default export
+      },
+    );
     import('@/components/TopDocsChips').then((mod: PreloadableModule) => {
       mod.default?.preload?.();
     });

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -25,8 +25,6 @@ interface FirestoreTimestamp {
   toDate: () => Date;
 }
 
-
-
 interface DashboardClientContentProps {
   locale: 'en' | 'es';
 }

--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -175,9 +175,9 @@ const DocumentDetail = React.memo(function DocumentDetail({
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-                img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                  <AutoImage {...props} className="mx-auto" />
-                ),
+              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                <AutoImage {...props} className="mx-auto" />
+              ),
             }}
           >
             {md}

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -115,9 +115,9 @@ const DocumentPreview = React.memo(function DocumentPreview({
             components={{
               p: (props) => <p {...props} className="select-none" />,
               // FIXED: ensure images have explicit dimensions
-                img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                  <AutoImage {...props} className="mx-auto" />
-                ),
+              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                <AutoImage {...props} className="mx-auto" />
+              ),
             }}
           >
             {md}

--- a/src/components/FieldRenderer.tsx
+++ b/src/components/FieldRenderer.tsx
@@ -64,7 +64,10 @@ const FieldRenderer = React.memo(function FieldRenderer({
   );
 
   const zodSchema = doc.schema as unknown as {
-    _def?: { typeName?: string; schema?: { shape: Record<string, ZodTypeAny> } };
+    _def?: {
+      typeName?: string;
+      schema?: { shape: Record<string, ZodTypeAny> };
+    };
     shape?: Record<string, ZodTypeAny>;
   };
 

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -215,9 +215,9 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-                img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                  <AutoImage {...props} className="mx-auto" />
-                ),
+              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                <AutoImage {...props} className="mx-auto" />
+              ),
             }}
           >
             {processedMarkdown}

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -90,22 +90,18 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
     const schemaDef = doc?.schema?._def;
     if (!schemaDef) return undefined;
     if (schemaDef.typeName === 'ZodObject')
-      return (
-        (doc.schema as unknown as AnyZodObject).shape as Record<
-          string,
-          z.ZodTypeAny
-        >
-      );
+      return ((doc.schema as unknown as AnyZodObject).shape as Record<
+        string,
+        z.ZodTypeAny
+      >);
     if (
       schemaDef.typeName === 'ZodEffects' &&
       schemaDef.schema?._def?.typeName === 'ZodObject'
     ) {
-      return (
-        (schemaDef.schema as unknown as AnyZodObject).shape as Record<
-          string,
-          z.ZodTypeAny
-        >
-      );
+      return ((schemaDef.schema as unknown as AnyZodObject).shape as Record<
+        string,
+        z.ZodTypeAny
+      >);
     }
     return undefined;
   }, [doc.schema]);

--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -75,10 +75,10 @@ const MemoizedTestimonialCard = React.memo(function TestimonialCard({
   t,
   isHydrated,
 }: {
-  testimonial: Testimonial | null;
-  index: number;
+    testimonial: Testimonial | null;
+    index: number;
     t: (_key: string, _fallback?: string | object) => string;
-  isHydrated: boolean;
+    isHydrated: boolean;
 }) {
   const rating = 5;
   const currentTestimonial = testimonial || {

--- a/src/hooks/useSmartField.ts
+++ b/src/hooks/useSmartField.ts
@@ -38,10 +38,14 @@ export const useSmartField = <T extends FieldValues>({
       const stringVal = String(currentVal);
       const sanitized = stringVal.replace(/\D/g, '').slice(0, 4);
       if (sanitized !== stringVal) {
-        setValue(name as Path<T>, sanitized as unknown as FieldPathValue<T, Path<T>>, {
-          shouldValidate: true,
-          shouldDirty: true,
-        });
+        setValue(
+          name as Path<T>,
+          sanitized as unknown as FieldPathValue<T, Path<T>>,
+          {
+            shouldValidate: true,
+            shouldDirty: true,
+          },
+        );
       }
     }
   }, [fieldValue, name, setValue, watch]);
@@ -52,12 +56,16 @@ export const useSmartField = <T extends FieldValues>({
       const currentVal = watch(name as Path<T>);
       if (typeof currentVal !== 'string') return; // Only process if it's a string
       const sanitized = currentVal.replace(/[^a-zA-Z\s]/gi, '');
-      if (sanitized !== currentVal) {
-        setValue(name as Path<T>, sanitized as unknown as FieldPathValue<T, Path<T>>, {
-          shouldValidate: true,
-          shouldDirty: true,
-        });
-      }
+        if (sanitized !== currentVal) {
+          setValue(
+            name as Path<T>,
+            sanitized as unknown as FieldPathValue<T, Path<T>>,
+            {
+              shouldValidate: true,
+              shouldDirty: true,
+            },
+          );
+        }
     }
   }, [fieldValue, name, setValue, watch]);
 
@@ -108,7 +116,10 @@ export const useSmartField = <T extends FieldValues>({
               ) {
                 setValue(
                   modelField,
-                  result.Model as unknown as FieldPathValue<T, typeof modelField>,
+                  result.Model as unknown as FieldPathValue<
+                    T,
+                    typeof modelField
+                  >,
                   {
                     shouldValidate: true,
                     shouldDirty: true,
@@ -124,7 +135,10 @@ export const useSmartField = <T extends FieldValues>({
               ) {
                 setValue(
                   yearField,
-                  Number(result.ModelYear) as unknown as FieldPathValue<T, typeof yearField>,
+                  Number(result.ModelYear) as unknown as FieldPathValue<
+                    T,
+                    typeof yearField
+                  >,
                   {
                     shouldValidate: true,
                     shouldDirty: true,

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,4 +1,6 @@
-export type AnyFn<Args extends unknown[] = unknown[]> = (..._args: Args) => void;
+export type AnyFn<Args extends unknown[] = unknown[]> = (
+  ..._args: Args
+) => void;
 
 export interface DebouncedFunction<F extends AnyFn> {
   (..._args: Parameters<F>): void;


### PR DESCRIPTION
## Summary
- fix formatting in HomePageClient imports
- trim excess whitespace in dashboard-client-content
- normalize markdown image indentation
- format complex type in FieldRenderer
- clean up effect blocks in useSmartField
- format debounce helper

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*