### PR TITLE
[Preview] Add clause explanation tooltips

### DIFF
--- a/src/ai/flows/explain-clause.ts
+++ b/src/ai/flows/explain-clause.ts
@@ -1,0 +1,36 @@
+import { OpenAI } from 'openai';
+
+let openai: OpenAI | null = null;
+
+const initOpenAI = (): OpenAI | null => {
+  if (openai) return openai;
+  const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error('[explain-clause] Missing NEXT_PUBLIC_OPENAI_API_KEY');
+    return null;
+  }
+  try {
+    openai = new OpenAI({ apiKey });
+    return openai;
+  } catch (err) {
+    console.error('[explain-clause] Failed to init OpenAI', err);
+    return null;
+  }
+};
+
+export async function explainClause(text: string): Promise<string> {
+  const client = initOpenAI();
+  if (!client) return 'AI service unavailable.';
+  const prompt = `Explain this legal clause in plain English: "${text}"`;
+  try {
+    const res = await client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      temperature: 0.3,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    return res.choices[0].message.content?.trim() || '';
+  } catch (err) {
+    console.error('[explain-clause] API error', err);
+    return 'Unable to retrieve explanation.';
+  }
+}

--- a/src/components/ClauseTooltip.tsx
+++ b/src/components/ClauseTooltip.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { explainClause } from '@/ai/flows/explain-clause';
+
+const memoryCache: Record<string, string> = {};
+
+function getCache(id: string): string | null {
+  if (memoryCache[id]) return memoryCache[id];
+  if (typeof window !== 'undefined') {
+    const val = localStorage.getItem('clause:' + id);
+    if (val) {
+      memoryCache[id] = val;
+      return val;
+    }
+  }
+  return null;
+}
+
+function setCache(id: string, text: string) {
+  memoryCache[id] = text;
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('clause:' + id, text);
+  }
+}
+
+interface ClauseTooltipProps {
+  id: string;
+  text: string;
+  children: React.ReactNode;
+}
+
+export function ClauseTooltip({ id, text, children }: ClauseTooltipProps) {
+  const [content, setContent] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+
+  const handleOpenChange = async (open: boolean) => {
+    if (!open) return;
+    const cached = getCache(id);
+    if (cached) {
+      setContent(cached);
+      return;
+    }
+    setLoading(true);
+    const result = await explainClause(text);
+    setLoading(false);
+    setContent(result);
+    setCache(id, result);
+  };
+
+  return (
+    <Tooltip onOpenChange={handleOpenChange} delayDuration={200}>
+      <span className="inline-flex items-start gap-1">
+        {children}
+        <TooltipTrigger asChild>
+          <button type="button" className="text-muted-foreground" aria-label="Explain clause">
+            🤖
+          </button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs text-xs leading-snug">
+          {loading ? 'Explaining...' : content || 'Explain clause'}
+        </TooltipContent>
+      </span>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary
- build new OpenAI flow `explain-clause`
- add client component `ClauseTooltip` that caches explanations
- wrap Markdown clauses in `DocumentDetail` with `ClauseTooltip`

## Testing
- `npm run lint` *(fails: 22 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b5aafacf0832da5c8ea905ecc6be1