### PR TITLE
Fix param usage order and log markdown snippet

### DIFF
--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -27,6 +27,7 @@ const DocumentDetail = React.memo(function DocumentDetail({
   const [isLoading, setIsLoading] = useState(!initialMarkdown); // If no initial markdown, consider it loading (for fallback/image)
   const [error, setError] = useState<string | null>(null); // Error if initialMarkdown is null/undefined and no docConfig?
   const [isHydrated, setIsHydrated] = useState(false);
+  console.log('DD props', { docId, locale, mdLen: md.length });
 
   const mdParser = useMemo(() => new MarkdownIt(), []);
   const html = useMemo(() => mdParser.render(md || ''), [md, mdParser]);


### PR DESCRIPTION
## Summary
- cache route params before awaiting in dynamic doc page
- log first 100 chars of markdown read
- pass cached params to MarkdownPreview
- add debug console in DocumentDetail

## Testing
- `npm test`