### PR TITLE
Fix AutoImage props

### DIFF
--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -175,8 +175,8 @@ const DocumentDetail = React.memo(function DocumentDetail({
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage {...props} className="mx-auto" />
+              img: ({ src = '', ...rest }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                <AutoImage src={src} {...rest} className="mx-auto" />
               ),
             }}
           >

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -115,8 +115,8 @@ const DocumentPreview = React.memo(function DocumentPreview({
             components={{
               p: (props) => <p {...props} className="select-none" />,
               // FIXED: ensure images have explicit dimensions
-              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage {...props} className="mx-auto" />
+              img: ({ src = '', ...rest }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                <AutoImage src={src} {...rest} className="mx-auto" />
               ),
             }}
           >

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -218,8 +218,8 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage {...props} className="mx-auto" />
+              img: ({ src = '', ...rest }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                <AutoImage src={src} {...rest} className="mx-auto" />
               ),
             }}
           >


### PR DESCRIPTION
## Summary
- ensure Markdown image handlers always pass a string `src`

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test`