### PR TITLE
[CI] Enforce bundle size budget

### DIFF
--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -1,0 +1,19 @@
+name: "Performance Budget"
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check-bundles:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run analyze --if-present
+      - run: npm run check:bundles

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ remains responsive.
 - Import components directly inside the pages that need them instead of in `_app` or root layouts when possible.
 - After making these changes, rebuild the project in production mode and re-run Lighthouse to verify reductions in unused JavaScript.
 
+## Performance Budgets
+
+Continuous integration runs `npm run check:bundles` after building. The script fails the job when any file in `.next/static` exceeds **250 KB**, helping avoid regressions. Run `npm run analyze` locally to open webpack-bundle-analyzer and inspect bundle contents.
+
 ## Intercom Chat Widget
 
 Set `NEXT_PUBLIC_INTERCOM_APP_ID` in your environment to enable the Intercom chat widget. The script loads only when the user clicks the chat button in the footer, minimizing third-party impact. Leave this variable unset to disable the widget entirely.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "gen:previews": "node --experimental-modules scripts/generate-previews.js",
     "extract:i18n": "i18next-parser \"src/**/*.{ts,tsx}\" --config i18next-parser.config.js",
     "seed:reviews": "node scripts/seed-reviews.ts",
-    "generate:doc": "tsx scripts/generate-doc.ts"
+    "generate:doc": "tsx scripts/generate-doc.ts",
+    "check:bundles": "node scripts/check-bundle-size.js"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.6.2",

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_SIZE_KB = 250; // 250 KB per bundle
+
+function walk(dir) {
+  let results = [];
+  const list = fs.readdirSync(dir);
+  list.forEach(function(file) {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+    if (stat && stat.isDirectory()) {
+      results = results.concat(walk(filePath));
+    } else if (file.endsWith('.js')) {
+      results.push({ path: filePath, size: stat.size });
+    }
+  });
+  return results;
+}
+
+const targetDir = path.join('.next', 'static');
+if (!fs.existsSync(targetDir)) {
+  console.error('Build output not found. Run "npm run build" first.');
+  process.exit(1);
+}
+
+const bundles = walk(targetDir);
+let hasError = false;
+for (const b of bundles) {
+  const sizeKb = b.size / 1024;
+  if (sizeKb > MAX_SIZE_KB) {
+    console.error(`Bundle ${b.path} is ${(sizeKb).toFixed(2)} KB - exceeds ${MAX_SIZE_KB} KB`);
+    hasError = true;
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+} else {
+  console.log('All bundles within size budget');
+}


### PR DESCRIPTION
## Summary
- add workflow that checks bundle sizes on CI
- add `check:bundles` script to scan `.next` output
- fail if any bundle exceeds 250 KB
- document performance budgets in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package)*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684237cccd80832d9419eb1c23effdce