### PR TITLE
[Lib] Limit lazyClient component types

### DIFF
--- a/src/lib/lazy-client.ts
+++ b/src/lib/lazy-client.ts
@@ -7,6 +7,6 @@ import type { ComponentType } from 'react';
  *   • loads in its own JS chunk after hydration
  *   • shows nothing while loading (customise if you prefer)
  */
-export const lazyClient = <T extends ComponentType<any>>(
+export const lazyClient = <T extends ComponentType<unknown>>(
   loader: () => Promise<{ default: T }>
 ) => dynamic(loader, { ssr: false, loading: () => null });


### PR DESCRIPTION
## Summary
- use `ComponentType<unknown>` instead of `ComponentType<any>` in `lazy-client`

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run typecheck` *(fails: Cannot find name 'app' etc.)*
- `npm run build` *(fails: Failed to collect page data for /[locale]/signwell)*