### PR TITLE
[Backend] Add lazy Firebase admin initializer

### DIFF
--- a/src/app/[locale]/api/wizard/[docId]/submit/route.ts
+++ b/src/app/[locale]/api/wizard/[docId]/submit/route.ts
@@ -1,7 +1,7 @@
 // src/app/[locale]/api/wizard/[docId]/submit/route.ts
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
-import { admin } from '@/lib/firebase-admin'; // Firebase Admin SDK
+import { getAdmin } from '@/lib/firebase-admin'; // Firebase Admin SDK
 import { documentLibrary } from '@/lib/document-library';
 
 // Placeholder for user authentication - replace with your actual auth logic
@@ -29,6 +29,8 @@ export async function POST(
 ) {
   const logPrefix = `[API /wizard/${params.docId}/submit]`;
   console.log(`${logPrefix} Received POST request.`);
+
+  const admin = getAdmin();
 
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
 

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -1,51 +1,60 @@
 // src/lib/firebase-admin.ts
 import * as admin from 'firebase-admin';
 
-if (!admin.apps.length) {
-  console.log(
-    '[firebase-admin] Attempting to initialize Firebase Admin SDK...',
-  );
-  try {
-    const serviceAccountKeyString =
-      process.env.FIREBASE_SERVICE_ACCOUNT_KEY_JSON;
-    if (!serviceAccountKeyString) {
-      console.error(
-        '[firebase-admin] CRITICAL: FIREBASE_SERVICE_ACCOUNT_KEY_JSON environment variable is not set.',
-      );
-      throw new Error(
-        'FIREBASE_SERVICE_ACCOUNT_KEY_JSON environment variable is not set. Firebase Admin SDK cannot be initialized.',
-      );
-    }
+let cachedAdmin: typeof admin | null = null;
 
-    let serviceAccount;
-    try {
-      serviceAccount = JSON.parse(serviceAccountKeyString);
-    } catch (parseError) {
-      console.error(
-        '[firebase-admin] CRITICAL: Failed to parse FIREBASE_SERVICE_ACCOUNT_KEY_JSON. Ensure it is a valid JSON string.',
-        parseError,
-      );
-      throw new Error(
-        'Failed to parse FIREBASE_SERVICE_ACCOUNT_KEY_JSON. Firebase Admin SDK cannot be initialized.',
-      );
-    }
-
-    admin.initializeApp({
-      credential: admin.credential.cert(serviceAccount),
-    });
-    console.log(
-      '[firebase-admin] Firebase Admin SDK initialized successfully.',
-    );
-  } catch (error) {
-    console.error(
-      '[firebase-admin] Error during Firebase Admin SDK initialization:',
-      error,
-    );
-    // Re-throw the error to make it clear that initialization failed and to halt execution if necessary
-    throw error;
+export function getAdmin(): typeof admin {
+  if (cachedAdmin) {
+    return cachedAdmin;
   }
-} else {
-  console.log('[firebase-admin] Firebase Admin SDK already initialized.');
-}
 
-export { admin };
+  if (!admin.apps.length) {
+    console.log(
+      '[firebase-admin] Attempting to initialize Firebase Admin SDK...',
+    );
+    try {
+      const serviceAccountKeyString =
+        process.env.FIREBASE_SERVICE_ACCOUNT_KEY_JSON;
+      if (!serviceAccountKeyString) {
+        console.error(
+          '[firebase-admin] CRITICAL: FIREBASE_SERVICE_ACCOUNT_KEY_JSON environment variable is not set.',
+        );
+        throw new Error(
+          'FIREBASE_SERVICE_ACCOUNT_KEY_JSON environment variable is not set. Firebase Admin SDK cannot be initialized.',
+        );
+      }
+
+      let serviceAccount;
+      try {
+        serviceAccount = JSON.parse(serviceAccountKeyString);
+      } catch (parseError) {
+        console.error(
+          '[firebase-admin] CRITICAL: Failed to parse FIREBASE_SERVICE_ACCOUNT_KEY_JSON. Ensure it is a valid JSON string.',
+          parseError,
+        );
+        throw new Error(
+          'Failed to parse FIREBASE_SERVICE_ACCOUNT_KEY_JSON. Firebase Admin SDK cannot be initialized.',
+        );
+      }
+
+      admin.initializeApp({
+        credential: admin.credential.cert(serviceAccount),
+      });
+      console.log(
+        '[firebase-admin] Firebase Admin SDK initialized successfully.',
+      );
+    } catch (error) {
+      console.error(
+        '[firebase-admin] Error during Firebase Admin SDK initialization:',
+        error,
+      );
+      // Re-throw the error to make it clear that initialization failed and to halt execution if necessary
+      throw error;
+    }
+  } else {
+    console.log('[firebase-admin] Firebase Admin SDK already initialized.');
+  }
+
+  cachedAdmin = admin;
+  return cachedAdmin;
+}


### PR DESCRIPTION
## Summary
- lazily initialize Firebase admin in `getAdmin`
- update submit API route to call `getAdmin`

## Testing
- `npm run lint` *(fails: 257 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails during page data collection)*