### PR TITLE
Fix stray token causing runtime error

### DIFF
--- a/src/app/[locale]/docs/[docId]/start/StartPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartPageClient.tsx
@@ -1,4 +1,3 @@
-tsx
 import GenerateClient from '@/components/GenerateClient';
 
 export default function StartPageClient() {


### PR DESCRIPTION
## Summary
- remove mistaken `tsx` token at top of `StartPageClient`

## Testing
- `npm test`
- `npm run typecheck` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*