### PR TITLE
[UI] Resolve lint issues and accessibility warnings

### DIFF
--- a/scripts/find-missing-i18n.js
+++ b/scripts/find-missing-i18n.js
@@ -12,11 +12,11 @@ if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
       if (i18nInstance) {
         const missingKeys = new Set();
 
-        i18nInstance.on('missingKey', (lngs, namespace, key, res) => {
+        i18nInstance.on('missingKey', (lngs, namespace, key) => {
           missingKeys.add(`${namespace}:${key}`);
         });
 
-        // @ts-ignore
+        // @ts-expect-error -- __printMissing is for debugging only
         window.__printMissing = () => {
           if (missingKeys.size > 0) {
             console.log('Missing i18n Keys:', [...missingKeys]);

--- a/scripts/splitTranslations.js
+++ b/scripts/splitTranslations.js
@@ -1,8 +1,8 @@
 // scripts/splitTranslations.js
 /* eslint-env node */
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
 
 // adjust these if you add/remove languages
 const LANGS = ['en', 'es'];

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -155,7 +155,7 @@ export default function DashboardClientContent({
     }
 
     switch (activeTab) {
-      case 'documents':
+      case 'documents': {
         const sorted = [...documents].sort((a, b) => {
           const dir = sortDir === 'asc' ? 1 : -1;
           let valA: string | number = '';
@@ -167,12 +167,14 @@ export default function DashboardClientContent({
             valA = a.status.toLowerCase();
             valB = b.status.toLowerCase();
           } else {
-            const dA = (typeof a.date === 'object' && 'toDate' in a.date)
-              ? a.date.toDate()
-              : new Date(a.date as any);
-            const dB = (typeof b.date === 'object' && 'toDate' in b.date)
-              ? b.date.toDate()
-              : new Date(b.date as any);
+            const dA =
+              typeof a.date === 'object' && 'toDate' in a.date
+                ? a.date.toDate()
+                : new Date(a.date as unknown as string);
+            const dB =
+              typeof b.date === 'object' && 'toDate' in b.date
+                ? b.date.toDate()
+                : new Date(b.date as unknown as string);
             valA = dA.getTime();
             valB = dB.getTime();
           }
@@ -300,6 +302,7 @@ export default function DashboardClientContent({
             />
           </>
         );
+      }
       case 'payments':
         return (
           <div className="space-y-4">

--- a/src/app/[locale]/docs/[docId]/page.tsx
+++ b/src/app/[locale]/docs/[docId]/page.tsx
@@ -71,7 +71,7 @@ export function Head({ params }: { params: DocPageParams }) {
   const faqJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
-    mainEntity: vehicleBillOfSaleFaqs.map((faq, index) => ({
+    mainEntity: vehicleBillOfSaleFaqs.map((faq) => ({
       '@type': 'Question',
       name: params.locale === 'es' ? faq.questionEs : faq.questionEn,
       acceptedAnswer: {

--- a/src/app/[locale]/docs/[docId]/start/page.tsx
+++ b/src/app/[locale]/docs/[docId]/start/page.tsx
@@ -4,9 +4,6 @@
 import StartWizardPageClient from './StartWizardPageClient';
 import { documentLibrary } from '@/lib/document-library';
 import { localizations } from '@/lib/localizations'; // Assuming this defines your supported locales e.g. [{id: 'en'}, {id: 'es'}]
-type StartWizardPageProps = {
-  params: { locale: 'en' | 'es'; docId: string };
-};
 
 // Revalidate every hour so start pages stay fresh without rebuilding constantly
 export const revalidate = 3600;
@@ -103,7 +100,7 @@ export async function generateStaticParams() {
 }
 
 // This Server Component now correctly passes params to the Client Component
-export default async function StartWizardPage({}: StartWizardPageProps) {
+export default async function StartWizardPage() {
   // Await a microtask to satisfy Next.js dynamic route requirements
   await Promise.resolve();
   // The StartWizardPageClient will handle fetching its own specific document data

--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -2,7 +2,6 @@
 'use client';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import dynamic from 'next/dynamic';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -42,11 +41,6 @@ import { useToast } from '@/hooks/use-toast';
 import AuthModal from '@/components/AuthModal';
 import { useAuth } from '@/hooks/useAuth'; // Import useAuth
 import { createSignWellDocument } from '@/services/signwell';
-
-const SignwellHeroAnimationClient = dynamic(
-  () => import('@/components/SignwellHeroAnimationClient'),
-  { ssr: false }
-);
 
 interface SignWellClientContentProps {
   params: { locale: 'en' | 'es' };
@@ -157,9 +151,13 @@ const DropzonePlaceholder = ({
       onDragLeave={handleDragLeave}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
-      onClick={onClick} // Use the passed onClick handler
-    >
+      onClick={onClick}
+      onKeyDown={(e) => e.key === 'Enter' && onClick(e)}
+      role="button"
+      tabIndex={0}
+      >
       <input
+        id="file-input"
         type="file"
         ref={inputRef}
         className="hidden"

--- a/src/app/[locale]/templates/templates-client-content.tsx
+++ b/src/app/[locale]/templates/templates-client-content.tsx
@@ -10,7 +10,6 @@ import TrustBadges from '@/components/TrustBadges';
 import { FileText } from 'lucide-react';
 import AutoImage from '@/components/AutoImage';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
 interface Props {
   locale: 'en' | 'es';
@@ -18,7 +17,6 @@ interface Props {
 
 export default function TemplatesClientContent({ locale }: Props) {
   const { t } = useTranslation('common');
-  const router = useRouter();
 
   const categoryHref = (key: string) =>
     `/${locale}/?category=${encodeURIComponent(key)}#workflow-start`;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default function RootLayout({
         className={`${inter.variable} ${merriweather.variable} antialiased flex flex-col min-h-screen overflow-x-hidden`}
       >
         <RootClient>{children}</RootClient>
-        {/* global gradient defs */}
+        {/* SVG defs for gradients */}
         <svg width="0" height="0">
           <linearGradient id="goldGradient" x1="0" x2="0" y1="0" y2="1">
             <stop offset="0%" stopColor="#fcd34d" />

--- a/src/app/sentry-example-page/page.tsx
+++ b/src/app/sentry-example-page/page.tsx
@@ -40,8 +40,22 @@ export default function Page() {
         </h1>
 
         <p className="description">
-          Click the button below, and view the sample error on the Sentry <a target="_blank" href="https://123legaldoc.sentry.io/issues/?project=4509409855340544">Issues Page</a>.
-          For more details about setting up Sentry, <a target="_blank" href="https://docs.sentry.io/platforms/javascript/guides/nextjs/">read our docs</a>.
+          Click the button below, and view the sample error on the Sentry{' '}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://123legaldoc.sentry.io/issues/?project=4509409855340544"
+          >
+            Issues Page
+          </a>.
+          For more details about setting up Sentry,
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://docs.sentry.io/platforms/javascript/guides/nextjs/"
+          >
+            read our docs
+          </a>.
         </p>
 
         <button
@@ -70,7 +84,18 @@ export default function Page() {
           </p>
         ) : !isConnected ? (
           <div className="connectivity-error">
-            <p>The Sentry SDK is not able to reach Sentry right now - this may be due to an adblocker. For more information, see <a target="_blank" href="https://docs.sentry.io/platforms/javascript/guides/nextjs/troubleshooting/#the-sdk-is-not-sending-any-data">the troubleshooting guide</a>.</p>
+            <p>
+              The Sentry SDK is not able to reach Sentry right now - this may be
+              due to an adblocker. For more information, see{' '}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://docs.sentry.io/platforms/javascript/guides/nextjs/troubleshooting/#the-sdk-is-not-sending-any-data"
+              >
+                the troubleshooting guide
+              </a>
+              .
+            </p>
           </div>
         ) : (
           <div className="success_placeholder" />

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -18,7 +18,6 @@ import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
 
 /* ---------- real Firebase Auth imports -------------------------------- */
 import type { UserCredential } from 'firebase/auth';
@@ -40,8 +39,6 @@ export default function AuthModal({
   const { t } = useTranslation('common');
   const { toast } = useToast();
   const { login } = useAuth(); // local auth context
-  const params = useParams();
-  const locale = (params?.locale as 'en' | 'es') || 'en';
 
   const [authMode, setAuthMode] = useState<'signin' | 'signup'>('signin');
   const [emailModal, setEmailModal] = useState('');
@@ -146,9 +143,9 @@ export default function AuthModal({
 
       // notify parent (WizardForm)
       onAuthSuccess(authMode, cred.user.uid);
-    } catch (err: any) {
-      console.error('[AuthModal] Firebase Auth error:', err);
-      toast({
+      } catch (err: unknown) {
+        console.error('[AuthModal] Firebase Auth error:', err);
+        toast({
         title: t('authModal.errorAuthFailedTitle', {
           defaultValue: 'Authentication Failed',
         }),

--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -29,7 +29,7 @@ const DocumentDetail = React.memo(function DocumentDetail({
   const [isLoading, setIsLoading] = useState(!initialMarkdown); // If no initial markdown, consider it loading (for fallback/image)
   const [error, setError] = useState<string | null>(null); // Error if initialMarkdown is null/undefined and no docConfig?
   const [isHydrated, setIsHydrated] = useState(false);
-  const [remarkGfmPlugin, setRemarkGfmPlugin] = useState<any | null>(null);
+  const [remarkGfmPlugin, setRemarkGfmPlugin] = useState<unknown | null>(null);
 
   const docConfig = useMemo(
     () => documentLibrary.find((d: LegalDocument) => d.id === docId),

--- a/src/components/DynamicFormRenderer.tsx
+++ b/src/components/DynamicFormRenderer.tsx
@@ -144,7 +144,7 @@ export default function DynamicFormRenderer({
   const analyzeThenSubmit = async () => {
     if (isReadOnly || isLoading || hasSubmitted) return;
 
-    const missing = schema.some((f) => f.required && !Boolean(values[f.id]));
+    const missing = schema.some((f) => f.required && !values[f.id]);
     if (missing) {
       alert(t('dynamicForm.errorMissingRequired'));
       return;

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { loadStripe } from '@stripe/stripe-js';
 import {
   Elements,

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -349,13 +349,14 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
         {fieldsToReview.map((field) => {
           const isCurrentlyEditing = editingFieldId === field.id;
           // console.log(`[ReviewStep] Rendering field: ${field.id}, isCurrentlyEditing: ${isCurrentlyEditing}`);
-          return (
-            <div
-              key={field.id}
-              className="py-3 border-b border-border last:border-b-0 cursor-pointer"
-              onClick={() => !isCurrentlyEditing && handleEdit(field.id)}
-            >
-              <div className="flex justify-between items-start gap-2">
+            return (
+              <React.Fragment key={field.id}>
+                <button
+                  type="button"
+                  className="w-full text-left py-3 border-b border-border last:border-b-0 cursor-pointer"
+                  onClick={() => !isCurrentlyEditing && handleEdit(field.id)}
+                >
+                  <div className="flex justify-between items-start gap-2">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-1 mb-0.5">
                     <p className="text-sm font-medium text-muted-foreground">
@@ -587,14 +588,12 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                                     onCheckedChange={controllerField.onChange}
                                     ref={controllerField.ref}
                                   />
-                                  <Label
-                                    htmlFor={`review-${field.id}`}
-                                    className="text-sm font-normal"
-                                  >
-                                    {Boolean(controllerField.value)
-                                      ? t('Yes')
-                                      : t('No')}
-                                  </Label>
+                                    <Label
+                                      htmlFor={`review-${field.id}`}
+                                      className="text-sm font-normal"
+                                    >
+                                      {controllerField.value ? t('Yes') : t('No')}
+                                    </Label>
                                 </div>
                               );
                             }
@@ -653,15 +652,16 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                     <Edit2 className="w-4 h-4" />
                   </Button>
                 )}
-              </div>
-              {errors[field.id] && isCurrentlyEditing && (
-                <p className="block text-xs text-destructive mt-1 flex items-center gap-1">
-                  <AlertTriangle className="h-3 w-3" />{' '}
-                  {String(errors[field.id]?.message)}
-                </p>
-              )}
-            </div>
-          );
+                </div>
+              </button>
+                {errors[field.id] && isCurrentlyEditing && (
+                  <p className="block text-xs text-destructive mt-1 flex items-center gap-1">
+                    <AlertTriangle className="h-3 w-3" />{' '}
+                    {String(errors[field.id]?.message)}
+                  </p>
+                )}
+              </React.Fragment>
+            );
         })}
       </CardContent>
     </Card>

--- a/src/components/StepThreeForm.tsx
+++ b/src/components/StepThreeForm.tsx
@@ -45,8 +45,12 @@ export function StepThreeForm({
         <PDFPreview url={previewUrl} className="flex-1 border rounded shadow" />
 
         <div className="flex-1 space-y-4">
-          <label className="flex items-center">
-            <Toggle pressed={notarize} onPressedChange={setNotarize} />
+          <label htmlFor="notarizeToggle" className="flex items-center">
+            <Toggle
+              id="notarizeToggle"
+              pressed={notarize}
+              onPressedChange={setNotarize}
+            />
             <span className="ml-2">Add Notarization (+$5)</span>
           </label>
 

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -73,9 +73,11 @@ export default function MobileDrawer({ open, children, onClose }: MobileDrawerPr
     <AnimatePresence>
       {open && (
         <>
-          <div
+          <button
+            type="button"
             className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40"
             onClick={onClose}
+            aria-label={t('Close menu')}
           />
           <motion.aside
             {...bind()}


### PR DESCRIPTION
## Summary
- fix unused var and ts-ignore in i18n debug helper
- migrate translations script to ES module imports
- wrap dashboard case block to avoid eslint errors
- clean up unused imports and props
- improve accessible click targets and roles
- type cleanup for DocumentDetail
- fix boolean cast in form renderer
- address a11y for signwell dropzone
- ensure labels associate with toggles

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683a87f9cc04832da73d8f622b85e777