### PR TITLE
[Perf] Reduce Sentry tracing overhead

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -9,7 +9,8 @@ Sentry.init({
   dsn: "https://7b10ad6837786c85f4b58112ee8fd516@o4509409853440000.ingest.us.sentry.io/4509409855340544",
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  // Sample only a fraction of traces to reduce edge runtime overhead
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,7 +8,8 @@ Sentry.init({
   dsn: "https://7b10ad6837786c85f4b58112ee8fd516@o4509409853440000.ingest.us.sentry.io/4509409855340544",
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  // Sample only a fraction of traces to reduce server overhead
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -8,7 +8,8 @@ Sentry.init({
   dsn: "https://7b10ad6837786c85f4b58112ee8fd516@o4509409853440000.ingest.us.sentry.io/4509409855340544",
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  // Sample only a fraction of traces to reduce client overhead
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
## Summary
- reduce sampling rate for Sentry tracing in server, edge and client configs

## Testing
- `npm run lint` *(fails: react/prop-types missing props validation)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683a3113e638832dbb89eb251fb7895f