### PR TITLE
Implement fade animation and mobile FAQ search focus

### DIFF
--- a/src/app/[locale]/docs/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/DocPageClient.tsx
@@ -356,7 +356,10 @@ export default function DocPageClient({
 
         <aside className="md:col-span-2 space-y-6">
           <div className="relative">
-            <div className="sticky top-24" data-testid="price-sticky">
+            <div
+              className="sticky top-24 [animation:fadeUp_0.4s_ease-out]"
+              data-testid="price-sticky"
+            >
               <Card className="shadow-lg border-primary">
                 <CardHeader>
                   <CardTitle className="text-lg text-primary">

--- a/src/app/[locale]/faq/faq-client-content.tsx
+++ b/src/app/[locale]/faq/faq-client-content.tsx
@@ -1,7 +1,7 @@
 // src/app/[locale]/faq/faq-client-content.tsx
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Accordion,
@@ -19,6 +19,7 @@ export default function FaqClientContent({ locale }: FaqClientContentProps) {
   const { t, i18n } = useTranslation(['faq', 'common']);
   const [isHydrated, setIsHydrated] = useState(false);
   const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     setIsHydrated(true);
@@ -26,6 +27,13 @@ export default function FaqClientContent({ locale }: FaqClientContentProps) {
       i18n.changeLanguage(locale);
     }
   }, [locale, i18n]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.innerWidth < 640) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, []);
 
   const placeholderTitle = 'Frequently Asked Questions';
   const placeholderSubtitle = 'Find answers to common questions below.';
@@ -64,6 +72,10 @@ export default function FaqClientContent({ locale }: FaqClientContentProps) {
         placeholder="Search FAQs..."
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        ref={inputRef}
+        onFocus={() =>
+          window.innerWidth < 640 && inputRef.current?.select()
+        }
         className="mb-4 w-full rounded-md border px-3 py-2"
       />
       <Accordion

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,7 +119,7 @@
   @keyframes fadeUp {
     from {
       opacity: 0;
-      transform: translateY(8px);
+      transform: translateY(20px);
     }
     to {
       opacity: 1;


### PR DESCRIPTION
## Summary
- add fadeUp scroll animation to pricing card
- tune fadeUp CSS animation for smoother effect
- auto-focus FAQ search on mobile devices

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module declarations)*