### PR TITLE
[UI] Fix unused imports in forms

### DIFF
--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -30,6 +30,7 @@ import ReviewStep from '@/components/ReviewStep';
 import PaymentModal from '@/components/PaymentModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation'; // Added useRouter
+import AddressField from '@/components/AddressField';
 
 interface WizardFormProps {
   locale: 'en' | 'es';
@@ -419,13 +420,10 @@ export default function WizardForm({
     setShowAuthModal(true);
   }, [isSavingDraft, formIsSubmitting, user?.uid, saveDraftAndRedirect]);
 
-  const handleAuthSuccess = useCallback(
-    (_mode, uid) => {
-      setShowAuthModal(false);
-      // saveDraftAndRedirect will fire via the pendingRedirect effect
-    },
-    [],
-  );
+  const handleAuthSuccess = useCallback(() => {
+    setShowAuthModal(false);
+    // saveDraftAndRedirect will fire via the pendingRedirect effect
+  }, []);
 
   if (!isHydrated || authIsLoading) {
     return (

--- a/src/components/docs/VehicleBillOfSaleDisplay.tsx
+++ b/src/components/docs/VehicleBillOfSaleDisplay.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/components/ui/table';
 import { track } from '@/lib/analytics';
 import { useCart } from '@/contexts/CartProvider';
-import { Car, Edit, Signature, ShieldCheck } from 'lucide-react';
+import { Edit, Signature, ShieldCheck } from 'lucide-react';
 import { BookOpen } from 'lucide-react';
 import StickyMobileCTA from '@/components/StickyMobileCTA';
 import StickyGuaranteeBar from '@/components/StickyGuaranteeBar';


### PR DESCRIPTION
## Summary
- add missing `AddressField` import in `WizardForm`
- remove unused `Car` icon import
- clean up auth callback params

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683a83d45d98832da8dd846facb4a9f5