### PR TITLE
Refactor document barrels

### DIFF
--- a/src/lib/documents/us/promissory-note/index.ts
+++ b/src/lib/documents/us/promissory-note/index.ts
@@ -1,4 +1,20 @@
 // src/lib/documents/us/promissory-note/index.ts
-export { promissoryNoteMeta as promissoryNote } from './metadata';
+import path from 'path';
+import * as schema from './schema';
+import * as questions from './questions';
+import { promissoryNoteMeta } from './metadata';
+
+export const document = {
+  id: 'promissory-note',
+  country: 'us',
+  languages: ['en', 'es'],
+  templatePath: (lang: string) =>
+    path.join(__dirname, `template.${lang}.md`),
+  schema,
+  questions,
+  marketing: promissoryNoteMeta,
+} as const;
+
+export { document as promissoryNote };
 export * from './schema'; // Keep this if other parts of your app import schema directly from here
 export * from './questions'; // Keep this if other parts of your app import questions directly from here

--- a/src/lib/documents/us/vehicle-bill-of-sale/index.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/index.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import * as schema from './schema';
 import * as questions from './questions';
 import * as compliance from './compliance';
@@ -8,7 +9,7 @@ export const document = {
   country: 'us',
   languages: ['en', 'es'],
   templatePath: (lang: string) =>
-    require.resolve(`./template.${lang}.md`),
+    path.join(__dirname, `template.${lang}.md`),
   schema,
   questions,
   marketing,


### PR DESCRIPTION
## Summary
- expose markdown paths in `promissory-note` and `vehicle-bill-of-sale`

## Testing
- `npm run build` *(fails: Cannot find package 'puppeteer')*