### PR TITLE
[Docs] Document architecture & ignore docs lint

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,42 @@
+# 123LegalDoc Overview
+
+123LegalDoc is a Next.js application for generating legal documents. It integrates AI-powered flows for document inference and uses Firebase for storage and authentication.
+
+## Architecture
+
+- **Next.js app (`src/`)** – Implements the user interface and routes for the document workflow. Internationalized pages live under `src/app/[locale]`.
+- **Legal document engine (`src/lib/documents/`)** – Provides schemas and question sets for each supported document type. Jurisdictional variations are organized under subfolders such as `us/`.
+- **AI flows (`src/ai`)** – Uses Genkit and Google AI to infer document types and assist with dynamic questionnaires.
+- **Cloud Functions (`functions/`)** – Placeholder for serverless logic. Not all functions are included in this repo but the directory is reserved for Firebase Functions.
+- **Scripts (`scripts/`)** – Utility scripts for tasks like generating previews or seeding reviews.
+
+## Development Workflow
+
+1. Install dependencies with `yarn` or `npm install`.
+2. Copy your Firebase service account key to `serviceAccountKey.json` and export it as an environment variable as shown in the README.
+3. Run the development server with `npm run dev`.
+4. Validate your changes before committing:
+   ```bash
+   npm run lint
+   npm run test
+   npm run e2e
+   npm run build
+   ```
+
+## Directory Structure
+
+```text
+src/            # Application code
+  app/          # Next.js routes
+  components/   # Shared UI components
+  lib/documents/ # Document definitions and schemas
+  ai/           # AI flow definitions
+public/         # Static assets
+scripts/        # Command line utilities
+```
+
+## Additional Notes
+
+- Use React Server Components by default; only add `"use client"` when necessary.
+- Replace `<img>` tags with `<AutoImage />` from `src/components`.
+- Review `docs/blueprint.md` for design guidelines such as color palette and UI style.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,7 @@
    
 export default defineConfig([
   {
-    ignores: ['.next/**', 'public/**', 'coverage/**', '*.md', '*.json']
+    ignores: ['.next/**', 'public/**', 'coverage/**', '**/*.md', '**/*.json']
   },
   /* ───────── all JS/TS files ───────── */
   {


### PR DESCRIPTION
## Summary
- add new docs/overview.md describing architecture and workflow
- ignore Markdown files in eslint so docs don't trigger lint errors

## Testing
- `npm run lint` *(fails: 259 errors, 12 warnings)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683a76f3d8b4832da8f463d967f044c2