### PR TITLE
Fix Save Draft redirect flow

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -138,7 +138,7 @@ export default function AuthModal({
       }
 
       // update local auth context so the rest of the app knows the user
-      login(cred.user.uid);
+      login(cred.user.email ?? '', cred.user.uid);
 
       // notify parent (WizardForm)
       onAuthSuccess(authMode, cred.user.uid);


### PR DESCRIPTION
## Summary
- trigger redirect after auth by tracking `pendingRedirect`
- set `pendingRedirect` when guests choose Save & Finish Later
- simplify `handleAuthSuccess`
- ensure Auth context stores real Firebase UID

## Testing
- `npm test`
