### PR TITLE
[Perf] Trim Sentry and add bundle analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,12 @@ remains responsive.
 - Avoid including large libraries in the initial bundle; load them only on pages that need them.
 - Run Lighthouse against a production build to measure real-world performance.
 - Keep development-only dependencies out of client-side code.
-- Consider profiling with Next.js `ANALYZE=true` to inspect bundle sizes.
+- Consider profiling with Next.js `npm run analyze` to inspect bundle sizes.
 
 ## Reducing Unused JavaScript
 
-- Run `ANALYZE=true npm run build` to view the size of each client bundle and identify heavy modules.
+- Run `npm run analyze` to view the size of each client bundle and identify heavy modules.
+- Replace the heavy `@sentry/nextjs` integration with lightweight `@sentry/react` and `@sentry/browser` to trim unused tracing code.
 - Convert infrequently used components such as `Header`, `StickyFilterBar` and landing page sections to `next/dynamic` imports so they load only when rendered.
 - Move rarely needed imports out of `app/layout.tsx` and page-level layouts to avoid pulling them into every page's bundle.
 - Import components directly inside the pages that need them instead of in `_app` or root layouts when possible.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,8 @@
-/* next.config.mjs — Next 15 App Router, Sentry + Turbopack friendly  */
+/* next.config.mjs — Next 15 App Router with bundle analysis support */
 
-import { withSentryConfig } from '@sentry/nextjs';
-import webpack from 'webpack';
+import createAnalyzer from '@next/bundle-analyzer';
+
+const withBundleAnalyzer = createAnalyzer({ enabled: process.env.ANALYZE === 'true' });
 
 /* -------------------------------------------------------------------------- */
 /*  Core Next.js config                                                       */
@@ -40,27 +41,8 @@ const nextConfig = {
 /* -------------------------------------------------------------------------- */
 /*  Sentry wrapper                                                            */
 /* -------------------------------------------------------------------------- */
-export default withSentryConfig(
-  nextConfig,
-  {
-    org: '123legaldoc',
-    project: 'javascript-nextjs',
+const config = nextConfig;
 
-    /* quieter local builds, verbose in CI */
-    silent: !process.env.CI,
-
-    /* upload more source-maps for cleaner stack traces */
-    widenClientFileUpload: true,
-
-    /* client-side tunnel to dodge ad-blockers */
-    tunnelRoute: '/monitoring',
-
-    /* strip Sentry logger calls from bundles */
-    disableLogger: true,
-
-    /* auto-instrument Vercel Cron monitors (non-blocking if unsupported) */
-    automaticVercelMonitors: true,
-  },
-  /* Sentry Webpack Plugin options (leave empty → defaults) */
-  {},
-);
+export default process.env.ANALYZE === 'true'
+  ? withBundleAnalyzer(config)
+  : config;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev --turbopack",
     "dev:alt": "next dev --turbopack -p 9003",
     "build": "next build",
+    "analyze": "ANALYZE=true npm run build",
     "export": "next export -o apps/web/out",
     "start": "NODE_ENV=production node server.mjs",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" scripts || true",
@@ -45,7 +46,8 @@
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.8",
-    "@sentry/nextjs": "^9.23.0",
+    "@sentry/browser": "^9.23.0",
+    "@sentry/react": "^9.23.0",
     "@stripe/react-stripe-js": "^2.9.0",
     "@stripe/stripe-js": "^4.10.0",
     "@tailwindcss/typography": "^0.5.13",
@@ -124,7 +126,8 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.33.0",
-    "webpack": "^5.99.8"
+    "webpack": "^5.99.8",
+    "@next/bundle-analyzer": "^13.2.5"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -3,14 +3,11 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: "https://7b10ad6837786c85f4b58112ee8fd516@o4509409853440000.ingest.us.sentry.io/4509409855340544",
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  // Sample only a fraction of traces to reduce edge runtime overhead
-  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,14 +2,11 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/react";
 
 Sentry.init({
   dsn: "https://7b10ad6837786c85f4b58112ee8fd516@o4509409853440000.ingest.us.sentry.io/4509409855340544",
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  // Sample only a fraction of traces to reduce server overhead
-  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/react";
 import NextError from "next/error";
 import { useEffect } from "react";
 

--- a/src/app/sentry-example-page/page.tsx
+++ b/src/app/sentry-example-page/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Head from "next/head";
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/react";
 import { useState, useEffect } from "react";
 
 class SentryExampleFrontendError extends Error {
@@ -47,16 +47,14 @@ export default function Page() {
         <button
           type="button"
           onClick={async () => {
-            await Sentry.startSpan({
-              name: 'Example Frontend Span',
-              op: 'test'
-            }, async () => {
-              const res = await fetch("/api/sentry-example-api");
-              if (!res.ok) {
-                setHasSentError(true);
-                throw new SentryExampleFrontendError("This error is raised on the frontend of the example page.");
-              }
-            });
+            const res = await fetch("/api/sentry-example-api");
+            if (!res.ok) {
+              setHasSentError(true);
+              const err = new SentryExampleFrontendError(
+                "This error is raised on the frontend of the example page."
+              );
+              Sentry.captureException(err);
+            }
           }}
         >
           <span>

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -2,15 +2,10 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/browser";
 
 Sentry.init({
   dsn: "https://7b10ad6837786c85f4b58112ee8fd516@o4509409853440000.ingest.us.sentry.io/4509409855340544",
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  // Sample only a fraction of traces to reduce client overhead
-  tracesSampleRate: 0.1,
-
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/nextjs';
+import * as Sentry from '@sentry/react';
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {

--- a/src/pages/_error.jsx
+++ b/src/pages/_error.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/react";
 import Error from "next/error";
 
 const CustomErrorComponent = ({ statusCode }) => <Error statusCode={statusCode} />;


### PR DESCRIPTION
## Summary
- switch to `@sentry/react` and `@sentry/browser`
- drop tracing code from Sentry configs and sample page
- add `@next/bundle-analyzer` integration
- expose `npm run analyze` and document bundle inspection

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842361f8f40832d8f5990f12b1d79a4