### PR TITLE
[Instrumentation] Lazy load Node-only deps

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,3 +1,8 @@
+// src/instrumentation.ts
+// ─────────────────────────────────────────────────────────────
+// Do NOT import Node-only modules at the top level.
+// Instead, require them inside a function that only runs on the server.
+
 import * as Sentry from '@sentry/react';
 
 export async function register() {
@@ -11,3 +16,20 @@ export async function register() {
 }
 
 export const onRequestError = Sentry.captureRequestError;
+
+// Lazy-load Node-only instrumentation so Turbopack does not attempt to bundle
+// these dependencies for the browser or Edge runtimes.
+export function registerInstrumentation() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+
+  // These requires happen at runtime on the Node server:
+  const { NodeSDK } = require('@opentelemetry/sdk-node');
+  const { FirebasePerformanceInstrumentation } = require('@firebase/performance');
+  const { getFirestore } = require('firebase-admin/firestore');
+
+  const sdk = new NodeSDK({
+    instrumentations: [new FirebasePerformanceInstrumentation()],
+    // …other OpenTelemetry config…
+  });
+  sdk.start();
+}


### PR DESCRIPTION
## Summary
- clarify that instrumentation should lazy-load Node-only modules
- add `registerInstrumentation()` that requires Node modules at runtime

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425702a24c832da6f50b026ba9f1e2