### PR TITLE
[Navigation] Open Finance category in menu

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -217,6 +217,7 @@ const Header = React.memo(function Header() {
               <MegaMenuContent
                 categories={CATEGORY_LIST}
                 documents={documentLibrary}
+                defaultOpenCategories={['Finance']}
                 onLinkClick={() => {
                   setIsMegaMenuOpen(false);
                   setIsMobileMenuOpen(false);
@@ -438,6 +439,7 @@ const Header = React.memo(function Header() {
               <MegaMenuContent
                 categories={CATEGORY_LIST}
                 documents={documentLibrary}
+                defaultOpenCategories={['Finance']}
                 onLinkClick={() => {
                   setIsMegaMenuOpen(false);
                   setIsMobileMenuOpen(false);


### PR DESCRIPTION
## Summary
- make MegaMenu categories collapsible
- open Finance by default in header menu

## Testing
- `npm run lint` *(fails: 28 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683aa29cf494832dbd60cfd0c9d98a64