### PR TITLE
Fix login context UID for auth modal

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -138,7 +138,7 @@ export default function AuthModal({
       }
 
       // update local auth context so the rest of the app knows the user
-      login(cred.user.uid);
+      login(cred.user.email ?? '', cred.user.uid);
 
       // notify parent (WizardForm)
       onAuthSuccess(authMode, cred.user.uid);


### PR DESCRIPTION
## Summary
- pass the email and uid to `login` after Firebase auth so the user context stores the correct UID

## Testing
- `npm test`
