### PR TITLE
[Navigation] Improve mobile menu link accessibility

### DIFF
--- a/src/components/mega-menu/MegaMenuContent.tsx
+++ b/src/components/mega-menu/MegaMenuContent.tsx
@@ -47,15 +47,13 @@ const MemoizedDocLink = React.memo(function DocLink({
 
   return (
     <li className="md:px-0 md:py-0">
-      <div className="block w-full text-left py-3.5 md:py-3 px-4 md:px-4 hover:bg-muted/40 active:bg-muted/60 min-h-[44px] md:min-h-0">
-        <Link
-          href={docHref}
-          className="block text-base md:text-sm text-foreground md:text-muted-foreground font-medium md:font-normal hover:text-primary hover:underline transition-colors duration-150"
-          onClick={onClick}
-        >
-          {t(docName, { defaultValue: docName })}
-        </Link>
-      </div>
+      <Link
+        href={docHref}
+        onClick={onClick}
+        className="block w-full text-left px-4 md:px-4 py-3.5 md:py-3 min-h-[44px] md:min-h-0 text-base md:text-sm text-foreground md:text-muted-foreground font-medium md:font-normal hover:text-primary hover:underline hover:bg-muted/40 active:bg-muted/60 transition-colors duration-150"
+      >
+        {t(docName, { defaultValue: docName })}
+      </Link>
     </li>
   );
 });


### PR DESCRIPTION
## Summary
- make the entire document link area tappable
- keep desktop styling while improving contrast and size on mobile

## Testing
- `npm run lint` *(fails: jsx-a11y/no-static-element-interactions, no-extra-boolean-cast)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683aa5c2fe8c832d8b28e372b96db6e5