### PR TITLE
[MegaMenu] Improve mobile link touch targets

### DIFF
--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -34,14 +34,16 @@ const MemoizedDocLink = React.memo(function DocLink({
   const docHref = `/${locale}/docs/${doc.id}`;
 
   return (
-    <li className="px-4 py-3 md:px-0 md:py-0">
-      <Link
-        href={docHref}
-        className="block text-base md:text-sm text-muted-foreground hover:text-primary hover:underline transition-colors duration-150"
-        onClick={onClick}
-      >
-        {t(docName, { defaultValue: docName })}
-      </Link>
+    <li className="md:px-0 md:py-0">
+      <div className="block w-full text-left py-3 px-4 hover:bg-muted/40 active:bg-muted/60">
+        <Link
+          href={docHref}
+          className="block text-base md:text-sm text-muted-foreground hover:text-primary hover:underline transition-colors duration-150"
+          onClick={onClick}
+        >
+          {t(docName, { defaultValue: docName })}
+        </Link>
+      </div>
     </li>
   );
 });


### PR DESCRIPTION
## Summary
- make doc links easier to tap in mobile mega-menu

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails: `TypeError: (0 , s.createContext) is not a function`)*