### PR TITLE
Fix lint warnings

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -28,9 +28,10 @@ interface AuthContextType {
   isLoggedIn: boolean;
   user: User | null;
   isLoading: boolean;
-  login: (email: string, uid?: string) => void; // email is now required for login
+  // prefix unused parameter names with an underscore to satisfy lint rules
+  login: (_email: string, _uid?: string) => void; // email is now required for login
   logout: () => void;
-  updateUser: (updates: Partial<User> & { password?: string }) => void;
+  updateUser: (_updates: Partial<User> & { password?: string }) => void;
 }
 
 // 2) Create the context (default undefined to catch mis-use)

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,8 +1,8 @@
 /* super‑light wrapper – works with GA4, Plausible, FB Pixel, ... */
 declare global {
   interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    gtag?: (...args: unknown[]) => void;
+    // use an underscore to satisfy the unused-vars rule
+    gtag?: (..._args: unknown[]) => void;
   }
 }
 

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 export type AnyFn<Args extends unknown[] = unknown[]> = (
-  ...args: Args
+  ..._args: Args
 ) => void;
 
 export interface DebouncedFunction<F extends AnyFn> {
-  (...args: Parameters<F>): void;
+  (..._args: Parameters<F>): void;
   cancel(): void;
 }
 

--- a/src/types/google.maps.d.ts
+++ b/src/types/google.maps.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 declare global {
   namespace google.maps.places {
     interface AutocompleteOptions {
@@ -8,9 +7,9 @@ declare global {
     }
 
     class Autocomplete {
-      constructor(input: HTMLInputElement, opts?: AutocompleteOptions);
+      constructor(_input: HTMLInputElement, _opts?: AutocompleteOptions);
       getPlace(): unknown;
-      addListener(event: string, handler: () => void): void;
+      addListener(_event: string, _handler: () => void): void;
     }
   }
 }


### PR DESCRIPTION
## Summary
- satisfy lint rules by marking unused args with underscores
- update debounce util to fit prettier format

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test`