### PR TITLE
Fix TS errors in docs and components

### DIFF
--- a/src/components/docs/PromissoryNoteDisplay.tsx
+++ b/src/components/docs/PromissoryNoteDisplay.tsx
@@ -27,6 +27,26 @@ interface PromissoryNoteDisplayProps {
   locale: 'en' | 'es';
 }
 
+interface Section {
+  id: string;
+  titleKey: string;
+  type:
+    | 'list'
+    | 'table'
+    | 'paragraph'
+    | 'ordered-list'
+    | 'mixed-list'
+    | 'checklist'
+    | 'list-cta';
+  contentKey?: string;
+  itemsKey?: string;
+  lastParagraphKey?: string;
+  totalTimeKey?: string;
+  tableKey?: string;
+  printNoteKey?: string;
+  ctaKey?: string;
+}
+
 export default function PromissoryNoteDisplay({
   locale,
 }: PromissoryNoteDisplayProps) {
@@ -63,7 +83,7 @@ export default function PromissoryNoteDisplay({
     router.prefetch(`/${locale}/docs/promissory-note/start`);
   };
 
-  const informationalSections = [
+  const informationalSections: Section[] = [
     {
       id: 'what-is',
       titleKey: 'sections.whatIs.title',
@@ -125,7 +145,7 @@ export default function PromissoryNoteDisplay({
     },
   ];
 
-  const faqItems = [
+  const faqItems: Section[] = [
     {
       id: 'faq1',
       titleKey: 'faq.q1.question',
@@ -158,18 +178,9 @@ export default function PromissoryNoteDisplay({
     },
   ];
 
-  const allDisplaySections = [...informationalSections, ...faqItems];
+  const allDisplaySections: Section[] = [...informationalSections, ...faqItems];
 
-  interface DisplaySection {
-    type: 'paragraph' | 'list' | 'ordered-list' | 'table';
-    contentKey?: string;
-    itemsKey?: string;
-    lastParagraphKey?: string;
-    totalTimeKey?: string;
-    tableKey?: string;
-  }
-
-  const renderSectionContent = (section: DisplaySection) => {
+  const renderSectionContent = (section: Section) => {
     if (section.type === 'paragraph' && section.contentKey) {
       return <p className="text-muted-foreground">{t(section.contentKey)}</p>;
     }

--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -189,7 +189,7 @@ const TrustAndTestimonialsSection = React.memo(
   function TrustAndTestimonialsSection() {
     const { t, i18n, ready } = useTranslation('common');
     const tSimple = React.useCallback(
-      (key: string, fallback?: string | Record<string, unknown>): string =>
+      (key: string, fallback?: string | object): string =>
         typeof fallback === 'string'
           ? (t(key, { defaultValue: fallback }) as string)
           : (t(key, fallback as Record<string, unknown>) as string),

--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -53,7 +53,7 @@ export default function MegaMenuContent({
 }: MegaMenuContentProps) {
   const { t, i18n } = useTranslation('common');
   const tSimple = React.useCallback(
-    (key: string, fallback?: string | Record<string, unknown>): string =>
+    (key: string, fallback?: string | object): string =>
       typeof fallback === 'string'
         ? (t(key, { defaultValue: fallback }) as string)
         : (t(key, fallback as Record<string, unknown>) as string),

--- a/src/lib/document-library.ts
+++ b/src/lib/document-library.ts
@@ -8,10 +8,11 @@ import * as ca_docs_barrel from './documents/ca';
 
 const isValidDocument = (doc: unknown): doc is LegalDocument => {
   const d = doc as Partial<LegalDocument>;
-  const hasId = d && typeof d.id === 'string' && d.id.trim() !== '';
-  const hasCategory =
-    d && typeof d.category === 'string' && d.category.trim() !== '';
-  const hasSchema = d && d.schema && typeof d.schema.parse === 'function';
+  const hasId = !!(d && typeof d.id === 'string' && d.id.trim() !== '');
+  const hasCategory = !!(
+    d && typeof d.category === 'string' && d.category.trim() !== ''
+  );
+  const hasSchema = !!(d && d.schema && typeof d.schema.parse === 'function');
 
   // Check for English translation name as the primary indicator of a valid name structure
   // OR fallback to top-level name if translations are not yet populated by the forEach loop
@@ -19,13 +20,14 @@ const isValidDocument = (doc: unknown): doc is LegalDocument => {
     translations?: { en?: { name?: string } };
     name?: string;
   };
-  const hasValidTranslationsOrName =
+  const hasValidTranslationsOrName = !!(
     dRecord &&
-    ((dRecord.translations &&
-      dRecord.translations.en &&
-      typeof dRecord.translations.en.name === 'string' &&
-      dRecord.translations.en.name.trim() !== '') ||
-      (typeof dRecord.name === 'string' && dRecord.name.trim() !== ''));
+      ((dRecord.translations &&
+        dRecord.translations.en &&
+        typeof dRecord.translations.en.name === 'string' &&
+        dRecord.translations.en.name.trim() !== '') ||
+        (typeof dRecord.name === 'string' && dRecord.name.trim() !== ''))
+  );
 
   return hasId && hasCategory && hasSchema && hasValidTranslationsOrName;
 };


### PR DESCRIPTION
## Summary
- extend `Section` interface in PromissoryNoteDisplay and type arrays
- fix tSimple signature in TrustAndTestimonialsSection and MegaMenuContent
- make `isValidDocument` return boolean values

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test`