### PR TITLE
Make StickyGuaranteeBar clickable and dynamic

### DIFF
--- a/src/components/StickyGuaranteeBar.tsx
+++ b/src/components/StickyGuaranteeBar.tsx
@@ -1,11 +1,18 @@
 "use client";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
-export default function StickyGuaranteeBar() {
+interface Props {
+  href: string; // where the click should go
+  label: string; // text to display
+}
+
+export default function StickyGuaranteeBar({ href, label }: Props) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 600);
+    const onScroll = () =>
+      setVisible(window.scrollY > 600 && window.innerWidth >= 1024);
     window.addEventListener("scroll", onScroll);
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
@@ -13,8 +20,11 @@ export default function StickyGuaranteeBar() {
   if (!visible) return null;
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 bg-teal-50 text-teal-900 text-center py-2 shadow-md">
-      <span className="font-medium">Download today • 30-day refund guarantee</span>
-    </div>
+    <Link
+      href={href}
+      className="fixed inset-x-0 bottom-0 z-40 flex items-center justify-center bg-teal-50 py-3 text-teal-900 shadow-md hover:bg-teal-100 transition-colors"
+    >
+      <span className="text-sm font-medium">{label}</span>
+    </Link>
   );
 }

--- a/src/components/docs/VehicleBillOfSaleDisplay.tsx
+++ b/src/components/docs/VehicleBillOfSaleDisplay.tsx
@@ -467,7 +467,10 @@ export default function VehicleBillOfSaleDisplay({
         </section>
       </div>
       <StickyMobileCTA locale={locale} />
-      <StickyGuaranteeBar />
+      <StickyGuaranteeBar
+        href={`/${locale}/docs/bill-of-sale-vehicle/start`}
+        label="Create your Vehicle Bill of Sale in 5 minutes — download, print & share"
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- update `StickyGuaranteeBar` to accept `href` and `label` props
- update Vehicle Bill of Sale display page to pass these props when rendering `StickyGuaranteeBar`

## Testing
- `npm test`