### PR TITLE
[i18n] Localize trust strip badges

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -204,6 +204,7 @@
   "You're {{currentStep}} of {{totalSteps}} done!": "You're {{currentStep}} of {{totalSteps}} done!",
   "home.trustStrip.title": "Trusted By Professionals",
   "home.trustStrip.badge1": "Over {{count}} documents generated",
+  "home.trustStrip.usedBy": "Used by:",
   "home.testimonials.title": "What Our Users Say",
   "home.testimonials.t1.quote": "Incredibly intuitive! This platform saved me countless hours and thousands in legal fees for my startup. The AI suggestions were spot on and let me launch with full confidence.",
   "home.testimonials.t1.name": "Sarah L.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -204,6 +204,7 @@
   "You're {{currentStep}} of {{totalSteps}} done!": "¡Has completado {{currentStep}} de {{totalSteps}}!",
   "home.trustStrip.title": "Confiado por Profesionales",
   "home.trustStrip.badge1": "Más de {{count}} documentos generados",
+  "home.trustStrip.usedBy": "Utilizado por:",
   "home.testimonials.title": "Lo Que Dicen Nuestros Usuarios",
   "home.testimonials.t1.quote": "¡Increíblemente intuitivo! Esta plataforma me ahorró incontables horas y miles en honorarios legales para mi startup. Las sugerencias de la IA fueron perfectas y me permitieron lanzar con plena confianza.",
   "home.testimonials.t1.name": "Sofía L.",

--- a/src/components/landing/TrustAndTestimonialsSection.tsx
+++ b/src/components/landing/TrustAndTestimonialsSection.tsx
@@ -283,15 +283,12 @@ const TrustAndTestimonialsSection = React.memo(
               <div className="flex items-center gap-2">
                 <FileText className="h-5 w-5 text-primary" />
                 <span>
-                  {isHydrated ? (
-                    <>
-                      Over{' '}
-                      <span className="font-semibold leading-5">{formattedCount}</span>{' '}
-                      documents generated
-                    </>
-                  ) : (
-                    placeholderText
-                  )}
+                  {isHydrated
+                    ? t('home.trustStrip.badge1', {
+                        count: formattedCount,
+                        defaultValue: `Over ${formattedCount} documents generated`,
+                      })
+                    : placeholderText}
                 </span>
               </div>
               <div className="flex items-center gap-1">
@@ -305,7 +302,9 @@ const TrustAndTestimonialsSection = React.memo(
                 <span className="ml-1 font-semibold leading-5">4.9/5</span>
               </div>
               <div className="flex items-center gap-2 opacity-50">
-                <span className="text-xs">Used by:</span>
+                <span className="text-xs">
+                  {t('home.trustStrip.usedBy', 'Used by:')}
+                </span>
                 <AutoImage src="/images/logos/forbes-logo.svg" alt="Forbes logo" width={80} height={16} className="h-4 w-auto" />
                 <AutoImage src="/images/logos/bloomberg-logo.svg" alt="Bloomberg logo" width={80} height={16} className="h-4 w-auto" />
                 <AutoImage src="/images/logos/nyt-logo.svg" alt="New York Times logo" width={80} height={16} className="h-4 w-auto" />


### PR DESCRIPTION
## Summary
- translate doc count badge and partner label on the homepage

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/studio/node_modules/globals/index.js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841456acd94832da2f9ace97db6d7cb