### PR TITLE
[UI] Fix accessibility lint issues

### DIFF
--- a/src/components/DynamicFormRenderer.tsx
+++ b/src/components/DynamicFormRenderer.tsx
@@ -144,7 +144,7 @@ export default function DynamicFormRenderer({
   const analyzeThenSubmit = async () => {
     if (isReadOnly || isLoading || hasSubmitted) return;
 
-    const missing = schema.some((f) => f.required && !Boolean(values[f.id]));
+    const missing = schema.some((f) => f.required && !values[f.id]);
     if (missing) {
       alert(t('dynamicForm.errorMissingRequired'));
       return;

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { loadStripe } from '@stripe/stripe-js';
 import {
   Elements,

--- a/src/components/ReviewStep.tsx
+++ b/src/components/ReviewStep.tsx
@@ -337,8 +337,18 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
           return (
             <div
               key={field.id}
+              role="button"
+              tabIndex={0}
               className="py-3 border-b border-border last:border-b-0 cursor-pointer"
               onClick={() => !isCurrentlyEditing && handleEdit(field.id)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  if (!isCurrentlyEditing) {
+                    handleEdit(field.id);
+                  }
+                }
+              }}
             >
               <div className="flex justify-between items-start gap-2">
                 <div className="flex-1 min-w-0">
@@ -568,7 +578,7 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                                 <div className="flex items-center space-x-2">
                                   <Switch
                                     id={`review-${field.id}`}
-                                    checked={Boolean(controllerField.value)}
+                                    checked={!!controllerField.value}
                                     onCheckedChange={controllerField.onChange}
                                     ref={controllerField.ref}
                                   />
@@ -576,9 +586,7 @@ export default function ReviewStep({ doc, locale }: ReviewStepProps) {
                                     htmlFor={`review-${field.id}`}
                                     className="text-sm font-normal"
                                   >
-                                    {Boolean(controllerField.value)
-                                      ? t('Yes')
-                                      : t('No')}
+                                    {controllerField.value ? t('Yes') : t('No')}
                                   </Label>
                                 </div>
                               );

--- a/src/components/StepThreeForm.tsx
+++ b/src/components/StepThreeForm.tsx
@@ -45,10 +45,12 @@ export function StepThreeForm({
         <PDFPreview url={previewUrl} className="flex-1 border rounded shadow" />
 
         <div className="flex-1 space-y-4">
-          <label className="flex items-center">
-            <Toggle pressed={notarize} onPressedChange={setNotarize} />
-            <span className="ml-2">Add Notarization (+$5)</span>
-          </label>
+          <div className="flex items-center">
+            <Toggle id="notarize-toggle" pressed={notarize} onPressedChange={setNotarize} />
+            <label htmlFor="notarize-toggle" className="ml-2">
+              Add Notarization (+$5)
+            </label>
+          </div>
 
           <button
             className="w-full inline-flex items-center justify-center px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition"

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -73,9 +73,11 @@ export default function MobileDrawer({ open, children, onClose }: MobileDrawerPr
     <AnimatePresence>
       {open && (
         <>
-          <div
+          <button
+            type="button"
             className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40"
             onClick={onClose}
+            aria-label={t('Close menu')}
           />
           <motion.aside
             {...bind()}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -33,14 +33,16 @@ const Alert = React.forwardRef<
 Alert.displayName = 'Alert';
 
 const AlertTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <h5
     ref={ref}
     className={cn('mb-1 font-medium leading-none tracking-tight', className)}
     {...props}
-  />
+  >
+    {children}
+  </h5>
 ));
 AlertTitle.displayName = 'AlertTitle';
 


### PR DESCRIPTION
## Summary
- update StepThreeForm toggle label to be accessible
- convert overlay divs to buttons in MobileDrawer
- ensure AlertTitle renders children for screen readers
- add keyboard handlers in ReviewStep and remove Boolean casts
- fix minor lint warnings in DynamicFormRenderer and PaymentModal

## Testing
- `npm run lint` *(fails: react/jsx-no-target-blank etc.)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683aa7d81114832d99db11f5c58fa3b5