### PR TITLE
[SEO] Implement document state landing pages

### DIFF
--- a/src/app/docs/[doc]/[state]/page.tsx
+++ b/src/app/docs/[doc]/[state]/page.tsx
@@ -1,0 +1,82 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { documentLibrary } from '@/lib/document-library';
+import { usStates } from '@/lib/document-library/utils';
+import AutoImage from '@/components/AutoImage';
+import { Button } from '@/components/ui/button';
+
+export const dynamic = 'force-static';
+export const revalidate = 86400; // daily
+
+const slugify = (str: string) =>
+  str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+export async function generateStaticParams() {
+  const params: { doc: string; state: string }[] = [];
+  for (const doc of documentLibrary) {
+    if (!doc.id || doc.id === 'general-inquiry') continue;
+    const states =
+      doc.states === 'all'
+        ? usStates.map((s) => s.label)
+        : Array.isArray(doc.states)
+        ? doc.states
+        : [];
+    for (const state of states) {
+      const label = usStates.find((s) => s.value === state)?.label || state;
+      params.push({ doc: doc.id, state: slugify(label) });
+    }
+  }
+  return params;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { doc: string; state: string };
+}): Promise<Metadata> {
+  const docConfig = documentLibrary.find((d) => d.id === params.doc);
+  const state = usStates.find((s) => slugify(s.label) === params.state);
+  if (!docConfig || !state) return {};
+  const titleBase =
+    docConfig.translations?.en?.name || docConfig.name || docConfig.id;
+  const description =
+    docConfig.translations?.en?.description || docConfig.description || '';
+  const canonical = `https://123legaldoc.com/docs/${params.doc}/${params.state}`;
+  return {
+    title: `${titleBase} - ${state.label} | 123LegalDoc`,
+    description,
+    alternates: { canonical },
+  };
+}
+
+export default function DocStatePage({
+  params,
+}: {
+  params: { doc: string; state: string };
+}) {
+  const docConfig = documentLibrary.find((d) => d.id === params.doc);
+  const state = usStates.find((s) => slugify(s.label) === params.state);
+  if (!docConfig || !state) return notFound();
+  const name = docConfig.translations?.en?.name || docConfig.name || docConfig.id;
+  const desc = docConfig.translations?.en?.description || docConfig.description || '';
+  return (
+    <main className="container mx-auto py-8 space-y-6">
+      <h1 className="text-3xl font-bold">{name} - {state.label}</h1>
+      {desc && <p className="text-muted-foreground">{desc}</p>}
+      <div className="max-w-md mx-auto">
+        <AutoImage
+          src={`/images/previews/en/${docConfig.id}.png`}
+          alt={`${name} preview`}
+          width={850}
+          height={1100}
+          className="w-full"
+        />
+      </div>
+      <Button asChild className="mt-4">
+        <Link href={`/generate?docId=${docConfig.id}`}>Create Document</Link>
+      </Button>
+    </main>
+  );
+}
+

--- a/src/components/AutoImage.tsx
+++ b/src/components/AutoImage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 import Image, { type ImageProps } from 'next/image';
 import type { StaticImport } from 'next/dist/shared/lib/get-img-props';


### PR DESCRIPTION
## Summary
- add static landing pages for doc/state combos
- mark AutoImage as a client component for server usage

## Testing
- `npm run lint` *(fails: 23 errors, 5 warnings)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b5ab97708832db7ef28253e507792