### PR TITLE
[Docs] Improve page load with lazy modules

### DIFF
--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -10,8 +10,21 @@ import { Loader2, Edit, Eye } from 'lucide-react';
 
 import { documentLibrary } from '@/lib/document-library';
 import Breadcrumb from '@/components/Breadcrumb';
-import WizardForm from '@/components/WizardForm';
-import PreviewPane from '@/components/PreviewPane';
+import dynamic from 'next/dynamic';
+
+const Loading = () => (
+  <div className="flex justify-center items-center h-32">
+    <Loader2 className="h-8 w-8 animate-spin text-primary" />
+  </div>
+);
+
+const WizardForm = dynamic(() => import('@/components/WizardForm'), {
+  loading: () => <Loading />,
+});
+
+const PreviewPane = dynamic(() => import('@/components/PreviewPane'), {
+  loading: () => <Loading />,
+});
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import {

--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -1,13 +1,14 @@
 // src/app/[locale]/docs/page.tsx
 // This is an optional index page for all documents.
 // You can redirect to the main homepage or show a list of all categories/documents here.
-'use client';
+import { redirect } from 'next/navigation';
 
-import { redirect, useParams } from 'next/navigation';
+interface DocsIndexPageProps {
+  params: { locale: string };
+}
 
-export default function DocsIndexPage() {
-  const params = useParams();
-  const locale = params!.locale as string;
+export default function DocsIndexPage({ params }: DocsIndexPageProps) {
+  const locale = params.locale;
 
   // For now, redirect to the homepage's document selection area
   redirect(`/${locale}/#workflow-start`);


### PR DESCRIPTION
## Summary
- load WizardForm and PreviewPane lazily so the start wizard page has smaller JS bundle
- move `/[locale]/docs` redirect to a server component

## Testing
- `npm run lint` *(fails: 28 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683aa0477138832d979914099d4d3d95