### PR TITLE
Fix markdown preview hydration

### DIFF
--- a/src/app/[locale]/docs/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/DocPageClient.tsx
@@ -59,6 +59,7 @@ type DocumentDetailComponent = React.ComponentType<DocumentDetailProps> & {
 };
 
 const DocumentDetail = dynamic(() => import('@/components/DocumentDetail'), {
+  ssr: false,
   loading: () => (
     <div className="flex items-center justify-center border rounded-lg bg-muted p-4 aspect-[8.5/11] max-h-[500px] md:max-h-[700px] w-full shadow-lg">
       <Loader2 className="h-8 w-8 animate-spin text-primary" />


### PR DESCRIPTION
## Summary
- disable SSR for DocumentDetail dynamic import so hydration occurs client-side
- render markdown using MarkdownIt on the client

## Testing
- `npm test`