### PR TITLE
Fix vehicle Bill of Sale doc wiring

### DIFF
--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -60,14 +60,21 @@ export default async function DocPage({ params }: DocPageProps) {
   // Await a microtask to comply with Next.js dynamic param handling
   await Promise.resolve();
 
-  const filePath = path.join(
-    process.cwd(),
-    'public',
-    'templates',
-    params.locale,
-    `${params.docId}.md`,
-  );
+  const doc = documentLibrary.find((d) => d.id === params.docId);
   let markdownContent: string | null = null;
+
+  let filePath: string | null = null;
+  if (doc && typeof (doc as any).templatePath === 'function') {
+    filePath = (doc as any).templatePath(params.locale);
+  } else {
+    filePath = path.join(
+      process.cwd(),
+      'public',
+      'templates',
+      params.locale,
+      `${params.docId}.md`,
+    );
+  }
 
   try {
     markdownContent = await fs.readFile(filePath, 'utf-8');

--- a/src/lib/documents/us/vehicle-bill-of-sale/index.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/index.ts
@@ -1,17 +1,16 @@
 import path from 'path';
-import * as schema from './schema';
-import * as questions from './questions';
-import * as compliance from './compliance';
-import { marketing } from './metadata';
+import { vehicleBillOfSaleMeta } from './metadata';
+import { VehicleBillOfSaleCompliance } from './compliance';
 
-export const document = {
-  id: 'bill-of-sale-vehicle',
-  country: 'us',
-  languages: ['en', 'es'],
+export const vehicleBillOfSale = {
+  ...vehicleBillOfSaleMeta,
+  compliance: VehicleBillOfSaleCompliance,
   templatePath: (lang: string) =>
     path.join(__dirname, `template.${lang}.md`),
-  schema,
-  questions,
-  marketing,
-  compliance,
-} as const;
+};
+
+export { vehicleBillOfSale as document };
+
+export * from './schema';
+export * from './questions';
+export * from './compliance';


### PR DESCRIPTION
## Summary
- re-export metadata info for vehicle Bill of Sale and expose templatePath helper
- read markdown using document templatePath on doc page

## Testing
- `npm run build` *(fails: Cannot find package 'puppeteer')*
- `npm run start` *(fails: Cannot find package 'next')*