### PR TITLE
Fix lint warnings

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -126,7 +126,7 @@ export const reducer = (state: State, action: Action): State => {
   }
 };
 
-const listeners: Array<(_state: State) => void> = [];
+const listeners: Array<(state: State) => void> = [];
 
 let memoryState: State = { toasts: [] };
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -28,9 +28,9 @@ interface AuthContextType {
   isLoggedIn: boolean;
   user: User | null;
   isLoading: boolean;
-  login: (_email: string, _uid?: string) => void; // email is now required for login
+  login: (email: string, uid?: string) => void; // email is now required for login
   logout: () => void;
-  updateUser: (_updates: Partial<User> & { password?: string }) => void;
+  updateUser: (updates: Partial<User> & { password?: string }) => void;
 }
 
 // 2) Create the context (default undefined to catch mis-use)

--- a/src/hooks/useSmartField.ts
+++ b/src/hooks/useSmartField.ts
@@ -56,16 +56,16 @@ export const useSmartField = <T extends FieldValues>({
       const currentVal = watch(name as Path<T>);
       if (typeof currentVal !== 'string') return; // Only process if it's a string
       const sanitized = currentVal.replace(/[^a-zA-Z\s]/gi, '');
-        if (sanitized !== currentVal) {
-          setValue(
-            name as Path<T>,
-            sanitized as unknown as FieldPathValue<T, Path<T>>,
-            {
-              shouldValidate: true,
-              shouldDirty: true,
-            },
-          );
-        }
+      if (sanitized !== currentVal) {
+        setValue(
+          name as Path<T>,
+          sanitized as unknown as FieldPathValue<T, Path<T>>,
+          {
+            shouldValidate: true,
+            shouldDirty: true,
+          },
+        );
+      }
     }
   }, [fieldValue, name, setValue, watch]);
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,6 +1,7 @@
 /* super‑light wrapper – works with GA4, Plausible, FB Pixel, ... */
 declare global {
   interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     gtag?: (...args: unknown[]) => void;
   }
 }

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,9 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 export type AnyFn<Args extends unknown[] = unknown[]> = (
-  ..._args: Args
+  ...args: Args
 ) => void;
 
 export interface DebouncedFunction<F extends AnyFn> {
-  (..._args: Parameters<F>): void;
+  (...args: Parameters<F>): void;
   cancel(): void;
 }
 

--- a/src/types/google.maps.d.ts
+++ b/src/types/google.maps.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 declare global {
   namespace google.maps.places {
     interface AutocompleteOptions {
@@ -7,9 +8,9 @@ declare global {
     }
 
     class Autocomplete {
-      constructor(_input: HTMLInputElement, _opts?: AutocompleteOptions);
+      constructor(input: HTMLInputElement, opts?: AutocompleteOptions);
       getPlace(): unknown;
-      addListener(_event: string, _handler: () => void): void;
+      addListener(event: string, handler: () => void): void;
     }
   }
 }


### PR DESCRIPTION
## Summary
- clean up useToast listeners type
- remove unused parameter names in AuthContextType
- fix indentation in useSmartField hook
- silence unused vars in analytics, debounce, and google maps typings

## Testing
- `npm run lint` *(fails: next not found)*