### PR TITLE
[Features] Add customize block

### DIFF
--- a/public/images/laptop-check.svg
+++ b/public/images/laptop-check.svg
@@ -1,0 +1,5 @@
+<svg width="400" height="400" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <rect x="20" y="80" width="360" height="240" rx="12" fill="#1e293b" />
+  <path d="M40 300h320v20H40z" fill="#334155" />
+  <path d="M150 200l40 40 70-70" fill="none" stroke="#4ade80" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/app/[locale]/features/features-client-content.tsx
+++ b/src/app/[locale]/features/features-client-content.tsx
@@ -15,6 +15,7 @@ import {
   X,
 } from 'lucide-react';
 import React from 'react';
+import CustomizeDocBlock from '@/components/landing/CustomizeDocBlock';
 
 // Feature sub-component
 function Feature({
@@ -122,6 +123,8 @@ export default function FeaturesClientContent() {
           )}
         />
       </div>
+
+      <CustomizeDocBlock />
 
       <section className="mt-16 max-w-4xl mx-auto">
         <h2 className="text-2xl md:text-3xl font-bold mb-8 text-center text-foreground">

--- a/src/components/landing/CustomizeDocBlock.tsx
+++ b/src/components/landing/CustomizeDocBlock.tsx
@@ -1,0 +1,25 @@
+// src/components/landing/CustomizeDocBlock.tsx
+'use client';
+import AutoImage from '@/components/AutoImage';
+
+export default function CustomizeDocBlock() {
+  return (
+    <section className="bg-gray-50 py-16">
+      <div className="max-w-6xl mx-auto px-6 flex flex-col lg:flex-row-reverse items-center gap-8">
+        <AutoImage
+          src="/images/laptop-check.svg"
+          alt="Laptop with checkmark"
+          width={400}
+          height={400}
+          className="w-full max-w-sm"
+        />
+        <div className="text-center lg:text-left">
+          <h2 className="text-2xl lg:text-3xl font-semibold text-gray-800">Customize Your Document</h2>
+          <p className="mt-2 text-lg text-gray-600 max-w-md leading-relaxed">
+            Make edits with our built-in editor so every clause fits your exact situation.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add CustomizeDocBlock component with laptop illustration and reversed layout
- import and render CustomizeDocBlock in features page
- include simple laptop-check.svg asset

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8a561bc832da5429e30a9c57fb0