### PR TITLE
[Marketing] Add mission section and security note

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -181,8 +181,8 @@
     "note": "You can also check our FAQ for common questions.",
     "cta": "Go to FAQ"
   },
-  "home.hero.title": "Legal Peace of Mind. Instant. Intelligent.",
-  "home.hero.subtitle": "Say goodbye to confusion. Our AI crafts precise, professional legal documents tailored to your unique needs, fast.",
+  "home.hero.title": "Instant, Reliable Legal Documents",
+  "home.hero.subtitle": "Our friendly AI delivers attorney-reviewed contracts in minutes—no confusion.",
   "home.hero.pricingBadge": "One-time $35/document • No subscription",
   "home.steps.step1.title": "Tell Us Your Needs",
   "home.steps.step1.desc": "Answer a few quick prompts for tailored guidance.",
@@ -287,5 +287,9 @@
         "desc": "Encrypted data and compliant practices."
       }
     }
+  },
+  "mission": {
+    "title": "Our Mission",
+    "body": "123LegalDoc empowers everyone to handle routine legal needs quickly and confidently by blending attorney insight with intuitive AI."
   }
 }

--- a/public/locales/en/footer.json
+++ b/public/locales/en/footer.json
@@ -35,7 +35,7 @@
   "linkTermsOfService": "Terms",
   "linkDocs": "Docs",
   "linkDisclaimer": "Disclaimer",
-  "subhead": "AI-Powered Legal Document Generation. Fast, Affordable, Secure.",
+  "subhead": "AI-powered legal docs in minutes—secure, accurate, affordable.",
   "sectionCommunityTitle": "Community & Contact",
   "socialLinkedInAria": "LinkedIn Page",
   "socialTwitterAria": "Twitter Profile",
@@ -45,5 +45,6 @@
   "emailPlaceholderAria": "Email for newsletter",
   "subscribeButtonAria": "Subscribe to newsletter",
   "joinMailingListDesc": "Get 3 free templates — no spam.",
+  "securityNote": "Your info is encrypted with 256-bit SSL.",
   "openChatAria": "Open chat"
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -181,8 +181,8 @@
     "note": "También puedes consultar nuestras Preguntas Frecuentes para preguntas comunes.",
     "cta": "Ir a Preguntas Frecuentes"
   },
-  "home.hero.title": "Documentos legales instantáneos, hechos a tu medida",
-  "home.hero.subtitle": "Crea, firma y comparte contratos profesionales en minutos—sin necesidad de abogado.",
+  "home.hero.title": "Documentos legales confiables al instante",
+  "home.hero.subtitle": "Nuestra IA te entrega contratos revisados por abogados en minutos, sin complicaciones.",
   "home.hero.pricingBadge": "Pago único de $35/documento • Sin suscripción",
   "home.steps.step1.title": "Cuéntanos tus necesidades",
   "home.steps.step1.desc": "Responde unas breves preguntas para recibir orientación.",
@@ -288,5 +288,9 @@
         "desc": "Datos cifrados y prácticas conformes."
       }
     }
+  },
+  "mission": {
+    "title": "Nuestra Misión",
+    "body": "En 123LegalDoc creemos que todos merecen documentos legales claros y asequibles. Combinamos experiencia legal con IA intuitiva para que resuelvas trámites rápido y con confianza."
   }
 }

--- a/public/locales/es/footer.json
+++ b/public/locales/es/footer.json
@@ -35,7 +35,7 @@
   "linkTermsOfService": "Términos",
   "linkDocs": "Documentos",
   "linkDisclaimer": "Descargo de Responsabilidad",
-  "subhead": "Generación de documentos legales con IA. Rápido, accesible y seguro.",
+  "subhead": "Documentos legales con IA en minutos: seguros, precisos y económicos.",
   "sectionCommunityTitle": "Comunidad y Contacto",
   "socialLinkedInAria": "Página de LinkedIn",
   "socialTwitterAria": "Perfil de Twitter",
@@ -45,5 +45,6 @@
   "emailPlaceholderAria": "Correo para boletín",
   "subscribeButtonAria": "Suscribirse al boletín",
   "joinMailingListDesc": "Recibe 3 plantillas gratis — sin spam.",
+  "securityNote": "Tu información está cifrada con SSL de 256 bits.",
   "openChatAria": "Abrir chat"
 }

--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -48,6 +48,11 @@ const GuaranteeBadge = lazyOnView(
   },
 );
 
+const MissionSection = lazyOnView(
+  () => import('@/components/landing/MissionSection').then((m) => m.MissionSection),
+  { placeholder: <LoadingSpinner /> },
+);
+
 const TopDocsChips = lazyOnView(() => import('@/components/TopDocsChips'), {
   placeholder: <LoadingSpinner />,
 });
@@ -227,6 +232,7 @@ export default function HomePageClient() {
       <TrustAndTestimonialsSection />
       <FeaturedLogosSection />
       <GuaranteeBadge />
+      <MissionSection />
       <TopDocsChips />
 
       <Separator className="my-12" />

--- a/src/components/landing/MissionSection.tsx
+++ b/src/components/landing/MissionSection.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+import React, { useEffect, useState } from 'react';
+
+const MissionSection = React.memo(function MissionSection() {
+  const { t } = useTranslation('common');
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  const placeholder = '...';
+
+  return (
+    <section className="bg-background py-16 md:py-24">
+      <div className="container mx-auto px-4 max-w-3xl text-center">
+        <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+          {isHydrated ? t('mission.title', { defaultValue: 'Our Mission' }) : placeholder}
+        </h2>
+        <p className="text-lg text-muted-foreground">
+          {isHydrated
+            ? t('mission.body', {
+                defaultValue:
+                  '123LegalDoc empowers everyone to handle routine legal needs quickly and confidently by blending attorney insight with intuitive AI.',
+              })
+            : placeholder}
+        </p>
+      </div>
+    </section>
+  );
+});
+
+export { MissionSection };

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -270,6 +270,12 @@ export const Footer = React.memo(function Footer() {
                 defaultValue: 'Get 3 free templates — no spam.',
               })}
             </p>
+            <p className="text-xs mt-1 flex items-center gap-1 text-muted-foreground">
+              <Lock className="h-3 w-3" />
+              {t('securityNote', {
+                defaultValue: 'Your info is encrypted with 256-bit SSL.',
+              })}
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- emphasize security in the footer with a lock notice
- introduce MissionSection on the home page
- refresh tagline and copy for stronger brand voice
- update translations accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f1057fbf4832dbb62905e41908ee4