### PR TITLE
[Homepage] Revamp hero section

### DIFF
--- a/public/images/hero-digital-docs.svg
+++ b/public/images/hero-digital-docs.svg
@@ -1,0 +1,19 @@
+<svg width="800" height="500" viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4f46e5" />
+      <stop offset="100%" stop-color="#06b6d4" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#grad)" rx="20" />
+  <g fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M220 160h160v180H220z" fill="#1e293b" stroke="none" />
+    <path d="M300 100v60" />
+    <path d="M280 120h40" />
+    <path d="M520 200h80v80h-80z" fill="#1e293b" stroke="none" />
+    <path d="M560 160v40" />
+    <path d="M540 180h40" />
+    <path d="M380 320l40 40l80-80" />
+  </g>
+  <text x="50%" y="90%" text-anchor="middle" fill="#e0f2fe" font-size="24" font-family="Arial">Instant AI Document Generation</text>
+</svg>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -181,8 +181,8 @@
     "note": "You can also check our FAQ for common questions.",
     "cta": "Go to FAQ"
   },
-  "home.hero.title": "Legal Peace of Mind. Instant. Intelligent.",
-  "home.hero.subtitle": "Say goodbye to confusion. Our AI crafts precise, professional legal documents tailored to your unique needs, fast.",
+  "home.hero.title": "Your AI Legal Assistant. Documents Ready in Minutes.",
+  "home.hero.subtitle": "Answer a few questions and instantly receive lawyer-grade paperwork.",
   "home.hero.pricingBadge": "One-time $35/document • No subscription",
   "home.steps.step1.title": "Tell Us Your Needs",
   "home.steps.step1.desc": "Answer a few quick prompts for tailored guidance.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -181,8 +181,8 @@
     "note": "También puedes consultar nuestras Preguntas Frecuentes para preguntas comunes.",
     "cta": "Ir a Preguntas Frecuentes"
   },
-  "home.hero.title": "Documentos legales instantáneos, hechos a tu medida",
-  "home.hero.subtitle": "Crea, firma y comparte contratos profesionales en minutos—sin necesidad de abogado.",
+  "home.hero.title": "Tu asistente legal con IA, documentos listos en minutos",
+  "home.hero.subtitle": "Responde unas preguntas y obtén documentos de calidad profesional al instante.",
   "home.hero.pricingBadge": "Pago único de $35/documento • Sin suscripción",
   "home.steps.step1.title": "Cuéntanos tus necesidades",
   "home.steps.step1.desc": "Responde unas breves preguntas para recibir orientación.",

--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -182,10 +182,10 @@ export default function HomePageClient() {
         <div className="container mx-auto px-4 flex flex-col lg:flex-row items-center gap-8">
           <div className="flex-1 lg:pr-8 text-center lg:text-left">
             <h1 className="text-5xl md:text-6xl lg:text-7xl font-black leading-tight text-foreground font-sans">
-              Legal Peace of Mind. Instant. Intelligent.
+              Your AI Legal Assistant. Documents Ready in Minutes.
             </h1>
             <p className="mt-4 text-xl text-muted-foreground font-medium">
-              Say goodbye to confusion. Our AI crafts precise, professional legal documents tailored to your unique needs, fast.
+              Answer a few questions and instantly receive lawyer-grade paperwork.
             </p>
             <SmartAssistantBar />
             <div className="mt-6 flex gap-4">
@@ -217,7 +217,11 @@ export default function HomePageClient() {
             <LiveActivityFeed />
           </div>
           <div className="flex-1 hidden lg:block h-96 relative">
-            <AutoImage src="/images/hero-homepage.png" alt="" className="object-cover w-full h-full" />
+            <AutoImage
+              src="/images/hero-digital-docs.svg"
+              alt="Illustration of AI generating legal documents"
+              className="object-cover w-full h-full"
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- refresh hero headline and sub-headline on the homepage
- add an SVG illustration for the hero
- update English and Spanish translations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f10771cd4832dbfa36a782316c9fe