### PR TITLE
Add Firestore reviews seed script and placeholder carousel

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /reviews/{docId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.admin == true;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules for the reviews collection
- replace the seedReviews script with a one-time seeder
- show a placeholder message when there are no testimonials

## Testing
- `npm test`