### PR TITLE
[Perf] Lazy load widget and defer Sentry init

### DIFF
--- a/src/app/[locale]/widget-demo/page.tsx
+++ b/src/app/[locale]/widget-demo/page.tsx
@@ -1,0 +1,22 @@
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+import { localizations } from '@/lib/localizations';
+
+const MyWidget = dynamic(() => import('@/components/MyWidget.client'), {
+  ssr: false,
+  suspense: true,
+});
+
+export async function generateStaticParams() {
+  return localizations.map((locale) => ({ locale }));
+}
+
+export default function WidgetDemoPage() {
+  return (
+    <main className="container mx-auto py-8">
+      <Suspense fallback={<p>Loading widget...</p>}>
+        <MyWidget />
+      </Suspense>
+    </main>
+  );
+}

--- a/src/app/root-client.tsx
+++ b/src/app/root-client.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '@/lib/i18n';
 import { mark, measure } from '@/utils/performance';
+import { initSentry } from '@/instrumentation-client';
 
 // ✅ Dynamically load DocumentFlow to allow preload
 const DocumentFlow = dynamic(() => import('@/components/DocumentFlow'), {
@@ -29,6 +30,9 @@ export default function RootClient({
     if (typeof DocumentFlow?.preload === 'function') {
       void DocumentFlow.preload();
     }
+
+    // Initialize Sentry after the page becomes interactive
+    initSentry();
     // REMOVED: Problematic line below as StepThreeInput is not defined here.
     // if (typeof window !== 'undefined' && StepThreeInput?.preload) {
     //   void StepThreeInput.preload();

--- a/src/components/MyWidget.client.tsx
+++ b/src/components/MyWidget.client.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+export default function MyWidget() {
+  return (
+    <section className="p-4 border rounded">
+      <h2 className="text-lg font-semibold">My Widget</h2>
+      <p>This widget loads dynamically on the client.</p>
+    </section>
+  );
+}

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -2,12 +2,18 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/browser";
+import * as Sentry from '@sentry/browser';
 
-Sentry.init({
-  dsn: "https://7b10ad6837786c85f4b58112ee8fd516@o4509409853440000.ingest.us.sentry.io/4509409855340544",
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+let hasInit = false;
+
+export function initSentry() {
+  if (hasInit) return;
+  Sentry.init({
+    dsn: 'https://7b10ad6837786c85f4b58112ee8fd516@o4509409853440000.ingest.us.sentry.io/4509409855340544',
+    // Setting this option to true will print useful information to the console while you're setting up Sentry.
+    debug: false,
+  });
+  hasInit = true;
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## Summary
- add a demo MyWidget component for dynamic loading
- load MyWidget with `next/dynamic` inside a Suspense wrapper
- defer Sentry initialization until after the page is interactive

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684237b9edd8832d8593b27105853203