### PR TITLE
[UI] Replace placeholders with polished visuals

### DIFF
--- a/src/app/[locale]/templates/templates-client-content.tsx
+++ b/src/app/[locale]/templates/templates-client-content.tsx
@@ -62,7 +62,7 @@ export default function TemplatesClientContent({ locale }: Props) {
 
       <div className="flex justify-center mb-10">
         <AutoImage
-          src="/images/hero-placeholder.svg"
+          src="/images/hero-homepage.png"
           alt="Happy customer"
           width={400}
           height={240}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
               : setup();
           `}
         </Script>
-        <link rel="preload" href="/images/hero-placeholder.svg" as="image" />
+        <link rel="preload" href="/images/hero-homepage.png" as="image" />
         <link rel="preload" href="/images/signwell-hero.svg" as="image" />
         <link rel="alternate" href="https://123legaldoc.com/en/" hrefLang="en" />
         <link rel="alternate" href="https://123legaldoc.com/es/" hrefLang="es" />

--- a/src/components/DynamicFormRenderer.tsx
+++ b/src/components/DynamicFormRenderer.tsx
@@ -26,7 +26,14 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/components/ui/tooltip';
-import { Check, Loader2, Info, AlertTriangle, AlertCircle } from 'lucide-react';
+import {
+  Check,
+  Loader2,
+  Info,
+  AlertTriangle,
+  AlertCircle,
+  ClipboardList as QuestionnaireIcon,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { saveFormProgress } from '@/lib/firestore/saveFormProgress';
 import { track } from '@/lib/analytics';
@@ -45,27 +52,7 @@ interface Props {
   stateCode?: string;
 }
 
-/* ----------------- svg icon --------------- */
-const QuestionnaireIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="h-6 w-6 text-primary"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={2}
-      d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"
-    />
-    <polyline points="14 2 14 8 20 8" />
-    <line x1="16" y1="13" x2="8" y2="13" />
-    <line x1="16" y1="17" x2="8" y2="17" />
-    <line x1="10" y1="9" x2="8" y2="9" />
-  </svg>
-);
+/* ----------------- consistent icon --------------- */
 
 export default function DynamicFormRenderer({
   documentType,

--- a/src/components/questionnaire.tsx
+++ b/src/components/questionnaire.tsx
@@ -20,7 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'; // Import Select
-import { Loader2, Edit2, Lock, Check } from 'lucide-react'; // Updated icons
+import { Loader2, Edit2, Lock, Check, ClipboardList as QuestionnaireIcon } from 'lucide-react'; // Updated icons and custom icon
 import { useToast } from '@/hooks/use-toast';
 import { documentLibrary, type Question } from '@/lib/document-library'; // Import library and Question type
 
@@ -31,27 +31,7 @@ interface QuestionnaireProps {
   isReadOnly?: boolean; // Optional prop to make the form read-only
 }
 
-// Placeholder SVG Icon
-const QuestionnaireIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className="h-6 w-6 text-primary"
-  >
-    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-    <polyline points="14 2 14 8 20 8" />
-    <line x1="16" x2="8" y1="13" y2="13" />
-    <line x1="16" x2="8" y1="17" y2="17" />
-    <line x1="10" x2="8" y1="9" y2="9" />
-  </svg>
-);
+// Use a consistent Lucide icon for the questionnaire header
 
 export function Questionnaire({
   documentType,


### PR DESCRIPTION
## Summary
- switch to hero-homepage illustration on templates page and preload it
- standardize questionnaire icons with Lucide's ClipboardList

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f10714094832db4e50672ccbb38fb