### PR TITLE
[Docs] Fix duplicate variable causing build failure

### DIFF
--- a/src/components/VehicleBillOfSalePageClientWrapper.tsx
+++ b/src/components/VehicleBillOfSalePageClientWrapper.tsx
@@ -3,10 +3,8 @@
 import { lazyClient } from "@/lib/lazy-client";
 import React from "react";
 
-const VehicleBillOfSalePageClient = lazyClient(() => import("@/lib/documents/us/vehicle-bill-of-sale").then(mod => mod.VehicleBillOfSalePageClient));
-
-/*  NOTE: we now import from -client.ts to avoid shadowing the real
-    document folder that provides metadata for menu/search. */
+/* NOTE: we now import from -client.ts to avoid shadowing the real
+   document folder that provides metadata for menu/search. */
 const VehicleBillOfSalePageClient = lazyClient(() =>
   import("@/lib/documents/us/vehicle-bill-of-sale-client").then(
     (mod) => mod.VehicleBillOfSalePageClient,


### PR DESCRIPTION
## Summary
- remove duplicate declaration in `VehicleBillOfSalePageClientWrapper`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package '@playwright/test')*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.