### PR TITLE
Remove screenshot previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 9002",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
-    "build": "NODE_OPTIONS='--max_old_space_size=4096' npm run gen:previews && next build",
+    "build": "next build",
     "start": "NODE_ENV=production node server.mjs",
     "lint": "next lint",
     "format": "prettier --write .",

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -3,7 +3,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import DocPageClient from './DocPageClient';
+import DocumentPreview from '@/components/DocumentPreview';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
 import { vehicleBillOfSaleFaqs } from '@/app/[locale]/documents/bill-of-sale-vehicle/faqs';
@@ -92,9 +92,7 @@ export default async function DocPage({ params }: DocPageProps) {
     }
   }
 
-  // The `params` prop is directly available here from Next.js
-  // It's then passed down to the client component.
-  return <DocPageClient params={params} markdownContent={markdownContent} />;
+  return <DocumentPreview markdown={markdownContent ?? ''} />;
 }
 
 export function Head({ params }: { params: DocPageParams }) {

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -1,139 +1,23 @@
-// src/components/DocumentPreview.tsx
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { useTranslation } from 'react-i18next';
-import Image from 'next/image';
-import AutoImage from './AutoImage';
-import { Loader2 } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
 
-interface DocumentPreviewProps {
-  docId: string;
-  locale?: 'en' | 'es';
-  alt?: string;
+const DocumentDetail = dynamic(() => import('@/components/DocumentDetail'), {
+  ssr: false,
+});
+
+interface Props {
+  markdown: string;
 }
 
-const DocumentPreview = React.memo(function DocumentPreview({
-  docId,
-  locale = 'en',
-  alt,
-}: DocumentPreviewProps) {
-  const { t } = useTranslation('common');
-  const [imgExists, setImgExists] = useState<boolean>(true);
-  const [md, setMd] = useState<string>('');
-  const [isLoadingMd, setIsLoadingMd] = useState<boolean>(false);
-  const [errorMd, setErrorMd] = useState<string | null>(null);
-
-  const imgSrc = `/images/previews/${locale}/${docId}.png`;
-  const defaultAlt =
-    alt ??
-    (locale === 'es' ? t(`Vista previa de ${docId}`) : t(`${docId} preview`));
-
-  const handleImgError = () => {
-    console.warn(
-      `[DocumentPreview] Image not found or failed to load: ${imgSrc}. Falling back to Markdown.`,
-    );
-    setImgExists(false);
-  };
-
-  useEffect(() => {
-    if (!imgExists) {
-      setIsLoadingMd(true);
-      setErrorMd(null);
-      fetch(`/templates/${locale}/${docId}.md`)
-        .then((r) => {
-          if (!r.ok) {
-            throw new Error(
-              `Failed to fetch Markdown template (${r.status}): /templates/${locale}/${docId}.md`,
-            );
-          }
-          return r.text();
-        })
-        .then((text) => {
-          setMd(text);
-          setIsLoadingMd(false);
-        })
-        .catch((err) => {
-          console.error(
-            `[DocumentPreview] Error fetching Markdown for ${docId} (${locale}):`,
-            err,
-          );
-          setMd('');
-          setErrorMd(
-            err.message ||
-              t('Error loading preview content.', {
-                defaultValue: 'Error loading preview content.',
-              }),
-          );
-          setIsLoadingMd(false);
-        });
-    }
-  }, [docId, locale, imgExists, t]);
-
+export default function DocumentPreview({ markdown }: Props) {
   return (
-    <div className="relative w-full h-full overflow-auto rounded-lg bg-white shadow border border-border">
-      <div className="absolute inset-0 select-none pointer-events-none z-20" />
-      <div
-        className="absolute inset-0 flex items-center justify-center z-10 select-none pointer-events-none
-                   text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-widest opacity-10 rotate-[-35deg] text-muted-foreground"
-      >
-        {locale === 'es'
-          ? t('VISTA PREVIA', 'VISTA PREVIA')
-          : t('PREVIEW', 'PREVIEW')}
-      </div>
-
-      {imgExists ? (
-        <Image
-          src={imgSrc}
-          alt={defaultAlt}
-          width={850}
-          height={1100}
-          loading="lazy" // Added lazy loading
-          className="object-contain w-full h-full"
-          onError={handleImgError}
-          priority={false} // Set to false for lazy loading
-          unoptimized={process.env.NODE_ENV === 'development'}
-          data-ai-hint="document template screenshot"
-        />
-      ) : isLoadingMd ? (
-        <div className="flex flex-col items-center justify-center text-muted-foreground h-full p-4">
-          <Loader2 className="h-6 w-6 animate-spin mb-2" />
-          <p className="text-center text-sm ">
-            {t('Loading preview…', { defaultValue: 'Loading preview…' })}
-          </p>
-        </div>
-      ) : errorMd ? (
-        <p className="text-center text-sm text-destructive p-4 h-full flex items-center justify-center">
-          {errorMd}
-        </p>
-      ) : md ? (
-        <div className="prose prose-sm dark:prose-invert max-w-none w-full h-full overflow-y-auto p-4 md:p-6 bg-background text-foreground">
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              p: (props) => <p {...props} className="select-none" />,
-              // FIXED: ensure images have explicit dimensions
-              img: ({
-                src = '',
-                ...rest
-              }: React.ImgHTMLAttributes<HTMLImageElement>) => (
-                <AutoImage src={src} {...rest} className="mx-auto" />
-              ),
-            }}
-          >
-            {md}
-          </ReactMarkdown>
-        </div>
-      ) : (
-        <p className="text-center text-sm text-muted-foreground h-full flex items-center justify-center p-4">
-          {t('Preview not available.', {
-            defaultValue: 'Preview not available.',
-          })}
-        </p>
-      )}
+    <div className="border rounded-lg overflow-hidden h-[720px]">
+      <Suspense fallback={<Skeleton className="w-full h-full" />}>
+        <DocumentDetail markdownContent={markdown} liveData={null} />
+      </Suspense>
     </div>
   );
-});
-export default DocumentPreview;
+}


### PR DESCRIPTION
## Summary
- remove preview generation from build step
- simplify document preview component
- show live Markdown preview on doc page

## Testing
- `npx rimraf .next public/images/previews` *(fails: next not installed)*
- `npm run build` *(fails: next not installed)*
- `npm run start` *(fails: cannot find package 'next')*
- `curl -I http://localhost:3000/en/docs/bill-of-sale-vehicle` *(fails: couldn't connect)*