### PR TITLE
[ActivityTicker] Localize homepage ticker

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -329,5 +329,12 @@
     "instantDownload": "Instant Document Download",
     "bilingualSupport": "Fully Bilingual Support",
     "oneTimePayment": "One-Time Payment Option"
+  },
+  "activityTicker": {
+    "messages": [
+      "Ben from Ohio just created a Lease Agreement",
+      "Maria from Texas finished a Promissory Note",
+      "Someone in California started a Living Will"
+    ]
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -329,5 +329,12 @@
     "instantDownload": "Descarga Instantánea del Documento",
     "bilingualSupport": "Soporte Bilingüe Completo",
     "oneTimePayment": "Pago Único"
+  },
+  "activityTicker": {
+    "messages": [
+      "Ben de Ohio acaba de crear un Contrato de Arrendamiento",
+      "María de Texas finalizó un Pagaré",
+      "Alguien en California inició un Testamento en Vida"
+    ]
   }
 }

--- a/src/components/ActivityTicker.tsx
+++ b/src/components/ActivityTicker.tsx
@@ -3,17 +3,16 @@
 import React, { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { usePathname } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 
-const messages = [
-  'Ben from Ohio just created a Lease Agreement',
-  'Maria from Texas finished a Promissory Note',
-  'Someone in California started a Living Will',
-];
 
 export default function ActivityTicker() {
+  const { t } = useTranslation('common');
   const pathname = usePathname();
   const isHomePage = pathname === '/en' || pathname === '/es' || pathname === '/';
+  const messages =
+    (t('activityTicker.messages', { returnObjects: true }) as string[]) || [];
   const [index, setIndex] = useState(0);
 
   if (!isHomePage) {
@@ -25,9 +24,9 @@ export default function ActivityTicker() {
       setIndex((prev) => (prev + 1) % messages.length);
     }, 4000);
     return () => clearInterval(id);
-  }, []);
+  }, [messages.length]);
 
-  const message = messages[index];
+  const message = messages[index % messages.length];
 
   return (
     <div className="fixed bottom-4 right-4 z-[99] pointer-events-none">


### PR DESCRIPTION
## Summary
- pull ticker messages from translations based on locale
- add message arrays to English and Spanish locales

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684145a6efa4832db1670afa226470ba