### PR TITLE
[Mobile] Add icons to docs accordion

### DIFF
--- a/src/components/mobile/MobileDocsAccordion.tsx
+++ b/src/components/mobile/MobileDocsAccordion.tsx
@@ -41,7 +41,13 @@ export default function MobileDocsAccordion({ categories, documents, onLinkClick
           >
             <AccordionItem value="open" className="border-none">
               <AccordionTrigger className="w-full flex justify-between items-center px-4 py-3 text-base font-medium text-gray-900 border-t border-gray-200">
-                {label}
+                <span className="flex items-center gap-2">
+                  {cat.key === 'finance' && '💰'}
+                  {cat.key === 'business' && '🏢'}
+                  {cat.key === 'real-estate' && '🏠'}
+                  {cat.key === 'family' && '👨‍👩‍👧‍👦'}
+                  {label}
+                </span>
               </AccordionTrigger>
               <AccordionContent className="pl-6 pr-4 pb-2">
                 <ul>


### PR DESCRIPTION
## Summary
- add emoji icons before mobile accordion category labels

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ab9010ca8832d8174da53504121ea