### PR TITLE
[Testing] Switch to Playwright test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
 
-    "test": "node --test tests/prettify.test.mjs",
+    "test": "playwright test tests/prettify.test.mjs",
     "e2e": "playwright test --reporter=list || true",
 
     "gen:previews": "node --experimental-modules scripts/generate-previews.js",


### PR DESCRIPTION
## Summary
- run tests with Playwright instead of Node's built-in test runner

## Testing
- `npm run test` *(fails: `playwright: not found`)*