### PR TITLE
Fix TypeScript issues

### DIFF
--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -8,6 +8,7 @@ import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
 type DocPageProps = {
   params: { locale: string; docId: string };
+  searchParams?: Record<string, string | string[] | undefined>;
 };
 
 // Revalidate this page every hour for fresh content while caching aggressively

--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -63,8 +63,8 @@ const DropzonePlaceholder = ({
   selectedFile: File | null;
   onClearFile: () => void;
   isHydrated: boolean;
-  tGeneral: TFunction;
-  tEsign: TFunction;
+  tGeneral: (key: string, opts?: Record<string, unknown>) => string;
+  tEsign: (key: string, opts?: Record<string, unknown>) => string;
   onClick?: () => void;
 }) => {
   const [isDragging, setIsDragging] = useState(false);
@@ -532,12 +532,12 @@ export default function SignWellClientContent({
               selectedFile={selectedFile}
               onClearFile={handleClearFile}
               isHydrated={isHydrated}
-              tGeneral={(key, opts) =>
-                t(key, { ...(opts ?? {}), ns: 'common' }) as string
+              tGeneral={(key: string, opts?: Record<string, unknown>) =>
+                t(key, { ...(opts || {}), ns: 'common' }) as string
               }
-              tEsign={(key, opts) =>
+              tEsign={(key: string, opts?: Record<string, unknown>) =>
                 t(key, {
-                  ...(opts ?? {}),
+                  ...(opts || {}),
                   ns: 'electronic-signature',
                 }) as string
               }

--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -175,9 +175,16 @@ const DocumentDetail = React.memo(function DocumentDetail({
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage {...props} className="mx-auto" />
-              ),
+              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+                const { src, ...rest } = props;
+                return (
+                  <AutoImage
+                    {...rest}
+                    src={typeof src === 'string' ? src : ''}
+                    className="mx-auto"
+                  />
+                );
+              },
             }}
           >
             {md}

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-export type AnyFn<Args extends unknown[] = unknown[]> = (
-  ...args: Args
-) => void;
+export type AnyFn<Args extends any[] = any[]> = (...args: Args) => void;
 
 export interface DebouncedFunction<F extends AnyFn> {
   (...args: Parameters<F>): void;


### PR DESCRIPTION
## Summary
- ensure AutoImage handles undefined src
- make signwell placeholders typed as functions returning strings
- relax debounce argument types
- add searchParams to docs page props

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
