### PR TITLE
[Infra] Allow SimpleIcons host

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,7 @@ const nextConfig = {
     remotePatterns: [
       { protocol: 'https', hostname: 'picsum.photos', pathname: '/**' },
       { protocol: 'https', hostname: 'placehold.co', pathname: '/**' },
+      { protocol: 'https', hostname: 'cdn.simpleicons.org', pathname: '/**' },
     ],
   },
   /* Add allowedDevOrigins here as instructed */

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,12 @@ const config: NextConfig = {
         hostname: 'placehold.co', // Added for placeholder images
         port: '',
         pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'cdn.simpleicons.org',
+        port: '',
+        pathname: '/**',
       }
     ],
   },


### PR DESCRIPTION
## Summary
- add cdn.simpleicons.org to Next.js image domains

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684235c0f6ac832db846c89a6064a8eb