### PR TITLE
[Mobile] Implement collapsible document menu

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -34,6 +34,7 @@ import { Input } from '@/components/ui/input';
 import type { LegalDocument } from '@/lib/document-library';
 import { CATEGORY_LIST } from '@/components/Step1DocumentSelector';
 import MegaMenuContent from '@/components/mega-menu/MegaMenuContent';
+import MobileDocsAccordion from '@/components/mobile/MobileDocsAccordion';
 
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
@@ -414,20 +415,16 @@ const Header = React.memo(function Header() {
           {/* Mobile categories toggle */}
           <Button
             variant="ghost"
-            className="w-full justify-between text-base font-medium flex items-center gap-2 px-2 py-3 hover:bg-muted group focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2"
+            className="w-full justify-between text-base font-medium flex items-center px-4 py-3 hover:bg-muted focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2"
             onClick={() => setShowMobileCategories((v) => !v)}
             aria-expanded={showMobileCategories}
-            data-state={showMobileCategories ? 'open' : 'closed'}
             disabled={!mounted}
           >
-            <div className="flex items-center gap-2">
-              <LayoutGrid className="h-5 w-5 text-muted-foreground group-data-[state=open]:text-primary" />
-              {mounted
-                ? tHeader('nav.makeDocuments', {
-                    defaultValue: 'Make Documents',
-                  })
-                : '...'}
-            </div>
+            {mounted
+              ? tHeader('nav.makeDocuments', {
+                  defaultValue: 'Make Documents',
+                })
+              : '...'}
             {showMobileCategories ? (
               <ChevronUp className="h-5 w-5 opacity-70" />
             ) : (
@@ -435,18 +432,15 @@ const Header = React.memo(function Header() {
             )}
           </Button>
           {showMobileCategories && (
-            <div className="pl-4 mt-0 border-l-2 border-muted/70">
-              <MegaMenuContent
-                categories={CATEGORY_LIST}
-                documents={documentLibrary}
-                defaultOpenCategories={['Finance']}
-                onLinkClick={() => {
-                  setIsMegaMenuOpen(false);
-                  setIsMobileMenuOpen(false);
-                  setShowMobileCategories(false);
-                }}
-              />
-            </div>
+            <MobileDocsAccordion
+              categories={CATEGORY_LIST}
+              documents={documentLibrary}
+              onLinkClick={() => {
+                setIsMegaMenuOpen(false);
+                setIsMobileMenuOpen(false);
+                setShowMobileCategories(false);
+              }}
+            />
           )}
 
           {/* Mobile footer links */}

--- a/src/components/mobile/MobileDocsAccordion.tsx
+++ b/src/components/mobile/MobileDocsAccordion.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import type { LegalDocument } from '@/lib/document-library';
+import type { CategoryInfo } from '@/components/Step1DocumentSelector';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { getDocTranslation } from '@/lib/i18nUtils';
+
+interface MobileDocsAccordionProps {
+  categories: CategoryInfo[];
+  documents: LegalDocument[];
+  onLinkClick?: () => void;
+}
+
+export default function MobileDocsAccordion({ categories, documents, onLinkClick }: MobileDocsAccordionProps) {
+  const { t, i18n } = useTranslation('common');
+  const locale = i18n.language as 'en' | 'es';
+  const [openKey, setOpenKey] = React.useState<string | null>(null);
+
+  const toggle = (key: string) => setOpenKey((prev) => (prev === key ? null : key));
+
+  const docsForCategory = (key: string) =>
+    documents.filter(
+      (doc) => doc.category.trim().toLowerCase() === key.trim().toLowerCase() && doc.id !== 'general-inquiry',
+    );
+
+  return (
+    <div className="divide-y border-t border-gray-200">
+      {categories.map((cat) => {
+        const docs = docsForCategory(cat.key);
+        if (docs.length === 0) return null;
+        const label = t(cat.labelKey, { defaultValue: cat.key });
+        const isOpen = openKey === cat.key;
+        return (
+          <Accordion
+            key={cat.key}
+            type="single"
+            collapsible
+            value={isOpen ? 'open' : ''}
+            onValueChange={() => toggle(cat.key)}
+          >
+            <AccordionItem value="open" className="border-none">
+              <AccordionTrigger className="w-full flex justify-between items-center px-4 py-3 text-base font-medium text-gray-900 border-t border-gray-200">
+                {label}
+              </AccordionTrigger>
+              <AccordionContent className="pl-6 pr-4 pb-2">
+                <ul>
+                  {docs.map((doc) => {
+                    const translated = getDocTranslation(doc, locale);
+                    return (
+                      <li key={doc.id}>
+                        <Link
+                          href={`/${locale}/docs/${doc.id}`}
+                          className="block py-2 text-primary-600 hover:underline"
+                          onClick={onLinkClick}
+                        >
+                          {translated.name}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                  <li>
+                    <Link
+                      href={`/${locale}/?category=${encodeURIComponent(cat.key)}#workflow-start`}
+                      className="block mt-2 text-sm italic text-gray-500"
+                      onClick={onLinkClick}
+                    >
+                      {t('nav.seeMoreDocuments', {
+                        defaultValue: 'See all in {{categoryName}}...',
+                        categoryName: label,
+                      })}
+                    </Link>
+                  </li>
+                </ul>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add MobileDocsAccordion component using Accordion primitives
- update Header mobile menu to use the new accordion for document links

## Testing
- `npm run lint` *(fails: 22 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683aae504544832d8d841d1af24d385a