### PR TITLE
[Homepage] Enhance category UI design

### DIFF
--- a/src/components/Step1DocumentSelector.tsx
+++ b/src/components/Step1DocumentSelector.tsx
@@ -173,11 +173,13 @@ const MemoizedCategoryCard = React.memo(function CategoryCard({
       variant="outline"
       onClick={onClick}
       disabled={disabled}
-      className="category-card h-auto min-h-[100px] p-6 border-border shadow-sm hover:shadow-lg transition text-center flex flex-col justify-center items-center bg-card hover:bg-muted active:scale-95 active:transition-transform active:duration-100"
+      className="category-card h-auto min-h-[110px] p-6 border-border shadow-sm hover:shadow-lg transition text-center flex flex-col justify-center items-center bg-card hover:bg-muted active:scale-95 active:transition-transform active:duration-100 rounded-xl"
     >
-      {React.createElement(category.icon || FileText, {
-        className: 'h-8 w-8 mb-3 text-primary/80',
-      })}
+      <span className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+        {React.createElement(category.icon || FileText, {
+          className: 'h-6 w-6 text-primary',
+        })}
+      </span>
       <span className="font-medium text-card-foreground text-base">
         {t(category.labelKey, { defaultValue: category.key })}
       </span>

--- a/src/components/StickyFilterBar.tsx
+++ b/src/components/StickyFilterBar.tsx
@@ -89,7 +89,7 @@ const StickyFilterBar = React.memo(function StickyFilterBar({
             placeholder={placeholderSearch}
             value={searchTerm}
             onChange={(e) => onSearchTermChange(e.target.value)}
-            className="w-full pl-12 h-12 text-base border-2 border-primary/40 bg-muted/30"
+            className="w-full pl-12 h-14 text-base rounded-full border-2 border-primary/50 bg-background shadow-md"
             aria-label={placeholderSearch}
             disabled={!isHydrated}
           />
@@ -115,7 +115,7 @@ const StickyFilterBar = React.memo(function StickyFilterBar({
             disabled={!isHydrated}
           >
             <SelectTrigger
-              className="w-full h-10 text-sm sm:pl-3 data-[placeholder]:text-muted-foreground"
+              className="w-full h-10 text-sm sm:pl-3 data-[placeholder]:text-muted-foreground rounded-full shadow-md"
               aria-label={placeholderState}
             >
               <MapPin className="h-4 w-4 mr-2 hidden sm:inline-block text-muted-foreground" />


### PR DESCRIPTION
## Summary
- style category icons with rounded backgrounds
- make search bar and state selector rounded and more prominent

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f1086bf64832d8ef00fa8277eb7a2