### PR TITLE
Fix type errors in SignWell client

### DIFF
--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -532,13 +532,13 @@ export default function SignWellClientContent({
               onClearFile={handleClearFile}
               isHydrated={isHydrated}
               tGeneral={(key, opts) =>
-                t<string>(key, { ...(opts ?? {}), ns: 'common' })
+                t(key, { ...(opts ?? {}), ns: 'common' }) as string
               }
               tEsign={(key, opts) =>
-                t<string>(key, {
+                t(key, {
                   ...(opts ?? {}),
                   ns: 'electronic-signature',
-                })
+                }) as string
               }
               onClick={handleHeroUploadAttempt} // Gated file input trigger
             />


### PR DESCRIPTION
## Summary
- fix TFunction return type casts in SignWell client content

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*