### PR TITLE
[Signwell] Remove i18next from server

### DIFF
--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -2,13 +2,25 @@ export const dynamic = 'force-static';
 // src/app/[locale]/signwell/page.tsx
 import React from 'react';
 import SignWellClientContent from './signwell-client-content';
-import type { Metadata } from 'next';
-
-import SignwellHeroAnimationClient from '@/components/SignwellHeroAnimationClient';
 interface SignWellPageProps {
   params: { locale: 'en' | 'es' } & Record<string, string>;
 }
-import i18n from '@/lib/i18n'; // Import i18n instance to access translations server-side for metadata
+import type { Metadata } from 'next';
+import SignwellHeroAnimationClient from '@/components/SignwellHeroAnimationClient';
+
+// Basic metadata strings to avoid loading react-i18next on the server
+const META = {
+  en: {
+    title: 'eSign Documents Online Securely | 123LegalDoc',
+    description:
+      'Upload, prepare, and send documents for legally binding electronic signatures with 123LegalDoc, powered by SignWell. Fast, secure, and compliant.',
+  },
+  es: {
+    title: 'Firmar Documentos Electrónicamente | 123LegalDoc',
+    description:
+      'Suba, prepare y envíe documentos para firmas electrónicas legalmente vinculantes con 123LegalDoc, impulsado por SignWell. Rápido, seguro y conforme.',
+  },
+} as const;
 
 export async function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'es' }];
@@ -20,21 +32,7 @@ export async function generateMetadata({
 }: {
   params: { locale: 'en' | 'es' };
 }): Promise<Metadata> {
-  // Ensure i18next is initialized for the correct language to fetch metadata
-  if (i18n.language !== params.locale) {
-    await i18n.changeLanguage(params.locale);
-  }
-
-  const title = i18n.t('pageTitle', {
-    ns: 'electronic-signature',
-    defaultValue: 'eSign Documents Online Securely | 123LegalDoc',
-  });
-  const description = i18n.t('pageDescription', {
-    ns: 'electronic-signature',
-    defaultValue:
-      'Upload, prepare, and send documents for legally binding electronic signatures with 123LegalDoc, powered by SignWell. Fast, secure, and compliant.',
-  });
-
+  const { title, description } = META[params.locale] ?? META.en;
   return {
     title,
     description,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -7,9 +7,13 @@ import { initReactI18next } from 'react-i18next';
 if (!i18n.isInitialized) {
   i18n
     /* Load JSON from /public/locales/{lng}/{ns}.json */
-    .use(HttpBackend)
-    /* Bridge to react-i18next so hooks work */
-    .use(initReactI18next)
+    .use(HttpBackend);
+  if (typeof window !== 'undefined') {
+    // react-i18next relies on browser APIs like createContext which
+    // aren't available when this file runs on the server.
+    i18n.use(initReactI18next);
+  }
+  i18n
     /* Initialise once with basic config */
     .init({
       lng: 'en',


### PR DESCRIPTION
## Summary
- simplify signwell metadata generation
- avoid loading `react-i18next` on the server

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build`
