### PR TITLE
[UI] Refine search bar with examples

### DIFF
--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -19,7 +19,8 @@
   },
   "logoAlt": "123LegalDoc Home",
   "SearchBar": {
-    "placeholder": "Search 200+ contracts & forms..."
+    "placeholder": "e.g. Lease, Will, NDA...",
+    "suggestionsHint": "Popular: Lease · Will · Bill of Sale · Power of Attorney"
   },
   "TopDocsChips": {
     "title": "Popular Legal Documents",

--- a/public/locales/es/header.json
+++ b/public/locales/es/header.json
@@ -19,7 +19,8 @@
   },
   "logoAlt": "123LegalDoc Inicio",
   "SearchBar": {
-    "placeholder": "Buscar más de 200 contratos y formularios..."
+    "placeholder": "p. ej. Arrendamiento, Testamento, NDA...",
+    "suggestionsHint": "Popular: Arrendamiento · Testamento · Factura de venta · Poder Notarial"
   },
   "TopDocsChips": {
     "title": "Documentos Legales Populares",

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -95,14 +95,19 @@ const SearchBar = React.memo(function SearchBar() {
 
   const placeholderText = isHydrated
     ? tHeader('SearchBar.placeholder', {
-        defaultValue: 'Search 200+ contracts…',
+        defaultValue: 'e.g. Lease, Will, NDA...',
       })
     : 'Loading…';
+  const suggestionsHint = isHydrated
+    ? tHeader('SearchBar.suggestionsHint', {
+        defaultValue: 'Popular: Lease \u00b7 Will \u00b7 Bill of Sale \u00b7 Power of Attorney',
+      })
+    : '';
 
   return (
     <form
       onSubmit={handleSearchSubmit}
-      className="relative w-full max-w-xl mx-auto"
+      className="relative w-full max-w-md mx-auto"
     >
       <div className="relative">
         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground pointer-events-none" />
@@ -148,6 +153,11 @@ const SearchBar = React.memo(function SearchBar() {
           </ul>
         )}
       </div>
+      {suggestionsHint && (
+        <p className="mt-2 text-center text-sm text-muted-foreground">
+          {suggestionsHint}
+        </p>
+      )}
     </form>
   );
 });


### PR DESCRIPTION
## Summary
- shrink global search bar width
- improve placeholder example text
- show popular document hints below search
- translate search example text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400f6d848c832d87383f5e911816e8