### PR TITLE
[Home] Add personalization block

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { useSearchParams, useRouter, useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
+import PersonalizationBlock from '@/components/PersonalizationBlock';
 
 const LoadingSpinner = () => (
   <div className="flex justify-center items-center h-32">
@@ -231,6 +232,7 @@ export default function HomePageClient() {
 
           <div className="mt-8 bg-card p-4 sm:p-6 md:p-8 rounded-xl shadow-2xl border border-border/20">
             <div className="mt-6">{renderMainInteraction()}</div>
+            <PersonalizationBlock />
           </div>
         </div>
       </section>

--- a/src/components/PersonalizationBlock.tsx
+++ b/src/components/PersonalizationBlock.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
+import { useEffect, useState } from 'react';
+
+interface RecentDocEntry {
+  id: string;
+  name: string;
+}
+
+export default function PersonalizationBlock() {
+  const { isLoggedIn } = useAuth();
+  const [lastDoc, setLastDoc] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = localStorage.getItem('recentDocs') || '[]';
+      const docs: RecentDocEntry[] = JSON.parse(raw);
+      if (Array.isArray(docs) && docs.length > 0) {
+        setLastDoc(docs[0].name);
+      }
+    } catch {
+      setLastDoc(null);
+    }
+  }, []);
+
+  if (!isLoggedIn) {
+    return (
+      <div className="mt-4 rounded-md bg-secondary p-4 text-center text-sm">
+        Start your first document now — it&apos;s free
+      </div>
+    );
+  }
+
+  if (lastDoc) {
+    return (
+      <div className="mt-4 rounded-md bg-secondary p-4 text-center text-sm">
+        Welcome back — Resume your {lastDoc} (Step 2 of 3)
+      </div>
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add new `PersonalizationBlock` component
- show the block below the document selector on the homepage

## Testing
- `npm run lint` *(fails: react/jsx-no-target-blank and other pre-existing lint errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b527a1730832dadb6513e6ede89b4