### PR TITLE
Add lazy-loaded doc preview

### DIFF
--- a/src/components/DocPreview.tsx
+++ b/src/components/DocPreview.tsx
@@ -1,0 +1,143 @@
+// src/components/DocumentPreview.tsx
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { useTranslation } from 'react-i18next';
+import Image from 'next/image';
+import AutoImage from './AutoImage';
+import { Loader2 } from 'lucide-react';
+
+interface DocumentPreviewProps {
+  docId: string;
+  locale?: 'en' | 'es';
+  alt?: string;
+}
+
+const DocumentPreview = React.memo(function DocumentPreview({
+  docId,
+  locale = 'en',
+  alt,
+}: DocumentPreviewProps) {
+  const { t } = useTranslation('common');
+  const [imgExists, setImgExists] = useState<boolean>(true);
+  const [md, setMd] = useState<string>('');
+  const [isLoadingMd, setIsLoadingMd] = useState<boolean>(false);
+  const [errorMd, setErrorMd] = useState<string | null>(null);
+
+  const imgSrc = `/images/previews/${locale}/${docId}.png`;
+  const defaultAlt =
+    alt ??
+    (locale === 'es' ? t(`Vista previa de ${docId}`) : t(`${docId} preview`));
+
+  const handleImgError = () => {
+    console.warn(
+      `[DocumentPreview] Image not found or failed to load: ${imgSrc}. Falling back to Markdown.`,
+    );
+    setImgExists(false);
+  };
+
+  useEffect(() => {
+    if (!imgExists) {
+      setIsLoadingMd(true);
+      setErrorMd(null);
+      fetch(`/templates/${locale}/${docId}.md`)
+        .then((r) => {
+          if (!r.ok) {
+            throw new Error(
+              `Failed to fetch Markdown template (${r.status}): /templates/${locale}/${docId}.md`,
+            );
+          }
+          return r.text();
+        })
+        .then((text) => {
+          setMd(text);
+          setIsLoadingMd(false);
+        })
+        .catch((err) => {
+          console.error(
+            `[DocumentPreview] Error fetching Markdown for ${docId} (${locale}):`,
+            err,
+          );
+          setMd('');
+          setErrorMd(
+            err.message ||
+              t('Error loading preview content.', {
+                defaultValue: 'Error loading preview content.',
+              }),
+          );
+          setIsLoadingMd(false);
+        });
+    }
+  }, [docId, locale, imgExists, t]);
+
+  return (
+    <div className="relative w-full h-full overflow-auto rounded-lg bg-white shadow border border-border">
+      <div className="absolute inset-0 select-none pointer-events-none z-20" />
+      <div
+        className="absolute inset-0 flex items-center justify-center z-10 select-none pointer-events-none
+                   text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-widest opacity-10 rotate-[-35deg] text-muted-foreground"
+      >
+        {locale === 'es'
+          ? t('VISTA PREVIA', 'VISTA PREVIA')
+          : t('PREVIEW', 'PREVIEW')}
+      </div>
+
+      {imgExists ? (
+        <Image
+          src={imgSrc}
+          alt={defaultAlt}
+          width={850}
+          height={1100}
+          loading="lazy" // Added lazy loading
+          className="object-contain w-full h-full"
+          onError={handleImgError}
+          priority={false} // Set to false for lazy loading
+          unoptimized={process.env.NODE_ENV === 'development'}
+          data-ai-hint="document template screenshot"
+        />
+      ) : isLoadingMd ? (
+        <div className="flex flex-col items-center justify-center text-muted-foreground h-full p-4">
+          <Loader2 className="h-6 w-6 animate-spin mb-2" />
+          <p className="text-center text-sm ">
+            {t('Loading preview…', { defaultValue: 'Loading preview…' })}
+          </p>
+        </div>
+      ) : errorMd ? (
+        <p className="text-center text-sm text-destructive p-4 h-full flex items-center justify-center">
+          {errorMd}
+        </p>
+      ) : md ? (
+        <div className="prose prose-sm dark:prose-invert max-w-none w-full h-full overflow-y-auto p-4 md:p-6 bg-background text-foreground">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              p: (props) => <p {...props} className="select-none" />,
+              // FIXED: ensure images have explicit dimensions
+              img: ({
+                src = '',
+                ...rest
+              }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                <AutoImage src={src} {...rest} className="mx-auto" />
+              ),
+            }}
+          >
+            {md}
+          </ReactMarkdown>
+        </div>
+      ) : (
+        <p className="text-center text-sm text-muted-foreground h-full flex items-center justify-center p-4">
+          {t('Preview not available.', {
+            defaultValue: 'Preview not available.',
+          })}
+        </p>
+      )}
+    </div>
+  );
+});
+export default DocumentPreview;
+
+export const SkeletonPreview = () => (
+  <div className="w-full aspect-[8.5/11] bg-muted animate-pulse rounded-lg border border-border" />
+);

--- a/src/components/docs/VehicleBillOfSaleDisplay.tsx
+++ b/src/components/docs/VehicleBillOfSaleDisplay.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -24,6 +25,11 @@ import {
 import { track } from '@/lib/analytics';
 import { useCart } from '@/contexts/CartProvider';
 import { Car } from 'lucide-react';
+import { SkeletonPreview } from '../DocPreview';
+const DocPreview = dynamic(() => import('../DocPreview'), {
+  ssr: false,
+  loading: () => <SkeletonPreview />,
+});
 
 interface VehicleBillOfSaleDisplayProps {
   locale: 'en' | 'es';
@@ -376,6 +382,10 @@ export default function VehicleBillOfSaleDisplay({
         </h1>
         <p className="text-lg text-muted-foreground">{t('pageSubtitle')}</p>
       </header>
+
+      <div className="mx-auto mb-8 max-w-3xl">
+        <DocPreview docId="bill-of-sale-vehicle" locale={locale} />
+      </div>
 
       <div className="flex justify-center mb-6">
         <Input


### PR DESCRIPTION
## Summary
- copy `DocumentPreview` to new `DocPreview` component and export `SkeletonPreview`
- load `DocPreview` dynamically in `VehicleBillOfSaleDisplay`
- render preview with loading skeleton

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*