### PR TITLE
Enable dynamic testimonials loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "node --test tests/prettify.test.js",
     "gen:previews": "node --experimental-modules scripts/generate-previews.js",
     "extract:i18n": "node_modules/.bin/i18next-parser \"src/**/*.{ts,tsx}\" --config i18next-parser.config.js",
-    "seed:reviews": "node scripts/seed-reviews.ts"
+    "seed:reviews": "node scripts/seed-reviews.ts",
+    "generate:doc": "tsx scripts/generate-doc.ts"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.6.2",

--- a/scripts/generate-doc.ts
+++ b/scripts/generate-doc.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+
+const slug = process.argv[2];
+if (!slug) throw new Error('Usage: npm run generate:doc <slug>');
+
+const reviewStub = `import { Review } from '@/types';
+export const reviews: Review[] = [
+  {
+    name: 'First Last',
+    location: 'City, ST',
+    rating: 5,
+    quote: 'Describe how the ${slug} template saved time / money here.',
+  },
+];
+`;
+
+fs.mkdirSync('src/data/reviews', { recursive: true });
+fs.writeFileSync(`src/data/reviews/${slug}.ts`, reviewStub);
+console.log(`✅  Created src/data/reviews/${slug}.ts`);

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -7,7 +7,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from '@/components/ui/carousel';
-import type { Review } from '@/types/reviews';
+import type { Review } from '@/types';
 
 export default function Carousel({ reviews }: { reviews: Review[] }) {
   return (
@@ -15,11 +15,17 @@ export default function Carousel({ reviews }: { reviews: Review[] }) {
       <BaseCarousel className="relative">
         <CarouselContent>
           {reviews.map((r, idx) => (
-            <CarouselItem key={idx} className="basis-3/4 sm:basis-1/2 md:basis-1/3">
+            <CarouselItem
+              key={idx}
+              className="basis-3/4 sm:basis-1/2 md:basis-1/3"
+            >
               <div className="p-4 bg-card border border-border rounded-lg shadow-sm h-full flex flex-col text-center">
                 <div className="flex justify-center mb-2">
                   {Array.from({ length: Math.round(r.rating) }).map((_, i) => (
-                    <Star key={i} className="h-4 w-4 text-yellow-400 fill-yellow-400" />
+                    <Star
+                      key={i}
+                      className="h-4 w-4 text-yellow-400 fill-yellow-400"
+                    />
                   ))}
                 </div>
                 <p className="text-sm italic mb-2">&ldquo;{r.quote}&rdquo;</p>

--- a/src/components/TestimonialsCarousel.tsx
+++ b/src/components/TestimonialsCarousel.tsx
@@ -1,12 +1,22 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import Carousel from './Carousel';
-import { vehicleBillOfSaleReviews } from '@/data/reviews/vehicle-bill-of-sale';
-import type { Review } from '@/types/reviews';
+import { Spinner } from '@/components/ui/Spinner';
+import type { Review } from '@/types';
 
-export default function TestimonialsCarousel({ templateId }: { templateId: string }) {
-  const reviews: Review[] =
-    templateId === 'vehicle-bill-of-sale' ? vehicleBillOfSaleReviews : [];
+export default function TestimonialsCarousel({
+  templateId,
+}: {
+  templateId: string;
+}) {
+  const [reviews, setReviews] = useState<Review[] | null>(null);
 
+  useEffect(() => {
+    import(`@/data/reviews/${templateId}.ts`)
+      .then((mod) => setReviews(mod.reviews as Review[]))
+      .catch(() => setReviews([]));
+  }, [templateId]);
+
+  if (reviews === null) return <Spinner className="my-12" />;
   if (reviews.length === 0) return null;
   return <Carousel reviews={reviews} />;
 }

--- a/src/data/reviews/vehicle-bill-of-sale.ts
+++ b/src/data/reviews/vehicle-bill-of-sale.ts
@@ -1,6 +1,6 @@
-import { Review } from '@/types/reviews';
+import { Review } from '@/types';
 
-export const vehicleBillOfSaleReviews: Review[] = [
+export const reviews: Review[] = [
   {
     name: 'Michelle R.',
     location: 'Austin, TX',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
-export type Review = {
+export interface Review {
   name: string;
   location: string;
   rating: number;
   quote: string;
-};
+}


### PR DESCRIPTION
## Summary
- dynamically import reviews based on template
- standardize review export
- create `generate:doc` script for scaffolding review files
- expose shared `Review` interface

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'react', etc.)*