### PR TITLE
[Home] Add use cases section

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -251,6 +251,24 @@
   "Showing documents matching your search and state criteria.": "Showing documents matching your search and state criteria.",
   "TopDocsChips.loading": "Loading popular documents...",
   "TopDocsChips.title": "Popular Legal Documents",
+  "useCases": {
+    "freelancers": {
+      "title": "For Freelancers",
+      "docs": "NDAs, Client Contracts"
+    },
+    "landlords": {
+      "title": "For Landlords",
+      "docs": "Leases, Eviction Notices"
+    },
+    "smallBusiness": {
+      "title": "For Small Businesses",
+      "docs": "Operating Agreements, Invoices"
+    },
+    "families": {
+      "title": "For Families",
+      "docs": "Wills, Power of Attorney"
+    }
+  },
   "features": {
     "title": "Key Features",
     "subtitle": "Powerful tools to simplify your legal document workflow.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -251,6 +251,24 @@
   "Showing documents matching your search and state criteria.": "Mostrando documentos que coinciden con tu búsqueda y criterios de estado.",
   "TopDocsChips.loading": "Cargando documentos populares...",
   "TopDocsChips.title": "Documentos Legales Populares",
+  "useCases": {
+    "freelancers": {
+      "title": "Para Freelancers",
+      "docs": "NDAs, Contratos con Clientes"
+    },
+    "landlords": {
+      "title": "Para Propietarios",
+      "docs": "Arrendamientos, Avisos de Desalojo"
+    },
+    "smallBusiness": {
+      "title": "Para Pequeñas Empresas",
+      "docs": "Acuerdos Operativos, Facturas"
+    },
+    "families": {
+      "title": "Para Familias",
+      "docs": "Testamentos, Poder Notarial"
+    }
+  },
   "features": {
     "title": "Características Clave",
     "subtitle": "Potentes herramientas para simplificar el flujo de tus documentos legales.",

--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -48,6 +48,11 @@ const GuaranteeBadge = lazyOnView(
   },
 );
 
+const UseCasesSection = lazyOnView(
+  () => import('@/components/landing/UseCasesSection').then((m) => m.UseCasesSection),
+  { placeholder: <LoadingSpinner /> },
+);
+
 const TopDocsChips = lazyOnView(() => import('@/components/TopDocsChips'), {
   placeholder: <LoadingSpinner />,
 });
@@ -231,6 +236,7 @@ export default function HomePageClient() {
       <TrustAndTestimonialsSection />
       <FeaturedLogosSection />
       <GuaranteeBadge />
+      <UseCasesSection />
       <TopDocsChips />
 
       <Separator className="my-12" />

--- a/src/components/landing/UseCasesSection.client.tsx
+++ b/src/components/landing/UseCasesSection.client.tsx
@@ -1,0 +1,70 @@
+'use client';
+import React from 'react';
+import Link from 'next/link';
+import { Briefcase, Home, Building2, Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'next/navigation';
+
+const cases = [
+  {
+    icon: Briefcase,
+    titleKey: 'useCases.freelancers.title',
+    docsKey: 'useCases.freelancers.docs',
+    defaultTitle: 'For Freelancers',
+    defaultDocs: 'NDAs, Client Contracts',
+    href: (locale: string) => `/${locale}/docs/nda`,
+  },
+  {
+    icon: Home,
+    titleKey: 'useCases.landlords.title',
+    docsKey: 'useCases.landlords.docs',
+    defaultTitle: 'For Landlords',
+    defaultDocs: 'Leases, Eviction Notices',
+    href: (locale: string) => `/${locale}/docs/leaseAgreement`,
+  },
+  {
+    icon: Building2,
+    titleKey: 'useCases.smallBusiness.title',
+    docsKey: 'useCases.smallBusiness.docs',
+    defaultTitle: 'For Small Businesses',
+    defaultDocs: 'Operating Agreements, Invoices',
+    href: (locale: string) => `/${locale}/docs/operating-agreement`,
+  },
+  {
+    icon: Users,
+    titleKey: 'useCases.families.title',
+    docsKey: 'useCases.families.docs',
+    defaultTitle: 'For Families',
+    defaultDocs: 'Wills, Power of Attorney',
+    href: (locale: string) => `/${locale}/docs/last-will-testament`,
+  },
+];
+
+export const UseCasesSection = React.memo(function UseCasesSection() {
+  const { t } = useTranslation('common');
+  const params = useParams<{ locale?: string }>();
+  const locale = (params?.locale as 'en' | 'es') || 'en';
+
+  return (
+    <section className="container mx-auto px-4 py-12">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+        {cases.map((c) => {
+          const Icon = c.icon;
+          return (
+            <Link href={c.href(locale)} key={c.titleKey} className="group">
+              <div className="p-6 bg-card rounded-xl border border-border shadow-sm transition-transform group-hover:scale-105">
+                <Icon className="h-8 w-8 text-primary mb-4" />
+                <h3 className="text-lg font-semibold text-card-foreground">
+                  {t(c.titleKey, { defaultValue: c.defaultTitle })}
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  {t(c.docsKey, { defaultValue: c.defaultDocs })}
+                </p>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+});

--- a/src/components/landing/UseCasesSection.tsx
+++ b/src/components/landing/UseCasesSection.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { lazyClient } from '@/lib/lazy-client';
+
+const UseCasesSection = lazyClient(() => import('./UseCasesSection.client').then(m => ({ default: m.UseCasesSection })));
+
+export { UseCasesSection };
+export default UseCasesSection;


### PR DESCRIPTION
## Summary
- add four use-case cards to showcase common templates
- localize card text for English and Spanish
- insert section on the homepage between guarantee badge and popular docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400ee993b4832da151acd181db23f6