### PR TITLE
[Perf] Lazy-load ActivityTicker

### DIFF
--- a/src/components/providers/ClientProviders.tsx
+++ b/src/components/providers/ClientProviders.tsx
@@ -19,7 +19,9 @@ interface ClientProvidersProps {
 import Header from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import ContactFormButton from '@/components/ContactFormButton';
-import ActivityTicker from '@/components/ActivityTicker';
+// Defer loading of ActivityTicker to keep initial JS lighter
+import { lazyClient } from '@/lib/lazy-client';
+const ActivityTicker = lazyClient(() => import('@/components/ActivityTicker'));
 
 const AppShell = React.memo(function AppShell({
   children,


### PR DESCRIPTION
## Summary
- defer ActivityTicker load using `lazyClient`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684232daac9c832d8438006baa9e9aab