### PR TITLE
[Perf] Serve modern image formats

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,9 +16,10 @@ const nextConfig = {
 
   /* —──────── Static-export image handling —──────── */
   images: {
-    unoptimized: true,
+    formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       { protocol: 'https', hostname: 'picsum.photos', pathname: '/**' },
+      { protocol: 'https', hostname: 'placehold.co', pathname: '/**' },
     ],
   },
   /* Add allowedDevOrigins here as instructed */

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const config: NextConfig = {
   swcMinify: true,
   productionBrowserSourceMaps: true,
   images: {
-    unoptimized: true, // Disable Next.js image optimization for static export
+    formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
## Summary
- allow Next.js to optimize images as AVIF or WebP

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842330c9194832d878056b395fa8b16