### PR TITLE
[Docs] Add Spanish translations for doc details

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -337,5 +337,30 @@
       "Maria from Texas finished a Promissory Note",
       "Someone in California started a Living Will"
     ]
-  }
+  },
+  "docDetail.benefit1": "Legally Sound & State-Specific",
+  "docDetail.benefit2": "Quick & Easy Customization",
+  "docDetail.benefit3": "Instant Download & Secure Sharing",
+  "Browse Templates": "Browse Templates",
+  "docDetail.previewTitle": "Document Preview",
+  "docDetail.previewSubtitle": "This is how your document will generally look. Specific clauses and details will be customized by your answers.",
+  "docDetail.pricingTitle": "Transparent Pricing",
+  "pricing.perDocument": "per document",
+  "docDetail.competitivePrice": "Compare to typical attorney fees of ${{competitorPrice}}+",
+  "docDetail.attorneyApproved": "Attorney-approved",
+  "docDetail.readyInMinutes": "Ready in 3 minutes",
+  "docDetail.moneyBackGuarantee": "100 % money-back guarantee",
+  "docDetail.templatesDownloaded": "templates downloaded this year",
+  "docDetail.moneyBack30": "30-day money-back guarantee",
+  "docDetail.optionalAddons": "Optional Add-ons",
+  "docDetail.aiAssistance": "AI Assistance",
+  "docDetail.aiAssistP1": "Our AI will help suggest",
+  "docDetail.relevantClauses": "relevant clauses",
+  "docDetail.aiAssistP2": "and ensure your document is tailored to the",
+  "docDetail.specificsOfYourSituation": "specifics of your situation",
+  "docDetail.aiAssistP3": "as you answer questions in the next step.",
+  "docDetail.aiHighlightPre": "AI Highlight:",
+  "docDetail.keyClauses": "Key clauses",
+  "docDetail.aiHighlightPost": "will be automatically tailored.",
+  "docDetail.aiHighlightTitle": "AI Highlight: This section will be auto-customized based on your answers."
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -337,5 +337,30 @@
       "María de Texas finalizó un Pagaré",
       "Alguien en California inició un Testamento en Vida"
     ]
-  }
+  },
+  "docDetail.benefit1": "Legalmente sólido y específico para cada estado",
+  "docDetail.benefit2": "Personalización rápida y sencilla",
+  "docDetail.benefit3": "Descarga instantánea y compartición segura",
+  "Browse Templates": "Explorar Plantillas",
+  "docDetail.previewTitle": "Vista previa del documento",
+  "docDetail.previewSubtitle": "Así se verá tu documento en general. Las cláusulas y detalles específicos se personalizarán según tus respuestas.",
+  "docDetail.pricingTitle": "Precios Transparentes",
+  "pricing.perDocument": "por documento",
+  "docDetail.competitivePrice": "Compara con los honorarios típicos de abogados de ${{competitorPrice}}+",
+  "docDetail.attorneyApproved": "Aprobado por abogados",
+  "docDetail.readyInMinutes": "Listo en 3 minutos",
+  "docDetail.moneyBackGuarantee": "Garantía de devolución del 100%",
+  "docDetail.templatesDownloaded": "plantillas descargadas este año",
+  "docDetail.moneyBack30": "Garantía de devolución de dinero de 30 días",
+  "docDetail.optionalAddons": "Complementos opcionales",
+  "docDetail.aiAssistance": "Asistencia de IA",
+  "docDetail.aiAssistP1": "Nuestra IA sugerirá",
+  "docDetail.relevantClauses": "cláusulas relevantes",
+  "docDetail.aiAssistP2": "y asegurará que tu documento se adapte a los",
+  "docDetail.specificsOfYourSituation": "detalles de tu situación",
+  "docDetail.aiAssistP3": "mientras respondes las preguntas en el siguiente paso.",
+  "docDetail.aiHighlightPre": "Resaltado de IA:",
+  "docDetail.keyClauses": "Cláusulas clave",
+  "docDetail.aiHighlightPost": "se personalizarán automáticamente.",
+  "docDetail.aiHighlightTitle": "Resaltado de IA: esta sección se personalizará automáticamente según tus respuestas."
 }

--- a/src/app/[locale]/docs/[docId]/DocPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/DocPageClient.tsx
@@ -76,10 +76,15 @@ interface DocPageClientProps {
 }
 
 // Placeholder for AI dynamic highlights
