### PR TITLE
[Next] Switch to static generation

### DIFF
--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -6,7 +6,7 @@ import path from 'node:path';
 import DocPageClient from './DocPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Ensure this path is correct
-export const dynamic = 'force-dynamic';
+export const dynamic = 'force-static';
 import { vehicleBillOfSaleFaqs } from '@/app/[locale]/documents/bill-of-sale-vehicle/faqs';
 export interface DocPageParams {
   locale: 'en' | 'es';

--- a/src/app/[locale]/documents/segment.config.ts
+++ b/src/app/[locale]/documents/segment.config.ts
@@ -1,3 +1,3 @@
 // All pages under /[locale]/documents/** are rendered on-demand and cached.
 // Build time stays fast—even after you add 100 more templates.
-export const dynamic = 'force-dynamic';
+export const dynamic = 'force-static';

--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -1,4 +1,4 @@
-export const dynamic = 'force-dynamic';
+export const dynamic = 'force-static';
 // src/app/[locale]/signwell/page.tsx
 import React from 'react';
 import SignWellClientContent from './signwell-client-content';


### PR DESCRIPTION
## Summary
- switch `dynamic` option to `force-static` for docs pages
- switch SignWell page to static generation
- make documents segment static too

## Testing
- `npm run lint` *(fails: 259 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails to collect config for signwell)*