### PR TITLE
[Dashboard] Fix soft-delete listing

### DIFF
--- a/src/lib/firestore/dashboardData.ts
+++ b/src/lib/firestore/dashboardData.ts
@@ -26,26 +26,31 @@ export async function getUserDocuments(
   // Changed orderBy from 'createdAt' to 'updatedAt'
   const q = query(col, orderBy('updatedAt', 'desc'), limit(max));
   const snap = await getDocs(q);
-  return snap.docs.map((d) => {
-    const data = d.data() as Record<string, unknown> & {
-      updatedAt?: Timestamp | Date | string;
-      createdAt?: Timestamp | Date | string; // Keep for compatibility if some docs only have createdAt
-    };
-    const docType = (data.originalDocId || data.docType || d.id) as string;
-    const docConfig = documentLibrary.find((doc) => doc.id === docType);
-    return {
-      id: d.id,
-      name:
-        (data.name as string) ||
-        docConfig?.name ||
-        docConfig?.translations?.en?.name ||
+  return snap.docs
+    .filter((d) => {
+      const data = d.data() as { deletedAt?: unknown };
+      return !data.deletedAt;
+    })
+    .map((d) => {
+      const data = d.data() as Record<string, unknown> & {
+        updatedAt?: Timestamp | Date | string;
+        createdAt?: Timestamp | Date | string; // Keep for compatibility if some docs only have createdAt
+      };
+      const docType = (data.originalDocId || data.docType || d.id) as string;
+      const docConfig = documentLibrary.find((doc) => doc.id === docType);
+      return {
+        id: d.id,
+        name:
+          (data.name as string) ||
+          docConfig?.name ||
+          docConfig?.translations?.en?.name ||
+          docType,
+        // Use updatedAt for the date display, fallback to createdAt if updatedAt is missing
+        date: data.updatedAt || data.createdAt || new Date(),
+        status: (data.status as string) || 'Draft',
         docType,
-      // Use updatedAt for the date display, fallback to createdAt if updatedAt is missing
-      date: data.updatedAt || data.createdAt || new Date(),
-      status: (data.status as string) || 'Draft',
-      docType,
-    };
-  });
+      };
+    });
 }
 
 export interface DashboardPayment {


### PR DESCRIPTION
## Summary
- filter out documents with `deletedAt` when fetching dashboard docs

## Testing
- `npm run lint` *(fails: 268 problems)*
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails: Failed to collect page data for /[locale]/signwell)*