### PR TITLE
Fix TypeScript issues

### DIFF
--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -6,9 +6,12 @@ import path from 'node:path';
 import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
-type DocPageProps = {
-  params: { locale: string; docId: string };
-};
+import type { PageProps } from 'next';
+
+type DocPageProps = PageProps<{
+  locale: string;
+  docId: string;
+}>;
 
 // Revalidate this page every hour for fresh content while caching aggressively
 export const revalidate = 3600;

--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -140,9 +140,10 @@ export default function StartWizardPageClient() {
 
   const debouncedSave = useMemo(
     () =>
-      debounce((data: Record<string, unknown>) => {
-        // Wrap async logic to satisfy debounce's void return type
-        void (async () => {
+      debounce<(data: Record<string, unknown>) => void>(
+        (data) => {
+          // Wrap async logic to satisfy debounce's void return type
+          void (async () => {
           if (
             !docConfig?.id ||
             authIsLoading ||
@@ -186,7 +187,9 @@ export default function StartWizardPageClient() {
             relevantDataToSave,
           );
         })();
-      }, 1000),
+        },
+        1000,
+      ),
     [
       isLoggedIn,
       user?.uid,

--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -2,7 +2,6 @@
 'use client';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -63,8 +62,8 @@ const DropzonePlaceholder = ({
   selectedFile: File | null;
   onClearFile: () => void;
   isHydrated: boolean;
-  tGeneral: TFunction;
-  tEsign: TFunction;
+  tGeneral: (key: string, opts?: Record<string, unknown>) => string;
+  tEsign: (key: string, opts?: Record<string, unknown>) => string;
   onClick?: () => void;
 }) => {
   const [isDragging, setIsDragging] = useState(false);
@@ -533,13 +532,13 @@ export default function SignWellClientContent({
               onClearFile={handleClearFile}
               isHydrated={isHydrated}
               tGeneral={(key, opts) =>
-                t(key, { ...(opts ?? {}), ns: 'common' }) as string
+                t<string>(key, { ...(opts ?? {}), ns: 'common' })
               }
               tEsign={(key, opts) =>
-                t(key, {
+                t<string>(key, {
                   ...(opts ?? {}),
                   ns: 'electronic-signature',
-                }) as string
+                })
               }
               onClick={handleHeroUploadAttempt} // Gated file input trigger
             />

--- a/src/components/AutoImage.tsx
+++ b/src/components/AutoImage.tsx
@@ -5,10 +5,12 @@ import type { StaticImport } from 'next/dist/shared/lib/get-img-props';
 // src/components/AutoImage.tsx
 // FIXED: new component ensuring images always have explicit width and height
 
-interface AutoImageProps extends Omit<ImageProps, 'width' | 'height' | 'src'> {
+interface AutoImageProps
+  extends Omit<ImageProps, 'width' | 'height' | 'src' | 'alt'> {
   width?: number | string;
   height?: number | string;
-  src?: string | StaticImport;
+  src: string | StaticImport;
+  alt?: string;
 }
 
 const AutoImage: React.FC<AutoImageProps> = ({

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -7,7 +7,7 @@ import remarkGfm from 'remark-gfm';
 import { useFormContext } from 'react-hook-form';
 import { Loader2, AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { debounce, type AnyFn } from '@/lib/debounce';
+import { debounce } from '@/lib/debounce';
 import { documentLibrary } from '@/lib/document-library';
 import { cn } from '@/lib/utils';
 import Image from 'next/image';
@@ -133,12 +133,15 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
 
   const debouncedUpdatePreview = useMemo(
     () =>
-      debounce(
-        ((formData: Record<string, unknown>, currentRawMarkdown: string) => {
+      debounce<(
+        formData: Record<string, unknown>,
+        currentRawMarkdown: string
+      ) => void>(
+        (formData, currentRawMarkdown) => {
           setProcessedMarkdown(
             updatePreviewContent(formData, currentRawMarkdown),
           );
-        }) as AnyFn<[Record<string, unknown>, string]>,
+        },
         300,
       ),
     [updatePreviewContent],


### PR DESCRIPTION
## Summary
- adjust `DocPage` props to extend Next.js `PageProps`
- fix `debounce` generics in `StartWizardPageClient` and `PreviewPane`
- simplify translation helpers in signwell client content
- update `AutoImage` typings to require `src` and allow optional `alt`

## Testing
- `npm test`
- `npm run -s typecheck` *(fails: Cannot find type definition file for 'node')*