### PR TITLE
[Home] Localize TopDocs badges

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -256,6 +256,10 @@
   "Showing documents matching your search and state criteria.": "Showing documents matching your search and state criteria.",
   "TopDocsChips.loading": "Loading popular documents...",
   "TopDocsChips.title": "Popular Legal Documents",
+  "TopDocsChips.badge.new": "New",
+  "TopDocsChips.badge.updated": "Updated",
+  "TopDocsChips.tooltip.new": "Recently added",
+  "TopDocsChips.tooltip.updated": "Recently refreshed",
   "useCases": {
     "freelancers": {
       "title": "For Freelancers",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -256,6 +256,10 @@
   "Showing documents matching your search and state criteria.": "Mostrando documentos que coinciden con tu búsqueda y criterios de estado.",
   "TopDocsChips.loading": "Cargando documentos populares...",
   "TopDocsChips.title": "Documentos Legales Populares",
+  "TopDocsChips.badge.new": "Nuevo",
+  "TopDocsChips.badge.updated": "Actualizado",
+  "TopDocsChips.tooltip.new": "Agregado recientemente",
+  "TopDocsChips.tooltip.updated": "Actualizado recientemente",
   "useCases": {
     "freelancers": {
       "title": "Para Freelancers",

--- a/src/components/TopDocsChips.tsx
+++ b/src/components/TopDocsChips.tsx
@@ -207,11 +207,21 @@ const TopDocsChips = React.memo(function TopDocsChips() {
                         ) : (
                           <RefreshCcw className="h-3 w-3" />
                         )}
-                        <span className="capitalize">{badge}</span>
+                        <span className="capitalize">
+                          {tCommon(`TopDocsChips.badge.${badge}`, {
+                            defaultValue: badge === 'new' ? 'New' : 'Updated',
+                          })}
+                        </span>
                       </Badge>
                     </TooltipTrigger>
                     <TooltipContent>
-                      {badge === 'new' ? 'Recently added' : 'Recently refreshed'}
+                      {badge === 'new'
+                        ? tCommon('TopDocsChips.tooltip.new', {
+                            defaultValue: 'Recently added',
+                          })
+                        : tCommon('TopDocsChips.tooltip.updated', {
+                            defaultValue: 'Recently refreshed',
+                          })}
                     </TooltipContent>
                   </Tooltip>
                 )}


### PR DESCRIPTION
## Summary
- translate `New` and `Updated` badges in TopDocs section
- add matching Spanish copy

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841440a7f30832dba5ad0c2f25228ef