### PR TITLE
[Landing] Improve how-it-works visuals

### DIFF
--- a/src/components/landing/HowItWorks.client.tsx
+++ b/src/components/landing/HowItWorks.client.tsx
@@ -3,34 +3,47 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Target, Sparkles, Download } from 'lucide-react';
+import {
+  FolderOpen,
+  FileQuestion,
+  Lock,
+  Share2,
+  ArrowRight,
+} from 'lucide-react';
 import StepCard from './StepCard';
 
 const steps = [
   {
     number: 1,
-    Icon: Target,
-    titleKey: 'home.steps.step1.titleUpdated', // Changed key
+    Icon: FolderOpen,
+    titleKey: 'home.steps.step1.titleUpdated',
     descKey: 'home.steps.step1.descUpdated',
-    defaultTitle: 'Select a Legal Template', // Ensured default is correct
+    defaultTitle: 'Select a Legal Template',
     defaultDesc:
       'Choose from 1,000+ state-specific templates built on up-to-date statutes & best practices.',
   },
   {
     number: 2,
-    Icon: Sparkles,
+    Icon: FileQuestion,
     titleKey: 'home.steps.step2.titleUpdated',
     descKey: 'home.steps.step2.descUpdated',
     defaultTitle: 'Answer Quick Prompts',
-    defaultDesc: 'Fill in simple fields—no legal expertise needed. As you answer plain-language questions, your document populates in real time. Then edit any clause or section until it’s exactly what you need.',
+    defaultDesc:
+      'Fill in simple fields—no legal expertise needed. As you answer plain-language questions, your document populates in real time. Then edit any clause or section until it’s exactly what you need.',
   },
   {
     number: 3,
-    Icon: Download,
+    Icon: () => (
+      <span className="relative inline-block w-8 h-8">
+        <Lock className="absolute inset-0" />
+        <Share2 className="absolute -right-2 -bottom-2 w-4 h-4" />
+      </span>
+    ),
     titleKey: 'home.steps.step3.title',
-    descKey: 'home.steps.step3.descUpdated', // Changed key
+    descKey: 'home.steps.step3.descUpdated',
     defaultTitle: 'Securely Download & Share',
-    defaultDesc: 'Once you’ve double-checked every detail, hit “Complete.” Your polished PDF is ready to download, print, or share via a protected link—controlled by you, accessible to anyone you choose.',
+    defaultDesc:
+      'Once you’ve double-checked every detail, hit “Complete.” Your polished PDF is ready to download, print, or share via a protected link—controlled by you, accessible to anyone you choose.',
   },
 ] as const;
 
@@ -61,14 +74,17 @@ const HowItWorks = React.memo(function HowItWorks() {
             })}
           </span>
         </h2>
-        <div className="mt-8 flex flex-col space-y-8 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-6">
-          {steps.map((step) => (
-            <StepCard
-              key={step.titleKey}
-              number={step.number}
-              title={t(step.titleKey, { defaultValue: step.defaultTitle })}
-              desc={t(step.descKey, { defaultValue: step.defaultDesc })}
-            />
+        <div className="mt-8 flex flex-col items-center space-y-8 sm:flex-row sm:space-y-0 sm:space-x-6 justify-center">
+          {steps.map((step, idx) => (
+            <div key={step.titleKey} className="flex items-center group">
+              <StepCard
+                number={step.number}
+                title={t(step.titleKey, { defaultValue: step.defaultTitle })}
+                desc={t(step.descKey, { defaultValue: step.defaultDesc })}
+                icon={<step.Icon className="w-8 h-8" />}
+                showConnector={idx < steps.length - 1}
+              />
+            </div>
           ))}
         </div>
       </div>

--- a/src/components/landing/StepCard.tsx
+++ b/src/components/landing/StepCard.tsx
@@ -4,23 +4,40 @@ interface StepCardProps {
   number: number;
   title: string;
   desc?: string;
-  icon?: React.ReactNode; // Made icon optional
+  icon?: React.ReactNode;
+  showConnector?: boolean;
 }
 
 const StepCard = React.memo(function StepCard({
   number,
   title,
   desc,
-  icon, // Icon is now optional
+  icon,
+  showConnector,
 }: StepCardProps) {
   return (
-    <div className="flex flex-col items-center text-center p-6 bg-gray-50 rounded-lg shadow-sm hover:shadow-md focus-within:ring-2 focus-within:ring-emerald-400 transition">
-      <div className="w-12 h-12 flex items-center justify-center rounded-full bg-primary/10 text-primary text-xl font-bold mb-4">
+    <div className="group relative flex flex-col items-center text-center p-6 bg-gray-50 rounded-lg shadow-sm hover:shadow-md focus-within:ring-2 focus-within:ring-emerald-400 transition">
+      <div className="w-12 h-12 flex items-center justify-center rounded-full bg-gradient-to-br from-[#006EFF] to-[#00C3A3] text-white text-xl font-bold mb-4 shadow">
         {number}
       </div>
-      {/* Icon rendering is removed from here */}
+      {icon && <div className="mb-3 text-primary">{icon}</div>}
       <h3 className="text-xl font-semibold mb-2 text-gray-800">{title}</h3>
       {desc && <p className="text-gray-600 text-sm">{desc}</p>}
+      {showConnector && (
+        <div className="hidden sm:flex absolute right-0 top-6 translate-x-full items-center w-24">
+          <div className="flex-1 h-px bg-gray-300 transition-colors group-hover:bg-primary" />
+          <svg
+            className="w-4 h-4 text-gray-300 transition-colors group-hover:text-primary"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M0 12h20m0 0l-4-4m4 4l-4 4" />
+          </svg>
+        </div>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- modernize step cards with gradient icons and connectors
- add legal-themed icons in HowItWorks section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684139086224832db57b4b68a71645c6