### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/ai/flows/infer-document-type.ts
+++ b/src/ai/flows/infer-document-type.ts
@@ -130,9 +130,9 @@ export const inferDocumentTypeFlow = ai.defineFlow<
     try {
       const response = await prompt({
         ...parsed.data,
-        // Extra context isn't part of the input schema
+        // Extra context isn't part of the input schema; cast to satisfy typing
         availableDocumentsContext: ctx,
-      });
+      } as InferDocumentTypeInput & { availableDocumentsContext: string });
       const output = response.output as InferDocumentTypeOutput;
 
       if (!output) throw new Error('AI returned no output');

--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -89,25 +89,21 @@ export default function HomePageClient() {
   // Preload dynamically imported sections once on the client
   useEffect(() => {
     // Use dynamic import to get the module and then call preload if available
-    import('@/components/landing/HowItWorks').then((mod: PreloadableModule) => {
-      mod.default?.preload?.();
+    import('@/components/landing/HowItWorks').then((mod) => {
+      (mod as PreloadableModule).default?.preload?.();
     });
-    import('@/components/landing/TrustAndTestimonialsSection').then(
-      (mod: PreloadableModule) => {
-        mod.default?.preload?.();
-      },
-    );
-    import('@/components/landing/GuaranteeBadge').then(
-      (mod: PreloadableModule) => {
-        mod.GuaranteeBadge?.preload?.();
-        mod.default?.preload?.(); // fallback for default export
-      },
-    );
-    import('@/components/TopDocsChips').then((mod: PreloadableModule) => {
-      mod.default?.preload?.();
+    import('@/components/landing/TrustAndTestimonialsSection').then((mod) => {
+      (mod as PreloadableModule).default?.preload?.();
     });
-    import('@/components/StickyFilterBar').then((mod: PreloadableModule) => {
-      mod.default?.preload?.();
+    import('@/components/landing/GuaranteeBadge').then((mod) => {
+      (mod as PreloadableModule).GuaranteeBadge?.preload?.();
+      (mod as PreloadableModule).default?.preload?.(); // fallback for default export
+    });
+    import('@/components/TopDocsChips').then((mod) => {
+      (mod as PreloadableModule).default?.preload?.();
+    });
+    import('@/components/StickyFilterBar').then((mod) => {
+      (mod as PreloadableModule).default?.preload?.();
     });
   }, []);
 

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,9 +1,10 @@
 // src/app/[locale]/blog/page.tsx
 import React from 'react';
-import type { PageProps } from 'next';
 import BlogClientContent from './blog-client-content';
 
-type BlogPageProps = PageProps<{ locale: 'en' | 'es' }>;
+type BlogPageProps = {
+  params: { locale: 'en' | 'es' };
+};
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -6,9 +6,9 @@ import path from 'node:path';
 import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
-import type { PageProps } from 'next';
-
-type DocPageProps = PageProps<{ locale: string; docId: string }>;
+type DocPageProps = {
+  params: { locale: string; docId: string };
+};
 
 // Revalidate this page every hour for fresh content while caching aggressively
 export const revalidate = 3600;

--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -140,17 +140,19 @@ export default function StartWizardPageClient() {
 
   const debouncedSave = useMemo(
     () =>
-      debounce(async (data: Record<string, unknown>) => {
-        if (
-          !docConfig?.id ||
-          authIsLoading ||
-          !isMounted ||
-          Object.keys(data).length === 0 ||
-          isLoadingConfig ||
-          !locale ||
-          !ready
-        )
-          return;
+      debounce((data: Record<string, unknown>) => {
+        // Wrap async logic to satisfy debounce's void return type
+        void (async () => {
+          if (
+            !docConfig?.id ||
+            authIsLoading ||
+            !isMounted ||
+            Object.keys(data).length === 0 ||
+            isLoadingConfig ||
+            !locale ||
+            !ready
+          )
+            return;
 
         const relevantDataToSave = Object.keys(data).reduce(
           (acc, key) => {
@@ -177,12 +179,13 @@ export default function StartWizardPageClient() {
             JSON.stringify(relevantDataToSave),
           );
         }
-        console.log(
-          '[WizardForm] Autosaved draft for:',
-          docConfig!.id,
-          locale,
-          relevantDataToSave,
-        );
+          console.log(
+            '[WizardForm] Autosaved draft for:',
+            docConfig!.id,
+            locale,
+            relevantDataToSave,
+          );
+        })();
       }, 1000),
     [
       isLoggedIn,

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -4,9 +4,9 @@
 import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
-import type { PageProps } from 'next';
-
-type StartWizardPageProps = PageProps<{ locale: 'en' | 'es'; docId: string }>;
+type StartWizardPageProps = {
+  params: { locale: 'en' | 'es'; docId: string };
+};
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly
 export const revalidate = 3600;

--- a/src/components/AddressField.tsx
+++ b/src/components/AddressField.tsx
@@ -37,6 +37,12 @@ interface AddressComponent {
   short_name: string;
 }
 
+interface GooglePlaceResult {
+  formatted_address?: string;
+  address_components?: AddressComponent[];
+  name?: string;
+}
+
 interface AddressFieldProps {
   name: string;
   label: string; // Expected to be a translation key
@@ -103,7 +109,7 @@ const AddressField = React.memo(function AddressField({
 
       autocomplete.addListener('place_changed', () => {
         if (!autocomplete) return;
-        const place = autocomplete.getPlace();
+        const place = autocomplete.getPlace() as GooglePlaceResult;
         const formattedAddress = place.formatted_address || '';
 
         const wanted = new Set([


### PR DESCRIPTION
## Notes
- `npm test` passes but `npm run typecheck` fails because dependencies like `@types/node` aren't installed in the environment.
- `npm run lint` also fails due to missing Next.js CLI.

## Summary
- cast additional prompt field in `infer-document-type` flow
- adjust dynamic import preloading logic
- replace deprecated `PageProps` usages
- wrap autosave logic to satisfy `debounce` return type
- add Google Places result typing for address field