### PR TITLE
[Docs] Preload wizard flow components

### DIFF
--- a/src/app/generate/page.tsx
+++ b/src/app/generate/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import React from 'react';
 import dynamic from 'next/dynamic';

--- a/src/app/root-client.tsx
+++ b/src/app/root-client.tsx
@@ -1,12 +1,18 @@
 // src/app/root-client.tsx
 'use client';
 import React, { useEffect } from 'react';
+import dynamic from 'next/dynamic';
 import { I18nextProvider } from 'react-i18next';
 // import { AuthProvider } from '@/hooks/useAuth'; // Ensure this was removed if consolidated
 import i18n from '@/lib/i18n';
 import { mark, measure } from '@/utils/performance';
 // import { DefaultSeo } from 'next-seo'; // Temporarily removed
 // import SEO from '@/next-seo.config'; // Temporarily removed
+
+// Dynamically loaded wizard to allow early prefetching
+const DocumentFlow = dynamic(() => import('@/components/DocumentFlow'), {
+  ssr: false,
+});
 
 export default function RootClient({
   children,
@@ -20,6 +26,8 @@ export default function RootClient({
   useEffect(() => {
     mark('root-layout-end');
     measure('root-layout', 'root-layout-start', 'root-layout-end');
+    // Preload the document flow wizard to speed up navigation
+    void DocumentFlow.preload();
   }, []);
 
   // Temporarily removed DefaultSeo to diagnose the error

--- a/src/components/DocumentFlow.tsx
+++ b/src/components/DocumentFlow.tsx
@@ -1,17 +1,23 @@
 // src/components/DocumentFlow.tsx
 'use client';
 
-import React, { useState, useEffect } from 'react'; // Added useEffect
+import React, { useState, useEffect } from 'react';
 import { StepOneInput } from '@/components/StepOneInput'; // This might be replaced or refactored
 import SlideFade from '@/components/motion/SlideFade';
 import { StepTwoInput } from '@/components/StepTwoInput'; // This might be replaced or refactored
 import dynamic from 'next/dynamic';
+import { useTranslation } from 'react-i18next';
+import { documentLibrary } from '@/lib/document-library'; // Import documentLibrary
+
 const StepThreeInput = dynamic(
   () => import('@/components/StepThreeInput').then((mod) => mod.StepThreeInput),
   { ssr: false },
-); // This might be replaced or refactored
-import { useTranslation } from 'react-i18next';
-import { documentLibrary } from '@/lib/document-library'; // Import documentLibrary
+);
+
+// Preload the heavy final step to make the wizard snappier
+if (typeof window !== 'undefined') {
+  void StepThreeInput.preload();
+}
 
 interface DocumentFlowProps {
   initialDocId?: string;


### PR DESCRIPTION
## Summary
- prefetch DocumentFlow in RootClient to load wizard scripts sooner
- preload StepThreeInput when DocumentFlow loads
- keep generate page as client component

Preloading the wizard components ensures the document pages feel more responsive when the user starts the document generator.

## Testing
- `npm run lint` *(fails: 22 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ab9782f84832db69613969d763938