### PR TITLE
[Pages] Add prop types to error page

### DIFF
--- a/src/pages/_error.jsx
+++ b/src/pages/_error.jsx
@@ -1,8 +1,12 @@
+import React from "react";
+import PropTypes from "prop-types";
 import * as Sentry from "@sentry/nextjs";
 import Error from "next/error";
 
-const CustomErrorComponent = (props) => {
-  return <Error statusCode={props.statusCode} />;
+const CustomErrorComponent = ({ statusCode }) => <Error statusCode={statusCode} />;
+
+CustomErrorComponent.propTypes = {
+  statusCode: PropTypes.number,
 };
 
 CustomErrorComponent.getInitialProps = async (contextData) => {


### PR DESCRIPTION
## Summary
- include React and PropTypes imports
- define propTypes for `_error.jsx`

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*
- `npm run test` *(fails: Playwright Test did not expect test())*
- `npm run e2e`
- `npm run build` *(fails: compile errors)*