### PR TITLE
[Perf] Dynamically load noncritical widgets

### DIFF
--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -39,7 +39,9 @@ import AutoImage from '@/components/AutoImage';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { useToast } from '@/hooks/use-toast';
-import AuthModal from '@/components/AuthModal';
+import dynamic from 'next/dynamic';
+
+const AuthModal = dynamic(() => import('@/components/AuthModal'));
 import { useAuth } from '@/hooks/useAuth'; // Import useAuth
 import { createSignWellDocument } from '@/services/signwell';
 

--- a/src/components/WizardForm.tsx
+++ b/src/components/WizardForm.tsx
@@ -21,12 +21,14 @@ import FieldRenderer from './FieldRenderer';
 import { Progress } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
 import { prettify } from '@/lib/schema-utils';
-import AuthModal from '@/components/AuthModal';
+import dynamic from 'next/dynamic';
+
+const AuthModal = dynamic(() => import('@/components/AuthModal'));
 import { saveFormProgress } from '@/lib/firestore/saveFormProgress';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import TrustBadges from '@/components/TrustBadges';
 import ReviewStep from '@/components/ReviewStep';
-import PaymentModal from '@/components/PaymentModal';
+const PaymentModal = dynamic(() => import('@/components/PaymentModal'));
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation'; // Added useRouter
 import AddressField from '@/components/AddressField';

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ import { Logo } from '@/components/layout/Logo';
 // pages.
 import Nav from '@/components/Nav';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import dynamic from 'next/dynamic';
 import {
   Popover,
   PopoverContent,
@@ -33,8 +34,9 @@ import {
 import { Input } from '@/components/ui/input';
 import type { LegalDocument } from '@/lib/document-library';
 import { CATEGORY_LIST } from '@/components/Step1DocumentSelector';
-import MegaMenuContent from '@/components/mega-menu/MegaMenuContent';
-import MobileDocsAccordion from '@/components/mobile/MobileDocsAccordion';
+// Load expensive menu components only when needed
+const MegaMenuContent = dynamic(() => import('@/components/mega-menu/MegaMenuContent'));
+const MobileDocsAccordion = dynamic(() => import('@/components/mobile/MobileDocsAccordion'));
 
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';

--- a/src/components/providers/ClientProviders.tsx
+++ b/src/components/providers/ClientProviders.tsx
@@ -18,8 +18,11 @@ interface ClientProvidersProps {
 // This avoids an additional network request on every navigation.
 import Header from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
-import ContactFormButton from '@/components/ContactFormButton';
-import ActivityTicker from '@/components/ActivityTicker';
+import dynamic from 'next/dynamic';
+
+// Load non-critical widgets lazily
+const ContactFormButton = dynamic(() => import('@/components/ContactFormButton'));
+const ActivityTicker = dynamic(() => import('@/components/ActivityTicker'));
 
 const AppShell = React.memo(function AppShell({
   children,


### PR DESCRIPTION
## Summary
- lazy-load ContactFormButton and ActivityTicker in `ClientProviders`
- dynamically load the mega-menu components in `Header`
- lazy load AuthModal and PaymentModal in `WizardForm`
- lazy load AuthModal for SignWell page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842814fdb58832da5869fb9478f9e2f