### PR TITLE
[Types] Replace empty node globals

### DIFF
--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -1,6 +1,6 @@
 declare global {
   namespace NodeJS {
-    interface Timeout {}
+    type Timeout = unknown;
     interface ErrnoException extends Error {
       code?: string;
       errno?: number;
@@ -17,7 +17,7 @@ declare global {
 
   const process: NodeJS.Process;
 
-  interface Buffer {}
+  type Buffer = unknown;
   const Buffer: {
     from(input: string | ArrayBuffer | ArrayBufferView, encoding?: string): Buffer;
   };


### PR DESCRIPTION
## Summary
- use concrete types in node.d.ts for `Timeout` and `Buffer`

## Testing
- `npm run lint` *(fails: parsing error and other lint issues)*
- `npm run test` *(fails: playwright test did not expect test to be called)*
- `npm run e2e`
- `npm run build` *(fails to compile VehicleBillOfSalePageClientWrapper.tsx)*