### PR TITLE
Add auth modal cancellation reset

### DIFF
--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -565,7 +565,10 @@ export default function WizardForm({
       </TooltipProvider>
       <AuthModal
         isOpen={showAuthModal}
-        onClose={() => setShowAuthModal(false)}
+        onClose={() => {
+          setShowAuthModal(false);
+          setPendingSaveDraft(false);
+        }}
         onAuthSuccess={handleAuthSuccess}
       />
       <PaymentModal


### PR DESCRIPTION
## Summary
- reset `pendingSaveDraft` when the auth modal closes so reopening doesn't auto-save

## Testing
- `npm test`