### PR TITLE
[Tests] Add VIN validation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" scripts || true",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
-    "test": "playwright test tests/prettify.test.mjs",
+    "test": "playwright test tests/prettify.test.mjs tests/isValidVIN.test.ts",
     "e2e": "playwright test --reporter=list || true",
     "gen:previews": "node --experimental-modules scripts/generate-previews.js",
     "extract:i18n": "i18next-parser \"src/**/*.{ts,tsx}\" --config i18next-parser.config.js",

--- a/tests/isValidVIN.test.ts
+++ b/tests/isValidVIN.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { isValidVIN } from '../src/utils/isValidVIN';
+
+test('valid VINs pass validation', () => {
+  expect(isValidVIN('1HGCM82633A004352')).toBe(true);
+  expect(isValidVIN('JH4TB2H26CC000000')).toBe(true);
+});
+
+test('invalid VIN due to wrong length', () => {
+  expect(isValidVIN('1HGCM82633A00435')).toBe(false);
+  expect(isValidVIN('1HGCM82633A0043529')).toBe(false);
+});
+
+test('invalid VIN due to illegal characters', () => {
+  expect(isValidVIN('1HGCM82633A00I352')).toBe(false);
+  expect(isValidVIN('1HGCM82633A00435O')).toBe(false);
+  expect(isValidVIN('1HGCM82633A0043$2')).toBe(false);
+});
+
+test('invalid when input is not a string', () => {
+  expect(isValidVIN(123456789 as any)).toBe(false);
+  expect(isValidVIN(undefined as any)).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add a new test suite for `isValidVIN`
- include the suite in `npm test` script

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build` *(fails: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_683a78d850a0832dae3b42ab1ea0df4d