### PR TITLE
[Docs] Move US doc names to translations

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -172,7 +172,10 @@ export default function HomePageClient() {
         toast({
           title: t('toasts.docTypeConfirmedTitle'),
           description: t('toasts.docTypeConfirmedDescription', {
-            docName: doc.name_es && locale === 'es' ? doc.name_es : doc.name,
+            docName:
+              locale === 'es'
+                ? doc.translations?.es?.name || doc.translations?.en?.name || doc.name
+                : doc.translations?.en?.name || doc.name || doc.translations?.es?.name,
           }),
         });
         router.push(`/${locale}/docs/${doc.id}/start`);

--- a/src/app/[locale]/api/wizard/[docId]/submit/route.ts
+++ b/src/app/[locale]/api/wizard/[docId]/submit/route.ts
@@ -178,13 +178,25 @@ export async function POST(
     let paymentIntent;
     try {
       const documentDisplayName =
-        docConfig.name_es && effectiveLocale === 'es'
-          ? docConfig.name_es
-          : docConfig.name || docConfig.id;
+        effectiveLocale === 'es'
+          ? docConfig.translations?.es?.name ||
+            docConfig.translations?.en?.name ||
+            docConfig.name ||
+            docConfig.id
+          : docConfig.translations?.en?.name ||
+            docConfig.name ||
+            docConfig.translations?.es?.name ||
+            docConfig.id;
       const documentDisplayDescription =
-        docConfig.description_es && effectiveLocale === 'es'
-          ? docConfig.description_es
-          : docConfig.description || '';
+        effectiveLocale === 'es'
+          ? docConfig.translations?.es?.description ||
+            docConfig.translations?.en?.description ||
+            docConfig.description ||
+            ''
+          : docConfig.translations?.en?.description ||
+            docConfig.description ||
+            docConfig.translations?.es?.description ||
+            '';
 
       const priceCents = (docConfig.basePrice || DEFAULT_DOCUMENT_PRICE) * 100;
       paymentIntent = await stripe.paymentIntents.create({

--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -68,8 +68,12 @@ const DocumentDetail = React.memo(function DocumentDetail({
       } else {
         const fallbackTitle =
           locale === 'es'
-            ? docConfig.name_es || docConfig.name
-            : docConfig.name;
+            ? docConfig.translations?.es?.name ||
+              docConfig.translations?.en?.name ||
+              docConfig.name
+            : docConfig.translations?.en?.name ||
+              docConfig.name ||
+              docConfig.translations?.es?.name;
         if (fallbackTitle) {
           modifiedMd = modifiedMd.replace(/^# .*/m, `# ${fallbackTitle}`);
         }

--- a/src/components/Step1DocumentSelector.tsx
+++ b/src/components/Step1DocumentSelector.tsx
@@ -58,6 +58,34 @@ export const CATEGORY_LIST: CategoryInfo[] = [
   { key: 'Miscellaneous', labelKey: 'General', icon: FileText },
 ];
 
+const getDocName = (
+  doc: Pick<LegalDocument, 'translations'>,
+  locale: string,
+) =>
+  locale === 'es'
+    ? doc.translations?.es?.name || doc.translations?.en?.name || ''
+    : doc.translations?.en?.name || doc.translations?.es?.name || '';
+
+const getDocDescription = (
+  doc: Pick<LegalDocument, 'translations'>,
+  locale: string,
+) =>
+  locale === 'es'
+    ? doc.translations?.es?.description ||
+      doc.translations?.en?.description ||
+      ''
+    : doc.translations?.en?.description ||
+      doc.translations?.es?.description ||
+      '';
+
+const getDocAliases = (
+  doc: Pick<LegalDocument, 'translations'>,
+  locale: string,
+) =>
+  locale === 'es'
+    ? doc.translations?.es?.aliases || []
+    : doc.translations?.en?.aliases || [];
+
 interface Step1DocumentSelectorProps {
   selectedCategory: string | null;
   onCategorySelect: (_categoryKey: string | null) => void;
@@ -69,50 +97,62 @@ interface Step1DocumentSelectorProps {
 
 // Placeholder for top docs - in a real app, this comes from Firestore
 const placeholderTopDocs: Array<
-  Pick<LegalDocument, 'id' | 'name' | 'name_es' | 'category'> & {
+  Pick<LegalDocument, 'id' | 'category' | 'translations'> & {
     icon?: React.ElementType;
   }
 > = [
   {
     id: 'bill-of-sale-vehicle',
-    name: 'Vehicle Bill of Sale',
-    name_es: 'Contrato de Compraventa de Vehículo',
     category: 'Finance',
+    translations: {
+      en: { name: 'Vehicle Bill of Sale', description: '' },
+      es: { name: 'Contrato de Compraventa de Vehículo', description: '' },
+    },
     icon: FileText,
   },
   {
     id: 'leaseAgreement',
-    name: 'Residential Lease Agreement',
-    name_es: 'Contrato de Arrendamiento Residencial',
     category: 'Real Estate',
+    translations: {
+      en: { name: 'Residential Lease Agreement', description: '' },
+      es: { name: 'Contrato de Arrendamiento Residencial', description: '' },
+    },
     icon: Home,
   },
   {
     id: 'nda',
-    name: 'Non-Disclosure Agreement (NDA)',
-    name_es: 'Acuerdo de Confidencialidad (NDA)',
     category: 'Business',
+    translations: {
+      en: { name: 'Non-Disclosure Agreement (NDA)', description: '' },
+      es: { name: 'Acuerdo de Confidencialidad (NDA)', description: '' },
+    },
     icon: ShieldQuestion,
   },
   {
     id: 'powerOfAttorney',
-    name: 'General Power of Attorney',
-    name_es: 'Poder Notarial General',
     category: 'Personal',
+    translations: {
+      en: { name: 'General Power of Attorney', description: '' },
+      es: { name: 'Poder Notarial General', description: '' },
+    },
     icon: User,
   },
   {
     id: 'last-will-testament',
-    name: 'Last Will and Testament',
-    name_es: 'Última Voluntad y Testamento',
     category: 'Estate Planning',
+    translations: {
+      en: { name: 'Last Will and Testament', description: '' },
+      es: { name: 'Última Voluntad y Testamento', description: '' },
+    },
     icon: ScrollText,
   },
   {
     id: 'eviction-notice',
-    name: 'Eviction Notice',
-    name_es: 'Aviso de Desalojo',
     category: 'Real Estate',
+    translations: {
+      en: { name: 'Eviction Notice', description: '' },
+      es: { name: 'Aviso de Desalojo', description: '' },
+    },
     icon: AlertTriangle,
   },
 ];
@@ -169,7 +209,9 @@ const MemoizedDocumentCard = React.memo(function DocumentCard({
       onClick={onSelect}
       tabIndex={disabled ? -1 : 0}
       role="button"
-      aria-label={t(doc.name ?? '', { defaultValue: doc.name ?? '' })}
+      aria-label={t(getDocName(doc, i18nLanguage), {
+        defaultValue: getDocName(doc, i18nLanguage),
+      })}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
@@ -183,16 +225,15 @@ const MemoizedDocumentCard = React.memo(function DocumentCard({
     >
       <CardHeader className="pb-2 pt-4 px-4">
         <CardTitle className="text-base font-semibold text-card-foreground">
-          {i18nLanguage === 'es' && doc.name_es
-            ? t(doc.name_es, { defaultValue: doc.name_es })
-            : t(doc.name ?? '', { defaultValue: doc.name ?? '' })}
+          {t(getDocName(doc, i18nLanguage), {
+            defaultValue: getDocName(doc, i18nLanguage),
+          })}
         </CardTitle>
       </CardHeader>
       <CardContent className="text-xs text-muted-foreground flex-grow px-4">
-        {i18nLanguage === 'es' && doc.description_es
-          ? t(doc.description_es, { defaultValue: doc.description_es })
-          : t(doc.description ?? '', { defaultValue: doc.description ?? '' }) ||
-            placeholderNoDescription}
+        {t(getDocDescription(doc, i18nLanguage), {
+          defaultValue: getDocDescription(doc, i18nLanguage),
+        }) || placeholderNoDescription}
       </CardContent>
       <CardFooter className="pt-2 pb-3 px-4 text-xs text-muted-foreground flex justify-between items-center border-t border-border mt-auto">
         <span>💲{doc.basePrice}</span>
@@ -216,7 +257,7 @@ const MemoizedTopDocChip = React.memo(function TopDocChip({
   t,
   i18nLanguage,
 }: {
-  doc: Pick<LegalDocument, 'id' | 'name' | 'name_es'> & {
+  doc: Pick<LegalDocument, 'id' | 'translations'> & {
     icon?: React.ElementType;
   };
   onSelect: () => void;
@@ -235,9 +276,9 @@ const MemoizedTopDocChip = React.memo(function TopDocChip({
       {doc.icon &&
         React.createElement(doc.icon, { className: 'h-4 w-4 text-primary/80' })}
       <span className="font-medium text-card-foreground text-xs">
-        {i18nLanguage === 'es' && doc.name_es
-          ? t(doc.name_es, { defaultValue: doc.name_es })
-          : t(doc.name ?? '', { defaultValue: doc.name ?? '' })}
+        {t(getDocName(doc, i18nLanguage), {
+          defaultValue: getDocName(doc, i18nLanguage),
+        })}
       </span>
     </Button>
   );
@@ -341,27 +382,29 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
       const lowerGlobalSearch = globalSearchTerm.toLowerCase();
       docs = docs.filter(
         (doc) =>
-          t(doc.name ?? '', { defaultValue: doc.name ?? '' })
+          t(getDocName(doc, 'en'), { defaultValue: getDocName(doc, 'en') })
             .toLowerCase()
             .includes(lowerGlobalSearch) ||
-          doc.aliases?.some((alias) =>
+          getDocAliases(doc, 'en').some((alias) =>
             alias.toLowerCase().includes(lowerGlobalSearch),
           ) ||
           (languageSupportsSpanish(doc.languageSupport) &&
-            doc.aliases_es?.some((alias) =>
+            getDocAliases(doc, 'es').some((alias) =>
               alias.toLowerCase().includes(lowerGlobalSearch),
             )) ||
           (languageSupportsSpanish(doc.languageSupport) &&
-            doc.name_es &&
-            t(doc.name_es, { defaultValue: doc.name_es })
+            t(getDocName(doc, 'es'), { defaultValue: getDocName(doc, 'es') })
               .toLowerCase()
               .includes(lowerGlobalSearch)) ||
-          t(doc.description ?? '', { defaultValue: doc.description ?? '' })
+          t(getDocDescription(doc, 'en'), {
+            defaultValue: getDocDescription(doc, 'en'),
+          })
             .toLowerCase()
             .includes(lowerGlobalSearch) ||
           (languageSupportsSpanish(doc.languageSupport) &&
-            doc.description_es &&
-            t(doc.description_es, { defaultValue: doc.description_es })
+            t(getDocDescription(doc, 'es'), {
+              defaultValue: getDocDescription(doc, 'es'),
+            })
               .toLowerCase()
               .includes(lowerGlobalSearch)),
       );
@@ -374,27 +417,29 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
         const lowerDocSearch = docSearch.toLowerCase();
         docs = docs.filter(
           (doc) =>
-            t(doc.name ?? '', { defaultValue: doc.name ?? '' })
+            t(getDocName(doc, 'en'), { defaultValue: getDocName(doc, 'en') })
               .toLowerCase()
               .includes(lowerDocSearch) ||
-            doc.aliases?.some((alias) =>
+            getDocAliases(doc, 'en').some((alias) =>
               alias.toLowerCase().includes(lowerDocSearch),
             ) ||
             (languageSupportsSpanish(doc.languageSupport) &&
-              doc.aliases_es?.some((alias) =>
+              getDocAliases(doc, 'es').some((alias) =>
                 alias.toLowerCase().includes(lowerDocSearch),
               )) ||
             (languageSupportsSpanish(doc.languageSupport) &&
-              doc.name_es &&
-              t(doc.name_es, { defaultValue: doc.name_es })
+              t(getDocName(doc, 'es'), { defaultValue: getDocName(doc, 'es') })
                 .toLowerCase()
                 .includes(lowerDocSearch)) ||
-            t(doc.description ?? '', { defaultValue: doc.description ?? '' })
+            t(getDocDescription(doc, 'en'), {
+              defaultValue: getDocDescription(doc, 'en'),
+            })
               .toLowerCase()
               .includes(lowerDocSearch) ||
             (languageSupportsSpanish(doc.languageSupport) &&
-              doc.description_es &&
-              t(doc.description_es, { defaultValue: doc.description_es })
+              t(getDocDescription(doc, 'es'), {
+                defaultValue: getDocDescription(doc, 'es'),
+              })
                 .toLowerCase()
                 .includes(lowerDocSearch)),
         );
@@ -450,9 +495,7 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
   };
 
   const handleDocSelect = (
-    doc:
-      | LegalDocument
-      | Pick<LegalDocument, 'id' | 'name' | 'name_es' | 'category'>,
+    doc: LegalDocument | Pick<LegalDocument, 'id' | 'category' | 'translations'>,
   ) => {
     if (!isHydrated) return;
     const fullDoc = documentLibrary.find((d) => d.id === doc.id);
@@ -477,7 +520,7 @@ const Step1DocumentSelector = React.memo(function Step1DocumentSelector({
     onDocumentSelect(fullDoc);
     track('select_item', {
       item_id: fullDoc.id,
-      item_name: fullDoc.name,
+      item_name: getDocName(fullDoc, i18n.language),
       item_category: fullDoc.category,
       price: fullDoc.basePrice,
       state: globalSelectedState,

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -524,13 +524,11 @@ export default function WizardForm({
             documentType:
               locale === 'es'
                 ? doc.translations?.es?.name ||
-                  doc.name_es ||
                   doc.translations?.en?.name ||
                   doc.name
                 : doc.translations?.en?.name ||
                   doc.name ||
-                  doc.translations?.es?.name ||
-                  doc.name_es,
+                  doc.translations?.es?.name,
           })}
         </p>
       </div>
@@ -647,8 +645,8 @@ export default function WizardForm({
         clientSecret={paymentClientSecret}
         documentName={
           locale === 'es'
-            ? doc.translations?.es?.name || doc.name_es || doc.name
-            : doc.translations?.en?.name || doc.name || doc.name_es
+            ? doc.translations?.es?.name || doc.translations?.en?.name || doc.name
+            : doc.translations?.en?.name || doc.name || doc.translations?.es?.name
         }
         priceCents={(doc.basePrice || 35) * 100}
         onSuccess={handlePaymentSuccess}

--- a/src/components/WizardLayout.tsx
+++ b/src/components/WizardLayout.tsx
@@ -23,7 +23,9 @@ export default function WizardLayout({
   const { t } = useTranslation('common');
 
   const documentDisplayName =
-    locale === 'es' && doc.name_es ? doc.name_es : doc.name;
+    locale === 'es'
+      ? doc.translations?.es?.name || doc.translations?.en?.name || doc.name
+      : doc.translations?.en?.name || doc.name || doc.translations?.es?.name;
 
   // This component now acts more as a structural wrapper if still needed.
   // The core form and preview logic is expected to be handled by its children,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -558,14 +558,20 @@ export const getLocalizedDocStrings = (
   doc: LegalDocument,
   locale: 'en' | 'es',
 ) => {
-  let name = doc.name;
-  let description = doc.description;
-  let aliases: string[] = doc.aliases || [];
+  let name =
+    doc.translations?.en?.name || doc.translations?.es?.name || doc.name || '';
+  let description =
+    doc.translations?.en?.description ||
+    doc.translations?.es?.description ||
+    doc.description ||
+    '';
+  let aliases: string[] =
+    doc.translations?.en?.aliases || doc.translations?.es?.aliases || doc.aliases || [];
 
   if (locale === 'es') {
-    name = doc.name_es || doc.name;
-    description = doc.description_es || doc.description;
-    aliases = doc.aliases_es || doc.aliases || [];
+    name = doc.translations?.es?.name || name;
+    description = doc.translations?.es?.description || description;
+    aliases = doc.translations?.es?.aliases || aliases;
   }
   return { name, description, aliases };
 };

--- a/src/lib/document-library.ts
+++ b/src/lib/document-library.ts
@@ -114,19 +114,16 @@ allDocuments.forEach((doc) => {
     es: {
       name:
         baseTranslations.es?.name ||
-        doc.name_es ||
         baseTranslations.en?.name ||
         doc.name ||
         doc.id,
       description:
         baseTranslations.es?.description ||
-        doc.description_es ||
         baseTranslations.en?.description ||
         doc.description ||
         '',
       aliases:
         baseTranslations.es?.aliases ||
-        doc.aliases_es ||
         baseTranslations.en?.aliases ||
         doc.aliases ||
         [],

--- a/src/lib/documents/us/bill-of-sale-vehicle.ts
+++ b/src/lib/documents/us/bill-of-sale-vehicle.ts
@@ -37,25 +37,6 @@ export const billOfSaleVehicle: LegalDocument = {
       ],
     },
   },
-  // Add these:
-  name: 'Vehicle Bill of Sale',
-  name_es: 'Contrato de Compraventa de Vehículo',
-  description:
-    'Document the sale and transfer of ownership for a vehicle, compliant with state requirements.',
-  description_es:
-    'Documentar la venta y transferencia de propiedad de un vehículo, conforme a los requisitos estatales.',
-  aliases: [
-    'sell car',
-    'used item sale',
-    'vehicle transfer',
-    'car sale contract',
-  ],
-  aliases_es: [
-    'venta de coche',
-    'venta de artículo usado',
-    'transferencia de vehículo',
-    'contrato de venta de auto',
-  ],
   templatePaths: {
     // Relative to /src/templates/
     en: 'en/us/bill-of-sale-vehicle.md',

--- a/src/lib/documents/us/child-medical-consent.ts
+++ b/src/lib/documents/us/child-medical-consent.ts
@@ -3,14 +3,19 @@ import type { LegalDocument } from '@/types/documents';
 
 export const childMedicalConsent: LegalDocument = {
   id: 'child-medical-consent',
-  // TODO: Refactor to use translations structure
-  name: 'Child Medical Consent Form',
-  name_es: 'Formulario de Consentimiento Médico para Menores',
   category: 'Family',
-  description:
-    'Authorize a caregiver to make medical decisions for your child.',
-  description_es:
-    'Autorizar a un cuidador a tomar decisiones médicas por su hijo.',
+  translations: {
+    en: {
+      name: 'Child Medical Consent Form',
+      description:
+        'Authorize a caregiver to make medical decisions for your child.',
+    },
+    es: {
+      name: 'Formulario de Consentimiento Médico para Menores',
+      description:
+        'Autorizar a un cuidador a tomar decisiones médicas por su hijo.',
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: false,

--- a/src/lib/documents/us/commercial-lease-agreement.ts
+++ b/src/lib/documents/us/commercial-lease-agreement.ts
@@ -3,13 +3,18 @@ import type { LegalDocument } from '@/types/documents';
 
 export const commercialLeaseAgreement: LegalDocument = {
   id: 'commercial-lease-agreement',
-  // TODO: Refactor to use translations structure
-  name: 'Commercial Lease Agreement',
-  name_es: 'Contrato de Arrendamiento Comercial',
   category: 'Real Estate',
-  description: 'Lease agreement specifically for commercial properties.',
-  description_es:
-    'Contrato de arrendamiento específico para propiedades comerciales.',
+  translations: {
+    en: {
+      name: 'Commercial Lease Agreement',
+      description: 'Lease agreement specifically for commercial properties.',
+    },
+    es: {
+      name: 'Contrato de Arrendamiento Comercial',
+      description:
+        'Contrato de arrendamiento específico para propiedades comerciales.',
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: true,

--- a/src/lib/documents/us/demand-letter-payment.ts
+++ b/src/lib/documents/us/demand-letter-payment.ts
@@ -3,14 +3,19 @@ import type { LegalDocument } from '@/types/documents';
 
 export const demandLetterPayment: LegalDocument = {
   id: 'demand-letter-payment',
-  // TODO: Refactor to use translations structure
-  name: 'Demand Letter (Payment)',
-  name_es: 'Carta de Reclamación (Pago)',
   category: 'Finance',
-  description: 'Formally request payment that is overdue.',
-  description_es: 'Solicitar formalmente un pago atrasado.',
-  aliases: ['request payment', 'owe money', 'legal demand'],
-  aliases_es: ['solicitar pago', 'deber dinero', 'demanda legal'],
+  translations: {
+    en: {
+      name: 'Demand Letter (Payment)',
+      description: 'Formally request payment that is overdue.',
+      aliases: ['request payment', 'owe money', 'legal demand'],
+    },
+    es: {
+      name: 'Carta de Reclamación (Pago)',
+      description: 'Solicitar formalmente un pago atrasado.',
+      aliases: ['solicitar pago', 'deber dinero', 'demanda legal'],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/divorce-settlement-agreement.ts
+++ b/src/lib/documents/us/divorce-settlement-agreement.ts
@@ -4,28 +4,33 @@ import { usStates } from '@/lib/document-library/utils';
 
 export const divorceSettlementAgreement: LegalDocument = {
   id: 'divorce-settlement-agreement',
-  // TODO: Refactor to use translations structure
-  name: 'Divorce Settlement Agreement',
-  name_es: 'Acuerdo de Divorcio',
   category: 'Family',
-  description:
-    'Formalizes the terms of a divorce, including property division, support, and custody.',
-  description_es:
-    'Formaliza los términos de un divorcio, incluyendo división de bienes, manutención y custodia.',
-  aliases: [
-    'divorce',
-    'separation',
-    'end marriage',
-    'get divorced',
-    'marital settlement',
-  ],
-  aliases_es: [
-    'divorcio',
-    'separación',
-    'terminar matrimonio',
-    'divorciarse',
-    'acuerdo matrimonial',
-  ],
+  translations: {
+    en: {
+      name: 'Divorce Settlement Agreement',
+      description:
+        'Formalizes the terms of a divorce, including property division, support, and custody.',
+      aliases: [
+        'divorce',
+        'separation',
+        'end marriage',
+        'get divorced',
+        'marital settlement',
+      ],
+    },
+    es: {
+      name: 'Acuerdo de Divorcio',
+      description:
+        'Formaliza los términos de un divorcio, incluyendo división de bienes, manutención y custodia.',
+      aliases: [
+        'divorcio',
+        'separación',
+        'terminar matrimonio',
+        'divorciarse',
+        'acuerdo matrimonial',
+      ],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: true,

--- a/src/lib/documents/us/employment-offer-letter.ts
+++ b/src/lib/documents/us/employment-offer-letter.ts
@@ -3,16 +3,21 @@ import type { LegalDocument } from '@/types/documents';
 
 export const employmentOfferLetter: LegalDocument = {
   id: 'employment-offer-letter',
-  // TODO: Refactor to use translations structure
-  name: 'Employment Offer Letter',
-  name_es: 'Carta de Oferta de Empleo',
   category: 'Employment',
-  description:
-    'Formalize a job offer with key terms like salary, start date, and position.',
-  description_es:
-    'Formalizar una oferta de trabajo con términos clave como salario, fecha de inicio y puesto.',
-  aliases: ['hire employee', 'job offer', 'terms of employment'],
-  aliases_es: ['contratar empleado', 'oferta de trabajo', 'términos de empleo'],
+  translations: {
+    en: {
+      name: 'Employment Offer Letter',
+      description:
+        'Formalize a job offer with key terms like salary, start date, and position.',
+      aliases: ['hire employee', 'job offer', 'terms of employment'],
+    },
+    es: {
+      name: 'Carta de Oferta de Empleo',
+      description:
+        'Formalizar una oferta de trabajo con términos clave como salario, fecha de inicio y puesto.',
+      aliases: ['contratar empleado', 'oferta de trabajo', 'términos de empleo'],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/employment-termination-letter.ts
+++ b/src/lib/documents/us/employment-termination-letter.ts
@@ -3,14 +3,19 @@ import type { LegalDocument } from '@/types/documents';
 
 export const employmentTerminationLetter: LegalDocument = {
   id: 'employment-termination-letter',
-  // TODO: Refactor to use translations and templatePaths structures
-  name: 'Employment Termination Letter',
-  name_es: 'Carta de Terminación de Empleo',
   category: 'Employment',
-  description: 'Formally notify an employee of their termination.',
-  description_es: 'Notificar formalmente a un empleado de su despido.',
-  aliases: ['fire employee', 'layoff letter', 'termination notice'],
-  aliases_es: ['despedir empleado', 'carta de despido', 'aviso de terminación'],
+  translations: {
+    en: {
+      name: 'Employment Termination Letter',
+      description: 'Formally notify an employee of their termination.',
+      aliases: ['fire employee', 'layoff letter', 'termination notice'],
+    },
+    es: {
+      name: 'Carta de Terminación de Empleo',
+      description: 'Notificar formalmente a un empleado de su despido.',
+      aliases: ['despedir empleado', 'carta de despido', 'aviso de terminación'],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/eviction-notice.ts
+++ b/src/lib/documents/us/eviction-notice.ts
@@ -4,20 +4,25 @@ import { usStates } from '@/lib/document-library/utils';
 
 export const evictionNotice: LegalDocument = {
   id: 'eviction-notice',
-  // TODO: Refactor to use translations structure
-  name: 'Eviction Notice',
-  name_es: 'Aviso de Desalojo',
   category: 'Real Estate',
-  description: 'Formal notice to a tenant to vacate the property.',
-  description_es:
-    'Notificación formal a un inquilino para desalojar la propiedad.',
-  aliases: ['remove tenant', 'late rent', 'kick out', 'notice to quit'],
-  aliases_es: [
-    'desalojar inquilino',
-    'renta atrasada',
-    'echar',
-    'notificación de desalojo',
-  ],
+  translations: {
+    en: {
+      name: 'Eviction Notice',
+      description: 'Formal notice to a tenant to vacate the property.',
+      aliases: ['remove tenant', 'late rent', 'kick out', 'notice to quit'],
+    },
+    es: {
+      name: 'Aviso de Desalojo',
+      description:
+        'Notificación formal a un inquilino para desalojar la propiedad.',
+      aliases: [
+        'desalojar inquilino',
+        'renta atrasada',
+        'echar',
+        'notificación de desalojo',
+      ],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/healthcare-power-of-attorney.ts
+++ b/src/lib/documents/us/healthcare-power-of-attorney.ts
@@ -5,25 +5,30 @@ import { usStates } from '@/lib/document-library/utils';
 
 export const healthcarePowerOfAttorney: LegalDocument = {
   id: 'healthcare-power-of-attorney',
-  // TODO: Refactor to use translations structure
-  name: 'Healthcare Power of Attorney',
-  name_es: 'Poder Notarial para Atención Médica',
   category: 'Personal',
-  description: 'Appoint an agent to make healthcare decisions if you cannot.',
-  description_es:
-    'Nombrar un agente para tomar decisiones de atención médica si usted no puede.',
-  aliases: [
-    'medical poa',
-    'healthcare proxy',
-    'appoint agent for health',
-    'medical decisions',
-  ],
-  aliases_es: [
-    'poder médico',
-    'proxy de salud',
-    'designar agente de salud',
-    'decisiones médicas',
-  ],
+  translations: {
+    en: {
+      name: 'Healthcare Power of Attorney',
+      description: 'Appoint an agent to make healthcare decisions if you cannot.',
+      aliases: [
+        'medical poa',
+        'healthcare proxy',
+        'appoint agent for health',
+        'medical decisions',
+      ],
+    },
+    es: {
+      name: 'Poder Notarial para Atención Médica',
+      description:
+        'Nombrar un agente para tomar decisiones de atención médica si usted no puede.',
+      aliases: [
+        'poder médico',
+        'proxy de salud',
+        'designar agente de salud',
+        'decisiones médicas',
+      ],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: false,

--- a/src/lib/documents/us/invoice.ts
+++ b/src/lib/documents/us/invoice.ts
@@ -3,12 +3,17 @@ import type { LegalDocument } from '@/types/documents';
 
 export const invoice: LegalDocument = {
   id: 'invoice',
-  // TODO: Refactor to use translations structure
-  name: 'Invoice',
-  name_es: 'Factura',
   category: 'Finance',
-  description: 'Request payment for goods or services rendered.',
-  description_es: 'Solicitar pago por bienes o servicios prestados.',
+  translations: {
+    en: {
+      name: 'Invoice',
+      description: 'Request payment for goods or services rendered.',
+    },
+    es: {
+      name: 'Factura',
+      description: 'Solicitar pago por bienes o servicios prestados.',
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/last-will-testament.ts
+++ b/src/lib/documents/us/last-will-testament.ts
@@ -4,15 +4,20 @@ import { usStates } from '@/lib/document-library/utils';
 
 export const lastWillTestament: LegalDocument = {
   id: 'last-will-testament',
-  // TODO: Refactor to use translations structure
-  name: 'Last Will and Testament',
-  name_es: 'Última Voluntad y Testamento',
   category: 'Estate Planning',
-  description: 'Specify how your assets should be distributed after death.',
-  description_es:
-    'Especificar cómo deben distribuirse sus bienes después de la muerte.',
-  aliases: ['will', 'inheritance', 'distribute assets'],
-  aliases_es: ['testamento', 'herencia', 'distribuir bienes'],
+  translations: {
+    en: {
+      name: 'Last Will and Testament',
+      description: 'Specify how your assets should be distributed after death.',
+      aliases: ['will', 'inheritance', 'distribute assets'],
+    },
+    es: {
+      name: 'Última Voluntad y Testamento',
+      description:
+        'Especificar cómo deben distribuirse sus bienes después de la muerte.',
+      aliases: ['testamento', 'herencia', 'distribuir bienes'],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: false,

--- a/src/lib/documents/us/living-trust.ts
+++ b/src/lib/documents/us/living-trust.ts
@@ -3,13 +3,19 @@ import type { LegalDocument } from '@/types/documents';
 
 export const livingTrust: LegalDocument = {
   id: 'living-trust',
-  name: 'Living Trust (Revocable)',
-  name_es: 'Fideicomiso en Vida (Revocable)',
   category: 'Estate Planning',
-  description:
-    'Manage assets during life and distribute after death, potentially avoiding probate.',
-  description_es:
-    'Gestionar activos durante la vida y distribuirlos después de la muerte, potencialmente evitando el proceso sucesorio.',
+  translations: {
+    en: {
+      name: 'Living Trust (Revocable)',
+      description:
+        'Manage assets during life and distribute after death, potentially avoiding probate.',
+    },
+    es: {
+      name: 'Fideicomiso en Vida (Revocable)',
+      description:
+        'Gestionar activos durante la vida y distribuirlos después de la muerte, potencialmente evitando el proceso sucesorio.',
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: false,

--- a/src/lib/documents/us/living-will.ts
+++ b/src/lib/documents/us/living-will.ts
@@ -3,24 +3,30 @@ import type { LegalDocument } from '@/types/documents';
 
 export const livingWill: LegalDocument = {
   id: 'living-will',
-  name: 'Living Will / Advance Directive',
-  name_es: 'Testamento Vital / Directiva Anticipada',
   category: 'Personal',
-  description: 'Specify your wishes for end-of-life medical care.',
-  description_es:
-    'Especificar sus deseos para la atención médica al final de la vida.',
-  aliases: [
-    'medical wishes',
-    'advance directive',
-    'life support',
-    'end of life',
-  ],
-  aliases_es: [
-    'deseos médicos',
-    'directiva anticipada',
-    'soporte vital',
-    'fin de vida',
-  ],
+  translations: {
+    en: {
+      name: 'Living Will / Advance Directive',
+      description: 'Specify your wishes for end-of-life medical care.',
+      aliases: [
+        'medical wishes',
+        'advance directive',
+        'life support',
+        'end of life',
+      ],
+    },
+    es: {
+      name: 'Testamento Vital / Directiva Anticipada',
+      description:
+        'Especificar sus deseos para la atención médica al final de la vida.',
+      aliases: [
+        'deseos médicos',
+        'directiva anticipada',
+        'soporte vital',
+        'fin de vida',
+      ],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: false,

--- a/src/lib/documents/us/non-compete-agreement.ts
+++ b/src/lib/documents/us/non-compete-agreement.ts
@@ -3,15 +3,21 @@ import type { LegalDocument } from '@/types/documents';
 
 export const nonCompeteAgreement: LegalDocument = {
   id: 'non-compete-agreement',
-  name: 'Non-Compete Agreement',
-  name_es: 'Acuerdo de No Competencia',
   category: 'Business',
-  description:
-    'Restrict an employee or contractor from competing after termination.',
-  description_es:
-    'Restringir a un empleado o contratista de competir después de la terminación.',
-  aliases: ['restrict competition', 'former employee', 'noncompete'],
-  aliases_es: ['restringir competencia', 'ex empleado', 'no competencia'],
+  translations: {
+    en: {
+      name: 'Non-Compete Agreement',
+      description:
+        'Restrict an employee or contractor from competing after termination.',
+      aliases: ['restrict competition', 'former employee', 'noncompete'],
+    },
+    es: {
+      name: 'Acuerdo de No Competencia',
+      description:
+        'Restringir a un empleado o contratista de competir después de la terminación.',
+      aliases: ['restringir competencia', 'ex empleado', 'no competencia'],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/operating-agreement.ts
+++ b/src/lib/documents/us/operating-agreement.ts
@@ -3,15 +3,21 @@ import type { LegalDocument } from '@/types/documents';
 
 export const operatingAgreement: LegalDocument = {
   id: 'operating-agreement',
-  name: 'Operating Agreement (LLC)',
-  name_es: 'Acuerdo Operativo (LLC)',
   category: 'Business',
-  description:
-    'Outline the ownership structure and operating procedures for an LLC.',
-  description_es:
-    'Esbozar la estructura de propiedad y los procedimientos operativos para una LLC.',
-  aliases: ['LLC agreement', 'limited liability company'],
-  aliases_es: ['acuerdo de LLC', 'sociedad de responsabilidad limitada'],
+  translations: {
+    en: {
+      name: 'Operating Agreement (LLC)',
+      description:
+        'Outline the ownership structure and operating procedures for an LLC.',
+      aliases: ['LLC agreement', 'limited liability company'],
+    },
+    es: {
+      name: 'Acuerdo Operativo (LLC)',
+      description:
+        'Esbozar la estructura de propiedad y los procedimientos operativos para una LLC.',
+      aliases: ['acuerdo de LLC', 'sociedad de responsabilidad limitada'],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/partnership-agreement.ts
+++ b/src/lib/documents/us/partnership-agreement.ts
@@ -4,15 +4,21 @@ import { usStates } from '@/lib/document-library/utils';
 
 export const partnershipAgreement: LegalDocument = {
   id: 'partnership-agreement',
-  name: 'Partnership Agreement',
-  name_es: 'Acuerdo de Sociedad',
   category: 'Business',
-  description:
-    'Define the terms, responsibilities, and profit sharing for business partners.',
-  description_es:
-    'Definir los términos, responsabilidades y reparto de beneficios para socios comerciales.',
-  aliases: ['business partners', 'joint venture', 'partner terms'],
-  aliases_es: ['socios de negocios', 'empresa conjunta', 'términos de socios'],
+  translations: {
+    en: {
+      name: 'Partnership Agreement',
+      description:
+        'Define the terms, responsibilities, and profit sharing for business partners.',
+      aliases: ['business partners', 'joint venture', 'partner terms'],
+    },
+    es: {
+      name: 'Acuerdo de Sociedad',
+      description:
+        'Definir los términos, responsabilidades y reparto de beneficios para socios comerciales.',
+      aliases: ['socios de negocios', 'empresa conjunta', 'términos de socios'],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/prenuptial-agreement.ts
+++ b/src/lib/documents/us/prenuptial-agreement.ts
@@ -3,15 +3,21 @@ import type { LegalDocument } from '@/types/documents';
 
 export const prenuptialAgreement: LegalDocument = {
   id: 'prenuptial-agreement',
-  name: 'Prenuptial Agreement',
-  name_es: 'Acuerdo Prenupcial',
   category: 'Family',
-  description:
-    'Agreement made before marriage regarding asset division if divorced.',
-  description_es:
-    'Acuerdo hecho antes del matrimonio sobre la división de bienes en caso de divorcio.',
-  aliases: ['prenup', 'marriage contract', 'before marriage agreement'],
-  aliases_es: ['prenup', 'contrato matrimonial', 'acuerdo prematrimonial'],
+  translations: {
+    en: {
+      name: 'Prenuptial Agreement',
+      description:
+        'Agreement made before marriage regarding asset division if divorced.',
+      aliases: ['prenup', 'marriage contract', 'before marriage agreement'],
+    },
+    es: {
+      name: 'Acuerdo Prenupcial',
+      description:
+        'Acuerdo hecho antes del matrimonio sobre la división de bienes en caso de divorcio.',
+      aliases: ['prenup', 'contrato matrimonial', 'acuerdo prematrimonial'],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: false,

--- a/src/lib/documents/us/quitclaim-deed.ts
+++ b/src/lib/documents/us/quitclaim-deed.ts
@@ -3,17 +3,23 @@ import type { LegalDocument } from '@/types/documents';
 
 export const quitclaimDeed: LegalDocument = {
   id: 'quitclaim-deed',
-  name: 'Quitclaim Deed',
-  name_es: 'Escritura de Finiquito',
   category: 'Real Estate',
-  description: 'Transfer property interest without warranty of title.',
-  description_es: 'Transferir interés en una propiedad sin garantía de título.',
-  aliases: ['property transfer', 'quit claim deed', 'transfer ownership'],
-  aliases_es: [
-    'transferencia de propiedad',
-    'escritura de finiquito',
-    'transferir titularidad',
-  ],
+  translations: {
+    en: {
+      name: 'Quitclaim Deed',
+      description: 'Transfer property interest without warranty of title.',
+      aliases: ['property transfer', 'quit claim deed', 'transfer ownership'],
+    },
+    es: {
+      name: 'Escritura de Finiquito',
+      description: 'Transferir interés en una propiedad sin garantía de título.',
+      aliases: [
+        'transferencia de propiedad',
+        'escritura de finiquito',
+        'transferir titularidad',
+      ],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: true,
   canBeRecorded: true,

--- a/src/lib/documents/us/service-agreement.ts
+++ b/src/lib/documents/us/service-agreement.ts
@@ -4,18 +4,24 @@ import { usStates } from '@/lib/document-library/utils';
 
 export const serviceAgreement: LegalDocument = {
   id: 'service-agreement',
-  name: 'Service Agreement',
-  name_es: 'Acuerdo de Servicios',
   category: 'Business',
-  description: 'Outline terms for providing or receiving ongoing services.',
-  description_es:
-    'Esbozar términos para proporcionar o recibir servicios continuos.',
-  aliases: ['hire services', 'service provider', 'payment terms'],
-  aliases_es: [
-    'contratar servicios',
-    'proveedor de servicios',
-    'términos de pago',
-  ],
+  translations: {
+    en: {
+      name: 'Service Agreement',
+      description: 'Outline terms for providing or receiving ongoing services.',
+      aliases: ['hire services', 'service provider', 'payment terms'],
+    },
+    es: {
+      name: 'Acuerdo de Servicios',
+      description:
+        'Esbozar términos para proporcionar o recibir servicios continuos.',
+      aliases: [
+        'contratar servicios',
+        'proveedor de servicios',
+        'términos de pago',
+      ],
+    },
+  },
   languageSupport: ['en', 'es'],
   requiresNotarization: false,
   canBeRecorded: false,

--- a/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
+++ b/src/lib/documents/us/vehicle-bill-of-sale/metadata.ts
@@ -33,24 +33,6 @@ export const vehicleBillOfSaleMeta: LegalDocument = {
   questions: vehicleBillOfSaleQuestions,
   upsellClauses: [],
   // Direct name/description for fallbacks or non-i18n contexts
-  name: 'Vehicle Bill of Sale',
-  name_es: 'Contrato de Compraventa de Vehículo',
-  description:
-    'Document the sale and transfer of ownership for a vehicle, compliant with state requirements.',
-  description_es:
-    'Documentar la venta y transferencia de propiedad de un vehículo, conforme a los requisitos estatales.',
-  aliases: [
-    'sell car',
-    'used item sale',
-    'vehicle transfer',
-    'car sale contract',
-  ],
-  aliases_es: [
-    'venta de coche',
-    'venta de artículo usado',
-    'transferencia de vehículo',
-    'contrato de venta de auto',
-  ],
   translations: {
     // For i18n-heavy components or future use
     en: {


### PR DESCRIPTION
## Summary
- use `translations` property in US document metadata
- remove deprecated `name_es`/`description_es` fields
- read translations in document selector and other components
- adjust document library fallbacks

## Testing
- `npm run lint` *(fails: React must be in scope)*
- `npm run test`
- `npm run e2e`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683a7c47a7e0832da55774ec3a205fcf