-const AiHighlightPlaceholder = ({ text }: { text: string }) => (
+interface AiHighlightPlaceholderProps {
+  text: string;
+  title: string;
+}
+
+const AiHighlightPlaceholder = ({ text, title }: AiHighlightPlaceholderProps) => (
   <span
     className="bg-primary/10 text-primary px-1 py-0.5 rounded-sm text-xs font-medium border border-primary/30 cursor-help"
-    title="AI Highlight: This section will be auto-customized based on your answers."
+    title={title}
   >
     {text} <Zap size={12} className="inline ml-1" />
   </span>
@@ -90,6 +95,10 @@ export default function DocPageClient({
   markdownContent,
 }: DocPageClientProps) {
   const { t, i18n } = useTranslation('common');
+  const aiHighlightTitle = t(
+    'docDetail.aiHighlightTitle',
+    'AI Highlight: This section will be auto-customized based on your answers.'
+  );
   const router = useRouter();
   const urlParams = (useParams() ?? {}) as Record<string, string | string[]>;
 
@@ -348,8 +357,12 @@ export default function DocPageClient({
               markdownContent={markdownContent} // Add this prop
             />
             <p className="text-xs text-muted-foreground mt-2 text-center italic">
-              AI Highlight: <AiHighlightPlaceholder text="Key clauses" /> will
-              be automatically tailored.
+              {t('docDetail.aiHighlightPre', 'AI Highlight:')}{' '}
+              <AiHighlightPlaceholder
+                text={t('docDetail.keyClauses', 'Key clauses')}
+                title={aiHighlightTitle}
+              />{' '}
+              {t('docDetail.aiHighlightPost', 'will be automatically tailored.')}
             </p>
           </section>
 
@@ -385,15 +398,15 @@ export default function DocPageClient({
                     <ul className="mt-3 space-y-1 text-sm">
                       <li className="flex items-center gap-2">
                         <ShieldCheck className="h-4 w-4 text-teal-600" />{' '}
-                        Attorney-approved
+                        {t('docDetail.attorneyApproved', 'Attorney-approved')}
                       </li>
                       <li className="flex items-center gap-2">
-                        <Clock className="h-4 w-4 text-teal-600" /> Ready in 3
-                        minutes
+                        <Clock className="h-4 w-4 text-teal-600" />{' '}
+                        {t('docDetail.readyInMinutes', 'Ready in 3 minutes')}
                       </li>
                       <li className="flex items-center gap-2">
-                        <RotateCcw className="h-4 w-4 text-teal-600" /> 100 %
-                        money-back guarantee
+                        <RotateCcw className="h-4 w-4 text-teal-600" />{' '}
+                        {t('docDetail.moneyBackGuarantee', '100 % money-back guarantee')}
                       </li>
                     </ul>
                     <Button
@@ -411,7 +424,8 @@ export default function DocPageClient({
                   {/* Let’s Encrypt */}
                   {/* Documents generated counter */}
                   <p className="text-xs text-gray-500">
-                    <strong>104,213</strong> templates downloaded this year
+                    <strong>104,213</strong>{' '}
+                    {t('docDetail.templatesDownloaded', 'templates downloaded this year')}
                   </p>
                   {/* Refund badge */}
                   <div className="inline-flex items-center gap-1 text-xs text-gray-500">
@@ -427,7 +441,7 @@ export default function DocPageClient({
                     >
                       <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
                     </svg>
-                    30-day money-back guarantee
+                    {t('docDetail.moneyBack30', '30-day money-back guarantee')}
                   </div>
                 </div>
               </div>
@@ -472,11 +486,17 @@ export default function DocPageClient({
               </CardHeader>
               <CardContent>
                 <p className="text-xs text-muted-foreground">
-                  Our AI will help suggest{' '}
-                  <AiHighlightPlaceholder text="relevant clauses" /> and ensure
-                  your document is tailored to the{' '}
-                  <AiHighlightPlaceholder text="specifics of your situation" />{' '}
-                  as you answer questions in the next step.
+                  {t('docDetail.aiAssistP1', 'Our AI will help suggest')}{' '}
+                  <AiHighlightPlaceholder
+                    text={t('docDetail.relevantClauses', 'relevant clauses')}
+                    title={aiHighlightTitle}
+                  />{' '}
+                  {t('docDetail.aiAssistP2', 'and ensure your document is tailored to the')}{' '}
+                  <AiHighlightPlaceholder
+                    text={t('docDetail.specificsOfYourSituation', 'specifics of your situation')}
+                    title={aiHighlightTitle}
+                  />{' '}
+                  {t('docDetail.aiAssistP3', 'as you answer questions in the next step.')}
                 </p>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- localize doc detail strings for Spanish
- embed new translation keys in English and Spanish locale files
- update DocPageClient to display translated strings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414eefc110832dab93c77ce7673196