### PR TITLE
[signwell] Dynamically load hero animation

### DIFF
--- a/src/app/[locale]/signwell/page.tsx
+++ b/src/app/[locale]/signwell/page.tsx
@@ -4,7 +4,12 @@ import React from 'react';
 import SignWellClientContent from './signwell-client-content';
 import type { Metadata } from 'next';
 
-import SignwellHeroAnimationClient from '@/components/SignwellHeroAnimationClient';
+import dynamic from 'next/dynamic';
+
+const SignwellHeroAnimationClient = dynamic(
+  () => import('@/components/SignwellHeroAnimationClient'),
+  { ssr: false },
+);
 interface SignWellPageProps {
   params: { locale: 'en' | 'es' } & Record<string, string>;
 }


### PR DESCRIPTION
## Summary
- dynamically load hero animation component so it won't be evaluated on the server

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails: Failed to collect configuration for /[locale]/signwell)*