### PR TITLE
Fix i18n default export and relocate locale helper

### DIFF
--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -26,7 +26,7 @@ import AuthModal from '@/components/AuthModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { saveFormProgress } from '@/lib/firestore/saveFormProgress';
-import { resolveLocale } from '@/lib/i18n';
+import { resolveLocale } from '@/lib/locale';
 import type { UserCredential } from 'firebase/auth';
 import AddressField from '@/components/AddressField';
 import { TooltipProvider } from '@/components/ui/tooltip';

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,11 +1,43 @@
-export const supportedLocales = ['en', 'es'] as const;
-export type Locale = (typeof supportedLocales)[number];
+// src/lib/i18n.ts
+import i18n from 'i18next';
+import HttpBackend from 'i18next-http-backend';
 
-export const fallbackLocale: Locale = 'en';
+const isBrowser = typeof window !== 'undefined';
 
-export const resolveLocale = (
-  raw?: string | string[]
-): Locale => {
-  const val = Array.isArray(raw) ? raw[0] : raw;
-  return supportedLocales.includes(val as Locale) ? (val as Locale) : fallbackLocale;
-};
+// Initialize the core i18n instance
+// This instance is server-safe and can be used in `generateMetadata`
+if (!i18n.isInitialized) {
+  i18n
+    .use(HttpBackend) // For loading translations
+    .init({
+      // Core i18next options
+      debug: process.env.NODE_ENV === 'development' && isBrowser,
+      fallbackLng: 'en',
+      supportedLngs: ['en', 'es'],
+      load: 'languageOnly',
+      ns: [
+        'common',
+        'header',
+        'footer',
+        'support',
+        'faq',
+        'electronic-signature',
+        'online-notary',
+        'documents',
+        'doc_bill_of_sale_vehicle',
+      ],
+      defaultNS: 'common',
+      backend: {
+        loadPath: '/locales/{{lng}}/{{ns}}.json',
+      },
+      interpolation: {
+        escapeValue: false,
+      },
+      returnObjects: false,
+      returnEmptyString: true,
+      keySeparator: '.',
+      nsSeparator: ':',
+    });
+}
+
+export default i18n;

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -1,0 +1,11 @@
+export const supportedLocales = ['en', 'es'] as const;
+export type Locale = (typeof supportedLocales)[number];
+
+export const fallbackLocale: Locale = 'en';
+
+export const resolveLocale = (
+  raw?: string | string[],
+): Locale => {
+  const val = Array.isArray(raw) ? raw[0] : raw;
+  return supportedLocales.includes(val as Locale) ? (val as Locale) : fallbackLocale;
+};


### PR DESCRIPTION
## Summary
- restore default i18n instance export
- move locale utilities to `locale.ts`
- update WizardForm to use the new helper

## Testing
- `npm run build` *(fails: Cannot find package 'puppeteer')*
- `npm test`