### PR TITLE
[Layout] Add mobile drawer backdrop and gestures

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "use-places-autocomplete": "^4.0.1",
+    "@use-gesture/react": "^10.2.23",
     "vaul": "^0.9.1",
     "zod": "^3.24.2"
   },

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import { useDrag } from '@use-gesture/react';
+import { cn } from '@/lib/utils';
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = React.useState(false);
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = () => setMatches(mql.matches);
+    handler();
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}
+
+interface MobileDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export default function MobileDrawer({ open, onClose, children }: MobileDrawerProps) {
+  const isDesktop = useMediaQuery('(min-width:768px)');
+  const bind = useDrag(({ last, movement: [, my] }) => {
+    if (last && my > 50) onClose();
+  });
+
+  if (isDesktop) return <>{children}</>;
+
+  return (
+    <>
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40"
+          onClick={onClose}
+        />
+      )}
+      <div
+        {...bind()}
+        className={cn(
+          'fixed bottom-0 left-0 right-0 z-50 bg-background transition-transform',
+          open ? 'translate-y-0' : 'translate-y-full'
+        )}
+      >
+        {children}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `@use-gesture/react` dependency
- implement `MobileDrawer` with backdrop and swipe down close logic

## Testing
- `pnpm turbo run lint typecheck test build --parallel` *(fails: command not found)*
- `npm run lint` *(fails: 270 problems)*
- `npm run test`
- `npm run e2e`
- `npm run build` *(failed to finish)*