### PR TITLE
[UI] Add floating document activity ticker

### DIFF
--- a/src/components/ActivityTicker.tsx
+++ b/src/components/ActivityTicker.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+const messages = [
+  'Ben from Ohio just created a Lease Agreement',
+  'Maria from Texas finished a Promissory Note',
+  'Someone in California started a Living Will',
+];
+
+export default function ActivityTicker() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((prev) => (prev + 1) % messages.length);
+    }, 4000);
+    return () => clearInterval(id);
+  }, []);
+
+  const message = messages[index];
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[99] pointer-events-none">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={message}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.3 }}
+          className={cn(
+            'bg-background border border-border shadow px-4 py-2 rounded text-sm pointer-events-auto'
+          )}
+        >
+          {message}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/providers/ClientProviders.tsx
+++ b/src/components/providers/ClientProviders.tsx
@@ -19,6 +19,7 @@ interface ClientProvidersProps {
 import Header from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import ContactFormButton from '@/components/ContactFormButton';
+import ActivityTicker from '@/components/ActivityTicker';
 
 const AppShell = React.memo(function AppShell({
   children,
@@ -39,6 +40,7 @@ const AppShell = React.memo(function AppShell({
       <main className="flex-grow">{children}</main>
       <Footer />
       <ContactFormButton />
+      <ActivityTicker />
       {/* Conditionally render Toaster only on the client after mount */}
       {isMounted && <Toaster />}
     </>


### PR DESCRIPTION
## Summary
- create `ActivityTicker` to cycle through recent document activity messages
- show the ticker globally via `ClientProviders`

## Testing
- `npm run lint` *(fails: 23 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b528fe750832db6b09b5a4fd6e2b8