### PR TITLE
[layout] Add mobile drawer backdrop and swipe gesture

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "tailwindcss-animate": "^1.0.7",
     "use-places-autocomplete": "^4.0.1",
     "vaul": "^0.9.1",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "@use-gesture/react": "^10.2.23"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useDrag } from '@use-gesture/react';
 
 function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = React.useState<boolean>(false);
@@ -21,13 +22,22 @@ function useMediaQuery(query: string): boolean {
 interface MobileDrawerProps {
   open: boolean;
   children: React.ReactNode;
+  onClose: () => void;
 }
 
-export default function MobileDrawer({ open, children }: MobileDrawerProps) {
+export default function MobileDrawer({ open, children, onClose }: MobileDrawerProps) {
   const isDesktop = useMediaQuery('(min-width:768px)');
   const { t } = useTranslation();
 
   const firstHeadingRef = React.useRef<HTMLElement>(null);
+  const bind = useDrag(
+    ({ last, movement: [, my] }) => {
+      if (last && my > 50) {
+        onClose();
+      }
+    },
+    { axis: 'y' }
+  );
 
   React.useEffect(() => {
     if (open) {
@@ -62,17 +72,24 @@ export default function MobileDrawer({ open, children }: MobileDrawerProps) {
   return (
     <AnimatePresence>
       {open && (
-        <motion.aside
-          initial={{ y: 60, opacity: 0 }}
-          animate={{ y: 0, opacity: 1, transition: { duration: 0.12 } }}
-          exit={{ y: 60, opacity: 0 }}
-          role="dialog"
-          aria-modal="true"
-          aria-label={t('Document menu')}
-          className="md:hidden absolute top-14 left-0 right-0 bg-background shadow-lg border-t border-border p-4 space-y-4 animate-fade-in z-[60] max-h-[calc(100vh-3.5rem)] overflow-y-auto"
-        >
-          {enhancedChildren}
-        </motion.aside>
+        <>
+          <div
+            className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40"
+            onClick={onClose}
+          />
+          <motion.aside
+            {...bind()}
+            initial={{ y: 60, opacity: 0 }}
+            animate={{ y: 0, opacity: 1, transition: { duration: 0.12 } }}
+            exit={{ y: 60, opacity: 0 }}
+            role="dialog"
+            aria-modal="true"
+            aria-label={t('Document menu')}
+            className="md:hidden absolute top-14 left-0 right-0 bg-background shadow-lg border-t border-border p-4 space-y-4 animate-fade-in z-[60] max-h-[calc(100vh-3.5rem)] overflow-y-auto"
+          >
+            {enhancedChildren}
+          </motion.aside>
+        </>
       )}
     </AnimatePresence>
   );


### PR DESCRIPTION
## Summary
- install `@use-gesture/react`
- add backdrop and swipe-to-close handling for `<MobileDrawer>`

## Testing
- `pnpm turbo run lint typecheck test build --parallel` *(fails: Command "turbo" not found)*
- `npm run lint` *(fails: 271 problems)*
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails: Failed to collect page data)*