### PR TITLE
[Dashboard] Filter out soft-deleted documents

### DIFF
--- a/src/lib/firestore/dashboardData.ts
+++ b/src/lib/firestore/dashboardData.ts
@@ -27,22 +27,27 @@ export async function getUserDocuments(
   // Changed orderBy from 'createdAt' to 'updatedAt'
   const q = query(col, orderBy('updatedAt', 'desc'), limit(max));
   const snap = await getDocs(q);
-  return snap.docs.map((d) => {
-    const data = d.data() as Record<string, unknown> & {
-      updatedAt?: Timestamp | Date | string;
-      createdAt?: Timestamp | Date | string; // Keep for compatibility if some docs only have createdAt
-    };
-    const docType = (data.originalDocId || data.docType || d.id) as string;
+  return snap.docs
+    .filter((d) => {
+      const data = d.data() as { deletedAt?: unknown };
+      return !data.deletedAt;
+    })
+    .map((d) => {
+      const data = d.data() as Record<string, unknown> & {
+        updatedAt?: Timestamp | Date | string;
+        createdAt?: Timestamp | Date | string; // Keep for compatibility if some docs only have createdAt
+      };
+      const docType = (data.originalDocId || data.docType || d.id) as string;
     const docConfig = documentLibrary.find((doc) => doc.id === docType);
-    return {
-      id: d.id,
-      name: docConfig?.name || docConfig?.translations?.en?.name || docType,
-      // Use updatedAt for the date display, fallback to createdAt if updatedAt is missing
-      date: data.updatedAt || data.createdAt || new Date(),
-      status: (data.status as string) || 'Draft',
-      docType,
-    };
-  });
+      return {
+        id: d.id,
+        name: docConfig?.name || docConfig?.translations?.en?.name || docType,
+        // Use updatedAt for the date display, fallback to createdAt if updatedAt is missing
+        date: data.updatedAt || data.createdAt || new Date(),
+        status: (data.status as string) || 'Draft',
+        docType,
+      };
+    });
 }
 
 export interface DashboardPayment {


### PR DESCRIPTION
## Summary
- prevent deleted documents from appearing in the dashboard

## Testing
- `npm run lint` *(fails: react/prop-types, @typescript-eslint/no-explicit-any)*
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails: Failed to parse FIREBASE_SERVICE_ACCOUNT_KEY_JSON)*