### PR TITLE
Fix dynamic import for Generate page

### DIFF
--- a/src/app/generate/page.tsx
+++ b/src/app/generate/page.tsx
@@ -1,9 +1,6 @@
 // src/app/generate/page.tsx
 import React from 'react';
-import dynamic from 'next/dynamic';
-const DocumentFlow = dynamic(() => import('@/components/DocumentFlow'), {
-  ssr: false,
-});
+import GenerateClient from '@/components/GenerateClient';
 import { Button } from '@/components/ui/button';
 
 export default function GeneratePage() {
@@ -12,7 +9,7 @@ export default function GeneratePage() {
       <h1 className="text-3xl font-bold mb-8">Generate Document</h1>
 
       <div className="max-w-3xl mx-auto">
-        <DocumentFlow />
+        <GenerateClient />
         <div className="mt-8">
           <Button className="bg-gradient-to-r from-electric-500 to-electric-700 hover:to-electric-600 text-white shadow-glass">
             Continue

--- a/src/components/GenerateClient.tsx
+++ b/src/components/GenerateClient.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const DocumentFlow = dynamic(() => import('@/components/DocumentFlow'), {
+  ssr: false,
+});
+
+export default DocumentFlow;


### PR DESCRIPTION
## Summary
- create `GenerateClient` wrapper so `DocumentFlow` runs client-side
- use the new wrapper in `src/app/generate/page.tsx`

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*