### PR TITLE
[lib] Type lazyClient loader return

### DIFF
--- a/src/lib/lazy-client.ts
+++ b/src/lib/lazy-client.ts
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import type { ComponentType } from 'react';
 
 /**
  * Wrap any heavy, browser-only component so it:
@@ -6,5 +7,6 @@ import dynamic from 'next/dynamic';
  *   • loads in its own JS chunk after hydration
  *   • shows nothing while loading (customise if you prefer)
  */
-export const lazyClient = <T extends () => Promise<any>>(loader: T) =>
-  dynamic(loader, { ssr: false, loading: () => null });
+export const lazyClient = <T extends ComponentType<any>>(
+  loader: () => Promise<{ default: T }>
+) => dynamic(loader, { ssr: false, loading: () => null });


### PR DESCRIPTION
## Summary
- make `lazyClient` generic return the correct typed module

## Testing
- `npm run lint` *(fails: Unexpected any, React prop-types, etc.)*
- `npm run test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run e2e`
- `npm run build` *(fails to compile VehicleBillOfSalePageClientWrapper)*