### PR TITLE
Fix generate page to use GenerateClient

### DIFF
--- a/src/app/generate/page.tsx
+++ b/src/app/generate/page.tsx
@@ -1,4 +1,3 @@
-'use client';
 // src/app/generate/page.tsx
 import React from 'react';
 import GenerateClient from '@/components/GenerateClient';
@@ -9,7 +8,7 @@ export default function GeneratePage() {
       <h1 className="text-3xl font-bold mb-8">Generate Document</h1>
 
       <div className="max-w-3xl mx-auto">
-        <DocumentFlow />
+        <GenerateClient />
         <div className="mt-8">
           <Button className="bg-gradient-to-r from-electric-500 to-electric-700 hover:to-electric-600 text-white shadow-glass">
             Continue

--- a/src/components/GenerateClient.tsx
+++ b/src/components/GenerateClient.tsx
@@ -1,4 +1,3 @@
-tsx
 'use client';
 
 import dynamic from 'next/dynamic';
@@ -7,4 +6,6 @@ const DocumentFlow = dynamic(() => import('@/components/DocumentFlow'), {
   ssr: false,
 });
 
-export default DocumentFlow;
+export default function GenerateClient() {
+  return <DocumentFlow />;
+}


### PR DESCRIPTION
## Summary
- remove direct DocumentFlow usage
- call `GenerateClient` client component from server page
- ensure GenerateClient exports a functional wrapper around DocumentFlow

## Testing
- `npm test`
