### PR TITLE
[SearchBar] Fix translation namespace

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -10,7 +10,7 @@ import { documentLibrary, type LegalDocument } from '@/lib/document-library';
 import { getDocTranslation } from '@/lib/i18nUtils';
 
 const SearchBar = React.memo(function SearchBar() {
-  const { t: tHeader } = useTranslation('common');
+  const { t: tHeader } = useTranslation('header');
   const router = useRouter();
   const params = (useParams<{ locale?: string }>() ?? {}) as {
     locale?: string;


### PR DESCRIPTION
## Summary
- switch SearchBar to `header` i18n namespace so Spanish strings load

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684142d7d10c832d95cef591787ca3ba