### PR TITLE
Add FAQ search & default open

### DIFF
--- a/public/locales/en/doc_bill_of_sale_vehicle.json
+++ b/public/locales/en/doc_bill_of_sale_vehicle.json
@@ -178,4 +178,7 @@
   "finalCtaTitle": "Ready to Close the Deal?",
   "finalCtaSubtitle": "Skip the paperwork stress. Click “Start My Bill of Sale” below, answer a few guided questions, and download your attorney-approved document in minutes.",
   "startMyBillOfSaleButton": "Start My Bill of Sale"
+,
+  "faqSearchPlaceholder": "Search FAQs...",
+  "noFaqResults": "No FAQs match your search."
 }

--- a/public/locales/es/doc_bill_of_sale_vehicle.json
+++ b/public/locales/es/doc_bill_of_sale_vehicle.json
@@ -187,4 +187,7 @@
   "finalCtaTitle": "¿Listo para Cerrar el Trato?",
   "finalCtaSubtitle": "Evita el estrés del papeleo. Haz clic en “Comenzar Mi Contrato de Compraventa” a continuación, responde unas pocas preguntas guiadas y descarga tu documento aprobado por abogados en minutos.",
   "startMyBillOfSaleButton": "Comenzar Mi Contrato de Compraventa"
+,
+  "faqSearchPlaceholder": "Buscar en las preguntas...",
+  "noFaqResults": "Ninguna pregunta coincide con tu búsqueda."
 }

--- a/src/components/docs/VehicleBillOfSaleDisplay.tsx
+++ b/src/components/docs/VehicleBillOfSaleDisplay.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import {
   Accordion,
   AccordionItem,
@@ -53,6 +54,7 @@ export default function VehicleBillOfSaleDisplay({
   const router = useRouter();
   const { addItem } = useCart();
   const [isHydrated, setIsHydrated] = useState(false);
+  const [query, setQuery] = useState('');
 
   useEffect(() => {
     setIsHydrated(true);
@@ -183,7 +185,17 @@ export default function VehicleBillOfSaleDisplay({
     },
   ];
 
-  const allSections: Section[] = [...informationalSections, ...faqItems];
+  const filteredFaqItems = faqItems.filter((faq) => {
+    if (!query) return true;
+    const q = t(faq.titleKey).toLowerCase();
+    const a = faq.contentKey ? t(faq.contentKey).toLowerCase() : '';
+    return q.includes(query.toLowerCase()) || a.includes(query.toLowerCase());
+  });
+
+  const allSections: Section[] = [
+    ...informationalSections,
+    ...filteredFaqItems,
+  ];
 
   const renderSectionContent = (section: Section, translate: typeof t) => {
     if (section.type === 'paragraph' && section.contentKey) {
@@ -363,7 +375,28 @@ export default function VehicleBillOfSaleDisplay({
         <p className="text-lg text-muted-foreground">{t('pageSubtitle')}</p>
       </header>
 
-      <Accordion type="single" collapsible className="w-full space-y-4 mb-10">
+      <div className="flex justify-center mb-6">
+        <Input
+          type="text"
+          placeholder={t('faqSearchPlaceholder', {
+            defaultValue: 'Search FAQs...',
+          })}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="max-w-md"
+        />
+      </div>
+      {query && filteredFaqItems.length === 0 && (
+        <p className="text-center text-sm text-muted-foreground mb-4">
+          {t('noFaqResults', { defaultValue: 'No FAQs match your search.' })}
+        </p>
+      )}
+
+      <Accordion
+        type="multiple"
+        defaultValue={['faq1', 'faq2', 'faq3']}
+        className="w-full space-y-4 mb-10"
+      >
         {allSections.map((section) => (
           <AccordionItem
             key={section.id}


### PR DESCRIPTION
## Summary
- auto-expand the first three FAQ sections for vehicle bill of sale
- add a search bar to filter FAQs
- include translations for new search labels

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*