### PR TITLE
[Layout] Auto-expand Make Documents on mobile

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -145,6 +145,13 @@ const Header = React.memo(function Header() {
   const [isMegaMenuOpen, setIsMegaMenuOpen] = useState(false);
   const [showMobileCategories, setShowMobileCategories] = useState(false);
 
+  // Auto-expand "Make Documents" accordion on initial render for mobile screens
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.innerWidth <= 768) {
+      setShowMobileCategories(true);
+    }
+  }, []);
+
   const placeholderSearch = mounted
     ? tHeader('nav.searchPlaceholder', { defaultValue: 'Search documents...' })
     : '...';


### PR DESCRIPTION
## Summary
- expand the Make Documents section on initial load when the screen width is 768px or less

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683a9ebdeb24832d91d09a882f4ea003