### PR TITLE
Refactor: Update header styles for improved contrast and placement

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -163,7 +163,7 @@ const Header = React.memo(function Header() {
         <div className="mr-auto md:mr-4 flex items-center">
           <Logo
             wrapperClassName="items-center self-center mr-2 md:mr-4"
-            svgClassName="h-6 w-6 md:h-7 md:w-7"
+            svgClassName="h-7 w-7 md:h-8 md:w-8"
             textClassName="text-xs md:text-sm"
           />
         </div>
@@ -205,8 +205,8 @@ const Header = React.memo(function Header() {
                 variant="default"
                 size="sm"
                 className={cn(
-                  'text-sm font-medium flex items-center gap-1 px-3 h-9 bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2',
-                  isMegaMenuOpen && 'bg-primary/80',
+                  'text-sm font-medium flex items-center gap-1 px-3 h-9 bg-make-docs-green text-white hover:bg-make-docs-green-hover focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2 drop-shadow-lg',
+                  isMegaMenuOpen && 'bg-make-docs-green-hover',
                 )}
                 disabled={!mounted}
                 aria-expanded={isMegaMenuOpen}
@@ -330,11 +330,10 @@ const Header = React.memo(function Header() {
                 </Button>
               </>
             ) : (
-              <>
+              <div className="flex items-center gap-2">
                 <Button
-                  variant="ghost"
                   size="sm"
-                  className="text-xs font-medium text-foreground/80 hover:bg-muted px-2 py-1.5 md:px-3 h-9 md:h-8 flex items-center focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2"
+                  className="text-xs font-medium flex items-center focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2 border border-primary px-3 py-1 rounded-md hover:bg-primary/10 h-9 md:h-8 text-primary"
                   asChild
                 >
                   <Link href={`/${clientLocale}/signup`}>
@@ -345,9 +344,8 @@ const Header = React.memo(function Header() {
                   </Link>
                 </Button>
                 <Button
-                  variant="default"
                   size="sm"
-                  className="text-xs font-medium px-2 py-1.5 md:px-3 h-9 md:h-8 shadow-sm bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2"
+                  className="text-xs font-medium flex items-center focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2 border border-primary px-3 py-1 rounded-md hover:bg-primary/10 h-9 md:h-8 text-primary"
                   asChild
                 >
                   <Link href={`/${clientLocale}/signin`}>
@@ -357,7 +355,7 @@ const Header = React.memo(function Header() {
                     </span>
                   </Link>
                 </Button>
-              </>
+              </div>
             ))}
         </nav>
       </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -73,6 +73,8 @@ const config: Config = {
         'brand-green': '#22c55e',
         'brand-slate': '#0f172a',
         'brand-sky': '#e0f2fe',
+        'make-docs-green': '#008466',
+        'make-docs-green-hover': '#00664e',
       },
 
       maxWidth: {


### PR DESCRIPTION
This commit addresses the following UI improvements in the header:

- Increased logo size:
    - Desktop: h-8 w-8
    - Mobile: h-7 w-7
- Enhanced "Make Documents" button:
    - Background color changed to a custom green (#008466).
    - Hover state uses a darker shade of green (#00664e).
    - Added a drop-shadow for better visibility.
- Re-styled and grouped "Sign Up" / "Sign In" links:
    - Links are now grouped together in the top-right corner.
    - Applied a border, padding, rounded corners, and a subtle hover background effect (border-primary px-3 py-1 rounded-md hover:bg-primary/10).

These changes improve the overall visual hierarchy and user experience of the navigation bar, making key elements more prominent and aligned with competitor best practices.