### PR TITLE
[i18n] Add pricing page translations

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -324,6 +324,63 @@
     }
     }
   },
+  "pricing": {
+    "title": "Simple, Transparent Pricing",
+    "payPerDocBadge": "One-time $35/document • No subscription",
+    "freeCreditTitle": "Your Free Document Credit",
+    "freeCreditStatus": "You've used {{used}} of {{total}} free document credits.",
+    "claimFreeCredit": "Sign Up to Claim Your Free Document!",
+    "plans": {
+      "single": {
+        "title": "Single Document",
+        "description": "Perfect for one-off needs.",
+        "item1": "1 downloadable legal PDF",
+        "item2": "Clause customization",
+        "item3": "Email support",
+        "item4": "Secure sharing (soon)"
+      },
+      "bundle": {
+        "title": "5-Document Bundle",
+        "description": "Ideal for multiple related documents.",
+        "item1": "5 downloadable PDFs",
+        "item2": "All single document features",
+        "item3": "Credits never expire",
+        "item4": "Best value per document"
+      },
+      "unlimited": {
+        "title": "Business Pro",
+        "description": "For frequent users & businesses.",
+        "item1": "Unlimited documents",
+        "item2": "Priority support",
+        "item3": "Team features (coming soon)",
+        "item4": "Cancel anytime"
+      }
+    },
+    "perDocument": "document",
+    "bundleOf5": "bundle of 5",
+    "perMonth": "month",
+    "cta": "Get Started",
+    "ctaContact": "Contact Sales",
+    "mostPopular": "Most Popular",
+    "comparisonTitle": "How We Compare",
+    "featureHeader": "Feature",
+    "competitorHeader": "Traditional Lawyer",
+    "competitorOnlineHeader": "Other Online Services",
+    "pricePerDocLabel": "Avg. Price Per Document",
+    "customizationLabel": "Customization Level",
+    "highLabel": "High (AI-assisted)",
+    "veryHighLabel": "Very High (Tailored)",
+    "mediumLabel": "Medium (Templates)",
+    "speedLabel": "Speed",
+    "minutesLabel": "Minutes",
+    "daysWeeksLabel": "Days/Weeks",
+    "hoursDaysLabel": "Hours/Days",
+    "accessibilityLabel": "Accessibility",
+    "accessible247Label": "24/7 Online",
+    "officeHoursLabel": "Office Hours, Appointments",
+    "onlineLimitedSupportLabel": "Online, Support Varies",
+    "guarantee": "100% Satisfaction Guarantee or Your Money Back on single/bundle purchases."
+  },
   "whyChooseUs": {
     "title": "Why Choose Us?",
     "aiDrafting": "AI-Powered Drafting",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -324,6 +324,63 @@
       }
     }
   },
+  "pricing": {
+    "title": "Precios Simples y Transparentes",
+    "payPerDocBadge": "Pago único de $35/documento • Sin suscripción",
+    "freeCreditTitle": "Tu Crédito de Documento Gratis",
+    "freeCreditStatus": "Has usado {{used}} de {{total}} créditos de documentos gratuitos.",
+    "claimFreeCredit": "¡Regístrate para reclamar tu documento gratis!",
+    "plans": {
+      "single": {
+        "title": "Documento Único",
+        "description": "Perfecto para necesidades puntuales.",
+        "item1": "1 PDF legal descargable",
+        "item2": "Personalización de cláusulas",
+        "item3": "Soporte por correo electrónico",
+        "item4": "Compartir seguro (próximamente)"
+      },
+      "bundle": {
+        "title": "Paquete de 5 Documentos",
+        "description": "Ideal para varios documentos relacionados.",
+        "item1": "5 PDFs descargables",
+        "item2": "Todas las características del documento único",
+        "item3": "Los créditos nunca vencen",
+        "item4": "Mejor valor por documento"
+      },
+      "unlimited": {
+        "title": "Negocios Pro",
+        "description": "Para usuarios frecuentes y empresas.",
+        "item1": "Documentos ilimitados",
+        "item2": "Soporte prioritario",
+        "item3": "Funciones de equipo (próximamente)",
+        "item4": "Cancela en cualquier momento"
+      }
+    },
+    "perDocument": "documento",
+    "bundleOf5": "paquete de 5",
+    "perMonth": "mes",
+    "cta": "Comenzar",
+    "ctaContact": "Contactar Ventas",
+    "mostPopular": "Más Popular",
+    "comparisonTitle": "Cómo Nos Comparamos",
+    "featureHeader": "Característica",
+    "competitorHeader": "Abogado Tradicional",
+    "competitorOnlineHeader": "Otros Servicios en Línea",
+    "pricePerDocLabel": "Precio Promedio por Documento",
+    "customizationLabel": "Nivel de Personalización",
+    "highLabel": "Alto (con IA)",
+    "veryHighLabel": "Muy Alto (Personalizado)",
+    "mediumLabel": "Medio (Plantillas)",
+    "speedLabel": "Velocidad",
+    "minutesLabel": "Minutos",
+    "daysWeeksLabel": "Días/Semanas",
+    "hoursDaysLabel": "Horas/Días",
+    "accessibilityLabel": "Accesibilidad",
+    "accessible247Label": "En línea 24/7",
+    "officeHoursLabel": "Horario de Oficina, Citas",
+    "onlineLimitedSupportLabel": "En línea, Soporte Variable",
+    "guarantee": "Garantía de Satisfacción 100% o le Devolvemos su Dinero en compras individuales/paquetes."
+  },
   "whyChooseUs": {
     "title": "¿Por Qué Elegirnos?",
     "aiDrafting": "Redacción con IA",


### PR DESCRIPTION
## Summary
- translate all pricing content for en and es

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414f479f2c832db605478276d7c9ef