### PR TITLE
Fix next lint warnings

### DIFF
--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -134,7 +134,10 @@ export default function PreviewPane({ locale, docId }: PreviewPaneProps) {
   const debouncedUpdatePreview = useMemo(
     () =>
       debounce<
-        (formData: Record<string, unknown>, currentRawMarkdown: string) => void
+        (
+          _formData: Record<string, unknown>,
+          _currentRawMarkdown: string,
+        ) => void
       >((formData, currentRawMarkdown) => {
         setProcessedMarkdown(
           updatePreviewContent(formData, currentRawMarkdown),

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -1,4 +1,4 @@
-export type AnyFn<Args extends unknown[] = any[]> = (
+export type AnyFn<Args extends unknown[] = unknown[]> = (
   ..._args: Args
 ) => void;
 
@@ -8,7 +8,7 @@ export interface DebouncedFunction<Args extends unknown[]> {
 }
 
 export function debounce<Args extends unknown[]>(
-  fn: (...args: Args) => void,
+  fn: (..._args: Args) => void,
   wait: number,
 ): DebouncedFunction<Args> {
   let timer: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
## Summary
- silence unused param warnings in `PreviewPane` debounce type signature
- remove `any` usage in `debounce` helper

## Testing
- `npm test`