### PR TITLE
[Layout] Remove head whitespace

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@
 import './globals.css';
 import localFont from 'next/font/local';
 import Script from 'next/script';
+import Head from 'next/head';
 import SEOConfig from '../../next-seo.config.ts'; // Changed import
 import RootClient from './root-client';
 
@@ -75,8 +76,7 @@ export default function RootLayout({
 
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>{headElements}</head>
-      <body
+      <Head>{headElements}</Head><body
         className={`${inter.variable} ${merriweather.variable} antialiased flex flex-col min-h-screen overflow-x-hidden`}
       >
         <RootClient>{children}</RootClient>


### PR DESCRIPTION
## Summary
- import `Head` from next/head
- inline Head into html tag to prevent whitespace in the `<head>` section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414c82caf4832d9c7964e790e0aa18