### PR TITLE
Fix lint warnings

### DIFF
--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -58,7 +58,7 @@ const DropzonePlaceholder = ({
   tEsign,
   onClick,
 }: {
-  onFiles: (files: File[]) => void;
+  onFiles: (_files: File[]) => void;
   inputRef: React.RefObject<HTMLInputElement>;
   selectedFile: File | null;
   onClearFile: () => void;

--- a/src/components/AddressField.tsx
+++ b/src/components/AddressField.tsx
@@ -52,7 +52,7 @@ interface AddressFieldProps {
   error?: string; // Expected to be a translation key if it's a direct string
   tooltip?: string; // Expected to be a translation key
   value?: string;
-  onChange?: (value: string, parts?: Record<string, string>) => void;
+  onChange?: (_value: string, _parts?: Record<string, string>) => void;
 }
 
 const AddressField = React.memo(function AddressField({

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -21,7 +21,7 @@ import { useAuth } from '@/hooks/useAuth'; // Import useAuth
 interface AuthModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAuthSuccess: (mode: 'signin' | 'signup', email: string) => void;
+  onAuthSuccess: (_mode: 'signin' | 'signup', _email: string) => void;
 }
 
 export default function AuthModal({

--- a/src/components/DocumentTypeSelector.tsx
+++ b/src/components/DocumentTypeSelector.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/lib/document-library';
 
 interface Props {
-  onSelect: (documentId: string) => void; // Now accepts the document ID
+  onSelect: (_documentId: string) => void; // Now accepts the document ID
   selectedDocument?: string; // Optional prop for pre-selecting a document
 }
 

--- a/src/components/DynamicFormRenderer.tsx
+++ b/src/components/DynamicFormRenderer.tsx
@@ -39,7 +39,7 @@ import {
 interface Props {
   documentType: string;
   schema: FormField[];
-  onSubmit: (data: Record<string, unknown>) => void;
+  onSubmit: (_data: Record<string, unknown>) => void;
   isReadOnly?: boolean;
   userId?: string;
   stateCode?: string;

--- a/src/components/Step1DocumentSelector.tsx
+++ b/src/components/Step1DocumentSelector.tsx
@@ -55,8 +55,8 @@ export const CATEGORY_LIST: CategoryInfo[] = [
 
 interface Step1DocumentSelectorProps {
   selectedCategory: string | null;
-  onCategorySelect: (categoryKey: string | null) => void;
-  onDocumentSelect: (doc: LegalDocument) => void;
+  onCategorySelect: (_categoryKey: string | null) => void;
+  onDocumentSelect: (_doc: LegalDocument) => void;
   isReadOnly?: boolean;
   globalSearchTerm: string;
   globalSelectedState: string;

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -74,9 +74,9 @@ const SidebarProvider = React.forwardRef<
     // We use openProp and setOpenProp for control from outside the component.
     const [_open, _setOpen] = React.useState(defaultOpen);
     const open = openProp ?? _open;
-      const setOpen = React.useCallback(
-        (_value: boolean | ((_value: boolean) => boolean)) => {
-          const openState = typeof _value === 'function' ? _value(open) : _value;
+    const setOpen = React.useCallback(
+      (_value: boolean | ((_value: boolean) => boolean)) => {
+        const openState = typeof _value === 'function' ? _value(open) : _value;
         if (setOpenProp) {
           setOpenProp(openState);
         } else {

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -126,7 +126,7 @@ export const reducer = (state: State, action: Action): State => {
   }
 };
 
-const listeners: Array<(state: State) => void> = [];
+const listeners: Array<(_state: State) => void> = [];
 
 let memoryState: State = { toasts: [] };
 


### PR DESCRIPTION
## Summary
- silence no-unused-vars warnings in component props
- fix indent in sidebar component

## Testing
- `npm test`
- `npm run lint` *(fails: `next: not found`)*