### PR TITLE
[UI] Add expand all toggle for mobile docs

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -145,6 +145,7 @@ const Header = React.memo(function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isMegaMenuOpen, setIsMegaMenuOpen] = useState(false);
   const [showMobileCategories, setShowMobileCategories] = useState(false);
+  const [expandAllDocs, setExpandAllDocs] = useState(true);
 
   // Auto-expand "Make Documents" accordion on initial render for mobile screens
   useEffect(() => {
@@ -431,15 +432,25 @@ const Header = React.memo(function Header() {
             )}
           </Button>
           {showMobileCategories && (
-            <MobileDocsAccordion
-              categories={CATEGORY_LIST}
-              documents={documentLibrary}
-              onLinkClick={() => {
-                setIsMegaMenuOpen(false);
-                setIsMobileMenuOpen(false);
-                setShowMobileCategories(false);
-              }}
-            />
+            <>
+              <Button
+                variant="ghost"
+                className="w-full justify-center text-sm text-primary hover:underline"
+                onClick={() => setExpandAllDocs((v) => !v)}
+              >
+                {expandAllDocs ? 'Collapse All' : 'Expand All'}
+              </Button>
+              <MobileDocsAccordion
+                categories={CATEGORY_LIST}
+                documents={documentLibrary}
+                onLinkClick={() => {
+                  setIsMegaMenuOpen(false);
+                  setIsMobileMenuOpen(false);
+                  setShowMobileCategories(false);
+                }}
+                expandAll={expandAllDocs}
+              />
+            </>
           )}
 
           {/* Mobile footer links */}

--- a/src/components/mobile/MobileDocsAccordion.tsx
+++ b/src/components/mobile/MobileDocsAccordion.tsx
@@ -10,9 +10,15 @@ interface MobileDocsAccordionProps {
   categories: CategoryInfo[];
   documents: LegalDocument[];
   onLinkClick?: () => void;
+  expandAll?: boolean;
 }
 
-export default function MobileDocsAccordion({ categories, documents, onLinkClick }: MobileDocsAccordionProps) {
+export default function MobileDocsAccordion({
+  categories,
+  documents,
+  onLinkClick,
+  expandAll,
+}: MobileDocsAccordionProps) {
   const { t, i18n } = useTranslation('common');
   const locale = i18n.language as 'en' | 'es';
   const [openKey, setOpenKey] = React.useState<string | null>(null);
@@ -30,7 +36,7 @@ export default function MobileDocsAccordion({ categories, documents, onLinkClick
         const docs = docsForCategory(cat.key);
         if (docs.length === 0) return null;
         const label = t(cat.labelKey, { defaultValue: cat.key });
-        const isOpen = openKey === cat.key;
+        const isOpen = expandAll || openKey === cat.key;
         return (
           <Accordion
             key={cat.key}


### PR DESCRIPTION
## Summary
- let mobile users expand/collapse all categories at once
- wire toggle state from Header to MobileDocsAccordion

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build` *(failed: process timed out)*

------
https://chatgpt.com/codex/tasks/task_e_683abae21d88832dbfd87d49621e57be