### PR TITLE
Fix PreviewPane typing errors

### DIFF
--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -218,9 +218,12 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage {...props} className="mx-auto" />
-              ),
+              img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+                const { src = '', alt, ...rest } = props;
+                return (
+                  <AutoImage src={src} alt={alt} {...rest} className="mx-auto" />
+                );
+              },
             }}
           >
             {processedMarkdown}

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,4 +1,5 @@
-export type AnyFn<Args extends unknown[] = unknown[]> = (
+// Allow any argument types for debounced functions
+export type AnyFn<Args extends any[] = any[]> = (
   ..._args: Args
 ) => void;
 


### PR DESCRIPTION
## Summary
- loosen debounce argument constraints
- ensure AutoImage gets a defined src

## Testing
- `npm test`