### PR TITLE
Add mobile CTA and update vehicle bill of sale page

### DIFF
--- a/public/locales/en/doc_bill_of_sale_vehicle.json
+++ b/public/locales/en/doc_bill_of_sale_vehicle.json
@@ -175,6 +175,20 @@
       "answer": "Select “Gift” in Step 3. The price auto-sets to $0 and triggers the proper tax-exemption language."
     }
   },
+  "guideSections": [
+    {
+      "title": "Why you need a bill of sale",
+      "body": "It documents the legal transfer and protects both parties."
+    },
+    {
+      "title": "Key components",
+      "body": "Include names, addresses, price, vehicle details and mileage."
+    },
+    {
+      "title": "How to finalize",
+      "body": "Sign electronically then file with your local DMV."
+    }
+  ],
   "finalCtaTitle": "Ready to Close the Deal?",
   "finalCtaSubtitle": "Skip the paperwork stress. Click “Start My Bill of Sale” below, answer a few guided questions, and download your attorney-approved document in minutes.",
   "startMyBillOfSaleButton": "Start My Bill of Sale"

--- a/public/locales/es/doc_bill_of_sale_vehicle.json
+++ b/public/locales/es/doc_bill_of_sale_vehicle.json
@@ -184,6 +184,20 @@
       "answer": "Selecciona “Regalo” en el Paso 3. El precio se establece automáticamente en $0 y activa el lenguaje de exención de impuestos adecuado."
     }
   },
+  "guideSections": [
+    {
+      "title": "Por qué necesitas un contrato de compraventa",
+      "body": "Documenta la transferencia legal y protege a ambas partes."
+    },
+    {
+      "title": "Componentes clave",
+      "body": "Incluye nombres, direcciones, precio, detalles del vehículo y kilometraje."
+    },
+    {
+      "title": "Cómo finalizar",
+      "body": "Firma electrónicamente y luego preséntalo en tu DMV local."
+    }
+  ],
   "finalCtaTitle": "¿Listo para Cerrar el Trato?",
   "finalCtaSubtitle": "Evita el estrés del papeleo. Haz clic en “Comenzar Mi Contrato de Compraventa” a continuación, responde unas pocas preguntas guiadas y descarga tu documento aprobado por abogados en minutos.",
   "startMyBillOfSaleButton": "Comenzar Mi Contrato de Compraventa"

--- a/src/app/[locale]/docs/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/DocPageClient.tsx
@@ -13,6 +13,8 @@ import {
   Loader2,
   Star,
   ShieldCheck,
+  Clock,
+  RotateCcw,
   Zap,
   HelpCircle,
   Award,
@@ -362,14 +364,20 @@ export default function DocPageClient({
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-3">
-              <div className="flex items-baseline justify-between">
-                <span className="text-3xl font-bold text-foreground">
-                  ${docConfig.basePrice.toFixed(2)}
-                </span>
-                <span className="text-sm text-muted-foreground">
-                  {t('pricing.perDocument', { defaultValue: 'per document' })}
-                </span>
-              </div>
+              <p className="text-2xl font-bold">
+                ${docConfig.basePrice.toFixed(2)}
+              </p>
+              <ul className="mt-3 space-y-1 text-sm">
+                <li className="flex items-center gap-2">
+                  <ShieldCheck className="h-4 w-4 text-teal-600" /> Attorney-approved
+                </li>
+                <li className="flex items-center gap-2">
+                  <Clock className="h-4 w-4 text-teal-600" /> Ready in 3 minutes
+                </li>
+                <li className="flex items-center gap-2">
+                  <RotateCcw className="h-4 w-4 text-teal-600" /> 100 % money-back guarantee
+                </li>
+              </ul>
               <p className="text-xs text-muted-foreground">
                 {t('docDetail.competitivePrice', {
                   competitorPrice: competitorPrice.toFixed(2),

--- a/src/components/StickyMobileCTA.tsx
+++ b/src/components/StickyMobileCTA.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useEffect, useState } from "react";
+export default function StickyMobileCTA() {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    const onScroll = () => setShow(window.scrollY > 400);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+  if (!show) return null;
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 bg-white/95 shadow-lg md:hidden">
+      <div className="mx-auto flex max-w-xl items-center justify-between px-4 py-3">
+        <span className="font-semibold">$19.95 • attorney-drafted</span>
+        <button className="btn-primary">Start My Bill of Sale</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/docs/VehicleBillOfSaleDisplay.tsx
+++ b/src/components/docs/VehicleBillOfSaleDisplay.tsx
@@ -24,7 +24,8 @@ import {
 } from '@/components/ui/table';
 import { track } from '@/lib/analytics';
 import { useCart } from '@/contexts/CartProvider';
-import { Car } from 'lucide-react';
+import { Car, Edit, Signature, ShieldCheck } from 'lucide-react';
+import StickyMobileCTA from '@/components/StickyMobileCTA';
 import { SkeletonPreview } from '../DocPreview';
 const DocPreview = dynamic(() => import('../DocPreview'), {
   ssr: false,
@@ -62,6 +63,10 @@ export default function VehicleBillOfSaleDisplay({
   const { addItem } = useCart();
   const [isHydrated, setIsHydrated] = useState(false);
   const [query, setQuery] = useState('');
+  const guideSections = t('guideSections', { returnObjects: true }) as {
+    title: string;
+    body: string;
+  }[];
 
   useEffect(() => {
     setIsHydrated(true);
@@ -422,6 +427,32 @@ export default function VehicleBillOfSaleDisplay({
         />
       </section>
 
+      <ol className="mx-auto my-8 grid max-w-4xl gap-6 md:grid-cols-3">
+        {[
+          { icon: Edit, title: 'Answer 9 questions', copy: 'Takes 3 min' },
+          { icon: Signature, title: 'Download & e-Sign', copy: 'Legally binding' },
+          { icon: ShieldCheck, title: 'Store & Share', copy: 'Bank-grade security' },
+        ].map(({ icon: IconComp, title, copy }) => (
+          <li key={title} className="flex items-start gap-4">
+            <IconComp className="h-8 w-8 text-teal-500" />
+            <div>
+              <p className="font-medium">{title}</p>
+              <p className="text-sm text-gray-600">{copy}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <section className="prose mx-auto max-w-2xl">
+        <h2>Vehicle Bill of Sale: Plain-English Guide</h2>
+        {guideSections.map((s, i) => (
+          <details key={i} open={i === 0} className="mb-4 rounded-lg bg-gray-50 p-4">
+            <summary className="cursor-pointer font-semibold">{s.title}</summary>
+            <p className="mt-2">{s.body}</p>
+          </details>
+        ))}
+      </section>
+
       <div className="container mx-auto px-4 py-12">
 
         <div className="flex justify-center mb-6">
@@ -502,6 +533,7 @@ export default function VehicleBillOfSaleDisplay({
           )}
         </section>
       </div>
+      <StickyMobileCTA />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add StickyMobileCTA component
- insert mobile CTA into vehicle bill of sale display
- show three-step how-it-works section and plain-English guide
- enhance price card with benefit bullets
- add `guideSections` content to translations

## Testing
- `npm test`