### PR TITLE
Add sticky CTA & related docs cross-sell

### DIFF
--- a/src/app/[locale]/docs/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/DocPageClient.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/components/ui/accordion';
 import VehicleBillOfSaleDisplay from '@/components/docs/VehicleBillOfSaleDisplay'; // Import the specific display component
 import PromissoryNoteDisplay from '@/components/docs/PromissoryNoteDisplay';
+import RelatedDocs from '@/components/RelatedDocs';
 
 // Lazy load template-specific testimonials section
 const TestimonialsCarousel = dynamic(
@@ -364,40 +365,45 @@ export default function DocPageClient({
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-3">
-              <div className="flex items-baseline justify-between">
-                <p className="text-2xl font-bold">
-                  ${docConfig.basePrice.toFixed(2)}
-                </p>
-                <span className="text-sm text-muted-foreground">
-                  {t('pricing.perDocument', { defaultValue: 'per document' })}
-                </span>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {t('docDetail.competitivePrice', {
-                  competitorPrice: competitorPrice.toFixed(2),
-                  defaultValue: `Compare to typical attorney fees of $${competitorPrice.toFixed(2)}+`,
-                })}
-              </p>
-              <ul className="mt-3 space-y-1 text-sm">
-                <li className="flex items-center gap-2">
-                  <ShieldCheck className="h-4 w-4 text-teal-600" /> Attorney-approved
-                </li>
-                <li className="flex items-center gap-2">
-                  <Clock className="h-4 w-4 text-teal-600" /> Ready in 3 minutes
-                </li>
-                <li className="flex items-center gap-2">
-                  <RotateCcw className="h-4 w-4 text-teal-600" /> 100 % money-back guarantee
-                </li>
-              </ul>
-              <Button
-                size="lg"
-                className="w-full mt-2"
-                onClick={handleStartWizard}
-                disabled={!isHydrated}
-              >
-                {t('Start For Free', { defaultValue: 'Start For Free' })}
-              </Button>
-            </CardContent>
+                  <div className="flex items-baseline justify-between">
+                    <p className="text-2xl font-bold">
+                      ${docConfig.basePrice.toFixed(2)}
+                    </p>
+                    <span className="text-sm text-muted-foreground">
+                      {t('pricing.perDocument', {
+                        defaultValue: 'per document',
+                      })}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {t('docDetail.competitivePrice', {
+                      competitorPrice: competitorPrice.toFixed(2),
+                      defaultValue: `Compare to typical attorney fees of $${competitorPrice.toFixed(2)}+`,
+                    })}
+                  </p>
+                  <ul className="mt-3 space-y-1 text-sm">
+                    <li className="flex items-center gap-2">
+                      <ShieldCheck className="h-4 w-4 text-teal-600" />{' '}
+                      Attorney-approved
+                    </li>
+                    <li className="flex items-center gap-2">
+                      <Clock className="h-4 w-4 text-teal-600" /> Ready in 3
+                      minutes
+                    </li>
+                    <li className="flex items-center gap-2">
+                      <RotateCcw className="h-4 w-4 text-teal-600" /> 100 %
+                      money-back guarantee
+                    </li>
+                  </ul>
+                  <Button
+                    size="lg"
+                    className="w-full mt-2"
+                    onClick={handleStartWizard}
+                    disabled={!isHydrated}
+                  >
+                    {t('Start For Free', { defaultValue: 'Start For Free' })}
+                  </Button>
+                </CardContent>
               </Card>
             </div>
           </div>
@@ -526,6 +532,8 @@ export default function DocPageClient({
       <div className="mt-16">
         <TestimonialsCarousel templateId={docConfig.id} />
       </div>
+
+      <RelatedDocs docId={docConfig.id} />
 
       {/* Sticky CTA for mobile */}
       <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-t p-4 shadow-lg z-40">

--- a/src/components/RelatedDocs.tsx
+++ b/src/components/RelatedDocs.tsx
@@ -1,0 +1,28 @@
+import related from '@/data/relatedDocs.json';
+import Link from 'next/link';
+
+export default function RelatedDocs({ docId }: { docId: string }) {
+  const list =
+    (related as Record<string, { slug: string; title: string }[]>)[docId] ?? [];
+  if (!list.length) return null;
+  return (
+    <section className="my-16 max-w-4xl mx-auto">
+      <h2 className="mb-6 text-xl font-semibold">
+        People who bought this also needed
+      </h2>
+      <ul className="grid gap-4 md:grid-cols-3">
+        {list.map((d) => (
+          <li key={d.slug} className="rounded-lg border p-4">
+            <p className="mb-2 font-medium">{d.title}</p>
+            <Link
+              href={`/docs/${d.slug}`}
+              className="text-sm text-teal-600 underline"
+            >
+              Preview template →
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/StickyDesktopCTA.tsx
+++ b/src/components/StickyDesktopCTA.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function StickyDesktopCTA() {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    const onScroll = () =>
+      setShow(window.scrollY > 400 && window.innerWidth >= 1024);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+  if (!show) return null;
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 hidden lg:block">
+      <div className="mx-auto flex max-w-4xl items-center justify-between rounded-t-lg bg-white/95 px-6 py-4 shadow-lg">
+        <p className="text-sm font-medium">Ready to download?</p>
+        <Button>Start My Bill of Sale</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/docs/VehicleBillOfSaleDisplay.tsx
+++ b/src/components/docs/VehicleBillOfSaleDisplay.tsx
@@ -26,6 +26,7 @@ import { useCart } from '@/contexts/CartProvider';
 import { Car, Edit, Signature, ShieldCheck } from 'lucide-react';
 import { BookOpen } from 'lucide-react';
 import StickyMobileCTA from '@/components/StickyMobileCTA';
+import StickyDesktopCTA from '@/components/StickyDesktopCTA';
 
 interface VehicleBillOfSaleDisplayProps {
   locale: 'en' | 'es';
@@ -65,6 +66,14 @@ export default function VehicleBillOfSaleDisplay({
       i18n.changeLanguage(locale);
     }
   }, [locale, i18n]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.location.hash) {
+      document
+        .querySelector(window.location.hash)
+        ?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, []);
 
   const handleStartProcess = () => {
     if (!isHydrated) return;
@@ -199,6 +208,19 @@ export default function VehicleBillOfSaleDisplay({
     ...informationalSections,
     ...filteredFaqItems,
   ];
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqItems.map((faq) => ({
+      '@type': 'Question',
+      name: t(faq.titleKey),
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.contentKey ? t(faq.contentKey) : '',
+      },
+    })),
+  };
 
   const renderSectionContent = (section: Section, translate: typeof t) => {
     if (section.type === 'paragraph' && section.contentKey) {
@@ -371,7 +393,6 @@ export default function VehicleBillOfSaleDisplay({
 
   return (
     <section aria-label="Vehicle Bill of Sale">
-
       <div className="container mx-auto px-4 pt-6 text-center">
         <h2 className="flex items-center gap-2 text-2xl font-semibold">
           <BookOpen aria-hidden="true" className="h-6 w-6 text-teal-600" />
@@ -385,8 +406,16 @@ export default function VehicleBillOfSaleDisplay({
       <ol className="mx-auto my-8 grid max-w-4xl gap-6 md:grid-cols-3">
         {[
           { Icon: Edit, title: 'Answer 9 questions', copy: 'Takes 3 min' },
-          { Icon: Signature, title: 'Download & e-Sign', copy: 'Legally binding' },
-          { Icon: ShieldCheck, title: 'Store & Share', copy: 'Bank-grade security' },
+          {
+            Icon: Signature,
+            title: 'Download & e-Sign',
+            copy: 'Legally binding',
+          },
+          {
+            Icon: ShieldCheck,
+            title: 'Store & Share',
+            copy: 'Bank-grade security',
+          },
         ].map(({ Icon, title, copy }) => (
           <li key={title} className="flex items-start gap-4">
             <Icon className="h-8 w-8 text-teal-500" />
@@ -399,7 +428,6 @@ export default function VehicleBillOfSaleDisplay({
       </ol>
 
       <div className="container mx-auto px-4 py-12">
-
         <div className="flex justify-center mb-6">
           <Input
             type="text"
@@ -425,6 +453,7 @@ export default function VehicleBillOfSaleDisplay({
           {allSections.map((section) => (
             <AccordionItem
               key={section.id}
+              id={section.id}
               value={section.id}
               className="border border-border rounded-lg bg-card shadow-md"
             >
@@ -477,6 +506,11 @@ export default function VehicleBillOfSaleDisplay({
         </section>
       </div>
       <StickyMobileCTA locale={locale} />
+      <StickyDesktopCTA />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
     </section>
   );
 }

--- a/src/data/relatedDocs.json
+++ b/src/data/relatedDocs.json
@@ -1,0 +1,10 @@
+{
+  "bill-of-sale-vehicle": [
+    { "slug": "power-of-attorney", "title": "Vehicle Power of Attorney" },
+    {
+      "slug": "vehicle-release-of-liability",
+      "title": "Vehicle Liability Release"
+    },
+    { "slug": "odometer-disclosure", "title": "Odometer Disclosure" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add desktop sticky CTA
- add related docs data and component
- show sticky desktop CTA on the bill of sale page
- link FAQ anchors and JSON-LD
- surface related docs cross-sell on doc pages

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `npm run format`