### PR TITLE
[Layout] Enhance header CTA and nav

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -58,9 +58,9 @@ const Nav = React.memo(function Nav() {
           key={link.href}
           href={`/${currentLocale}${link.href}`}
           className={cn(
-            'group hover:bg-primary/10 hover:text-primary focus-visible:bg-primary/10 focus-visible:text-primary transition-colors px-2 py-1.5 rounded-md',
+            'relative group px-2 py-1.5 rounded-md transition-colors hover:text-primary focus-visible:text-primary after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-0 after:bg-[#006EFF] after:transition-[width] after:duration-300 group-hover:after:w-full group-focus-visible:after:w-full',
             pathname === `/${currentLocale}${link.href}` &&
-              'bg-primary/10 text-primary font-semibold',
+              'text-primary font-semibold after:w-full',
           )}
         >
           {tHeader(link.labelKey, { defaultValue: link.defaultLabel })}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -219,8 +219,8 @@ const Header = React.memo(function Header() {
             <PopoverTrigger asChild>
               <Button
                 className={cn(
-                  'bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2 rounded-lg font-medium flex items-center gap-1 drop-shadow-lg focus-visible:ring-2 focus-visible:ring-offset-2',
-                  isMegaMenuOpen && 'bg-emerald-600',
+                  'bg-gradient-to-r from-[#006EFF] to-[#00C3A3] hover:from-[#0057CC] hover:to-[#00A38A] text-white px-4 py-2 rounded-lg font-medium flex items-center gap-1 drop-shadow-lg focus-visible:ring-2 focus-visible:ring-offset-2 transition-colors',
+                  isMegaMenuOpen && 'from-[#0057CC] to-[#00A38A]',
                 )}
                 disabled={!mounted}
                 aria-expanded={isMegaMenuOpen}
@@ -430,8 +430,8 @@ const Header = React.memo(function Header() {
 
             {/* Mobile categories toggle */}
             <Button
-              variant="ghost"
-              className="w-full justify-between text-base font-medium flex items-center px-4 py-3 hover:bg-muted focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2"
+              variant="default"
+              className="w-full justify-between text-base font-medium flex items-center px-4 py-3 bg-gradient-to-r from-[#006EFF] to-[#00C3A3] hover:from-[#0057CC] hover:to-[#00A38A] text-white focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2"
               onClick={() => setShowMobileCategories((v) => !v)}
               aria-expanded={showMobileCategories}
               disabled={!mounted}


### PR DESCRIPTION
## Summary
- upgrade `Make Documents` CTA to branded gradient
- add underline animation to nav links
- match mobile category toggle with gradient styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413656b9d4832d9669c299d9b43e78