### PR TITLE
[UI] Restrict ticker to homepage

### DIFF
--- a/src/components/ActivityTicker.tsx
+++ b/src/components/ActivityTicker.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
 const messages = [
@@ -11,7 +12,13 @@ const messages = [
 ];
 
 export default function ActivityTicker() {
+  const pathname = usePathname();
+  const isHomePage = pathname === '/en' || pathname === '/es' || pathname === '/';
   const [index, setIndex] = useState(0);
+
+  if (!isHomePage) {
+    return null;
+  }
 
   useEffect(() => {
     const id = setInterval(() => {


### PR DESCRIPTION
## Summary
- only render ActivityTicker on the homepage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684141ac48a8832dac0e613b758d0264