### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/components/AddressField.tsx
+++ b/src/components/AddressField.tsx
@@ -103,7 +103,7 @@ const AddressField = React.memo(function AddressField({
 
       autocomplete.addListener('place_changed', () => {
         if (!autocomplete) return;
-        const place = autocomplete.getPlace();
+        const place: google.maps.places.PlaceResult = autocomplete.getPlace();
         const formattedAddress = place.formatted_address || '';
 
         const wanted = new Set([

--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { documentLibrary, type LegalDocument } from '@/lib/document-library';
 import { Loader2, AlertTriangle } from 'lucide-react';
 import Image from 'next/image';
-import AutoImage from './AutoImage';
+import AutoImage, { type AutoImageProps } from './AutoImage';
 import { cn } from '@/lib/utils';
 
 export interface DocumentDetailProps {
@@ -176,7 +176,10 @@ const DocumentDetail = React.memo(function DocumentDetail({
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
               img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage {...props} className="mx-auto" />
+                <AutoImage
+                  {...(props as unknown as AutoImageProps)}
+                  className="mx-auto"
+                />
               ),
             }}
           >

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -6,7 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next';
 import Image from 'next/image';
-import AutoImage from './AutoImage';
+import AutoImage, { type AutoImageProps } from './AutoImage';
 import { Loader2 } from 'lucide-react';
 
 interface DocumentPreviewProps {
@@ -116,7 +116,10 @@ const DocumentPreview = React.memo(function DocumentPreview({
               p: (props) => <p {...props} className="select-none" />,
               // FIXED: ensure images have explicit dimensions
               img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage {...props} className="mx-auto" />
+                <AutoImage
+                  {...(props as unknown as AutoImageProps)}
+                  className="mx-auto"
+                />
               ),
             }}
           >

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -11,7 +11,7 @@ import { debounce } from '@/lib/debounce';
 import { documentLibrary } from '@/lib/document-library';
 import { cn } from '@/lib/utils';
 import Image from 'next/image';
-import AutoImage from './AutoImage';
+import AutoImage, { type AutoImageProps } from './AutoImage';
 
 interface PreviewPaneProps {
   locale: 'en' | 'es';
@@ -133,14 +133,13 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
 
   const debouncedUpdatePreview = useMemo(
     () =>
-      debounce(
-        (formData: Record<string, unknown>, currentRawMarkdown: string) => {
-          setProcessedMarkdown(
-            updatePreviewContent(formData, currentRawMarkdown),
-          );
-        },
-        300,
-      ),
+      debounce<
+        (formData: Record<string, unknown>, currentRawMarkdown: string) => void
+      >((formData, currentRawMarkdown) => {
+        setProcessedMarkdown(
+          updatePreviewContent(formData, currentRawMarkdown),
+        );
+      }, 300),
     [updatePreviewContent],
   );
 
@@ -215,9 +214,12 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage {...props} className="mx-auto" />
-              ),
+                img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                  <AutoImage
+                    {...(props as unknown as AutoImageProps)}
+                    className="mx-auto"
+                  />
+                ),
             }}
           >
             {processedMarkdown}

--- a/src/components/Step1DocumentSelector.tsx
+++ b/src/components/Step1DocumentSelector.tsx
@@ -247,7 +247,7 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
 }: Step1DocumentSelectorProps) {
   const { t, i18n } = useTranslation('common');
   const tSimple = React.useCallback(
-    (key: string, fallback?: string | Record<string, unknown>): string =>
+    (key: string, fallback?: string | object): string =>
       typeof fallback === 'string'
         ? (t(key, { defaultValue: fallback }) as string)
         : (t(key, fallback as Record<string, unknown>) as string),

--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -161,12 +161,21 @@ export default function PromissoryNoteDisplay({
   const allDisplaySections = [...informationalSections, ...faqItems];
 
   interface DisplaySection {
-    type: 'paragraph' | 'list' | 'ordered-list' | 'table';
+    type:
+      | 'paragraph'
+      | 'list'
+      | 'ordered-list'
+      | 'table'
+      | 'mixed-list'
+      | 'checklist'
+      | 'list-cta';
     contentKey?: string;
     itemsKey?: string;
     lastParagraphKey?: string;
     totalTimeKey?: string;
     tableKey?: string;
+    printNoteKey?: string;
+    ctaKey?: string;
   }
 
   const renderSectionContent = (section: DisplaySection) => {

--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -189,7 +189,7 @@ const TrustAndTestimonialsSection = React.memo(
   function TrustAndTestimonialsSection() {
     const { t, i18n, ready } = useTranslation('common');
     const tSimple = React.useCallback(
-      (key: string, fallback?: string | Record<string, unknown>): string =>
+      (key: string, fallback?: string | object): string =>
         typeof fallback === 'string'
           ? (t(key, { defaultValue: fallback }) as string)
           : (t(key, fallback as Record<string, unknown>) as string),

--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -53,7 +53,7 @@ export default function MegaMenuContent({
 }: MegaMenuContentProps) {
   const { t, i18n } = useTranslation('common');
   const tSimple = React.useCallback(
-    (key: string, fallback?: string | Record<string, unknown>): string =>
+    (key: string, fallback?: string | object): string =>
       typeof fallback === 'string'
         ? (t(key, { defaultValue: fallback }) as string)
         : (t(key, fallback as Record<string, unknown>) as string),

--- a/src/lib/document-library.ts
+++ b/src/lib/document-library.ts
@@ -8,10 +8,11 @@ import * as ca_docs_barrel from './documents/ca';
 
 const isValidDocument = (doc: unknown): doc is LegalDocument => {
   const d = doc as Partial<LegalDocument>;
-  const hasId = d && typeof d.id === 'string' && d.id.trim() !== '';
-  const hasCategory =
-    d && typeof d.category === 'string' && d.category.trim() !== '';
-  const hasSchema = d && d.schema && typeof d.schema.parse === 'function';
+  const hasId = !!(d && typeof d.id === 'string' && d.id.trim() !== '');
+  const hasCategory = !!(
+    d && typeof d.category === 'string' && d.category.trim() !== ''
+  );
+  const hasSchema = !!(d && d.schema && typeof d.schema.parse === 'function');
 
   // Check for English translation name as the primary indicator of a valid name structure
   // OR fallback to top-level name if translations are not yet populated by the forEach loop
@@ -19,13 +20,14 @@ const isValidDocument = (doc: unknown): doc is LegalDocument => {
     translations?: { en?: { name?: string } };
     name?: string;
   };
-  const hasValidTranslationsOrName =
+  const hasValidTranslationsOrName = !!(
     dRecord &&
     ((dRecord.translations &&
       dRecord.translations.en &&
       typeof dRecord.translations.en.name === 'string' &&
       dRecord.translations.en.name.trim() !== '') ||
-      (typeof dRecord.name === 'string' && dRecord.name.trim() !== ''));
+      (typeof dRecord.name === 'string' && dRecord.name.trim() !== ''))
+  );
 
   return hasId && hasCategory && hasSchema && hasValidTranslationsOrName;
 };


### PR DESCRIPTION
## Summary
- fix AddressField typings for Google place result
- ensure AutoImage props satisfy React Markdown image usage
- correct translation helper typing
- extend promissory note section type definitions
- ensure boolean checks in document library
- type debounced callback in PreviewPane

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test`