### PR TITLE
[Performance] Remove aggressive prefetching

### DIFF
--- a/src/app/[locale]/templates/templates-client-content.tsx
+++ b/src/app/[locale]/templates/templates-client-content.tsx
@@ -84,11 +84,7 @@ export default function TemplatesClientContent({ locale }: Props) {
               variant="outline"
               className="flex flex-col items-center gap-2 py-6"
             >
-              <Link
-                href={categoryHref(cat.key)}
-                prefetch
-                onMouseEnter={() => router.prefetch(categoryHref(cat.key))}
-              >
+              <Link href={categoryHref(cat.key)} prefetch>
                 {React.createElement(cat.icon || FileText, {
                   className: 'h-5 w-5 text-primary',
                 })}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -135,9 +135,7 @@ const SearchBar = React.memo(function SearchBar() {
                   <button
                     type="button"
                     onClick={() => handleSuggestionClick(suggestion.id)}
-                    onMouseEnter={() =>
-                      router.prefetch(`/${locale}/docs/${suggestion.id}`)
-                    }
+                    /* Removed eager prefetch to reduce network overhead */
                     className="w-full text-left px-3 py-2.5 hover:bg-muted text-sm flex items-center gap-2"
                   >
                     <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -47,13 +47,6 @@ const TopDocsChips = React.memo(function TopDocsChips() {
     setIsLoading(false);
   }, [isHydrated]);
 
-  // Prefetch document pages for snappier navigation
-  useEffect(() => {
-    if (!isHydrated || topDocs.length === 0) return;
-    topDocs.forEach((doc) => {
-      router.prefetch(`/${locale}/docs/${doc.id}`);
-    });
-  }, [isHydrated, topDocs, router, locale]);
 
   const handleExploreAll = () => {
     const workflowStartElement = document.getElementById('workflow-start');


### PR DESCRIPTION
## Summary
- eliminate router.prefetch calls in templates and search UI
- drop preload loop for top documents

## Testing
- `npm run lint` *(fails: 259 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683a6ad4798c832db1df9a10423876da