### PR TITLE
[Landing] Localize refund modal link

### DIFF
--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -359,8 +359,12 @@ const TrustAndTestimonialsSection = React.memo(
                   {isHydrated ? t('home.moneyBackGuarantee', { defaultValue: "100% Satisfaction Guarantee or Your Money Back" }) : placeholderText}
                 </span>
               </div>
-              <Button variant="link" className="text-xs p-0" onClick={() => setShowRefundModal(true)}>
-                Learn More
+              <Button
+                variant="link"
+                className="text-xs p-0"
+                onClick={() => setShowRefundModal(true)}
+              >
+                {t('ctaSecondary', { defaultValue: 'Learn More' })}
               </Button>
             </div>
             <Button size="lg" className="h-14 px-12 text-lg bg-gradient-to-r from-[#006EFF] to-[#00C3A3] text-white transition rounded-full font-semibold shadow-lg hover:shadow-xl transform hover:scale-105" onClick={scrollToWorkflow} disabled={!isHydrated}>


### PR DESCRIPTION
## Summary
- show translated label on Trust & Testimonials section refund link

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414438d304832db158ebee6727061b