### PR TITLE
Fix preview debounce type

### DIFF
--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -133,11 +133,8 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
 
   const debouncedUpdatePreview = useMemo(
     () =>
-      debounce<(
-        formData: Record<string, unknown>,
-        currentRawMarkdown: string
-      ) => void>(
-        (formData, currentRawMarkdown) => {
+      debounce(
+        (formData: Record<string, unknown>, currentRawMarkdown: string) => {
           setProcessedMarkdown(
             updatePreviewContent(formData, currentRawMarkdown),
           );
@@ -218,7 +215,10 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
               p: (props) => <p {...props} className="select-none" />,
               h1: (props) => <h1 {...props} className="text-center" />,
               // FIXED: ensure markdown images include dimensions
-              img: ({ src = '', ...rest }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+              img: ({
+                src = '',
+                ...rest
+              }: React.ImgHTMLAttributes<HTMLImageElement>) => (
                 <AutoImage src={src} {...rest} className="mx-auto" />
               ),
             }}


### PR DESCRIPTION
## Summary
- fix `debounce` call in PreviewPane so that it infers parameter types correctly

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test`