### PR TITLE
[Dashboard] Fix document table actions

### DIFF
--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -223,7 +223,12 @@ export default function DashboardClientContent({
                 {sorted.map((doc) => (
                   <TableRow key={doc.id} className="group">
                     <TableCell className="font-medium">
-                      {t(doc.name, doc.name)}
+                      <Link
+                        href={`/${locale}/docs/${doc.docType}/start`}
+                        className="hover:underline"
+                      >
+                        {t(doc.name, doc.name)}
+                      </Link>
                     </TableCell>
                     <TableCell>{formatDate(doc.date)}</TableCell>
                     <TableCell>{t(doc.status)}</TableCell>
@@ -239,11 +244,11 @@ export default function DashboardClientContent({
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          <DropdownMenuItem onSelect={() => setRenameDoc(doc)}>
+                          <DropdownMenuItem onClick={() => setRenameDoc(doc)}>
                             {t('Rename')}
                           </DropdownMenuItem>
                           <DropdownMenuItem
-                            onSelect={async () => {
+                            onClick={async () => {
                               await duplicateDocument(user!.uid, doc.id);
                               toast({
                                 title: t('Document duplicated'),
@@ -256,7 +261,7 @@ export default function DashboardClientContent({
                             {t('Duplicate')}
                           </DropdownMenuItem>
                           <DropdownMenuItem
-                            onSelect={async () => {
+                            onClick={async () => {
                               await softDeleteDocument(user!.uid, doc.id);
                               toast({
                                 title: t('Document deleted'),


### PR DESCRIPTION
## Summary
- make My Documents table names open the relevant wizard page
- wire up kebab actions with standard `onClick` events

## Testing
- `npm run lint` *(fails: 269 problems)*
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails: Failed to collect configuration for /[locale]/signwell)*