### PR TITLE
[Build] Enable JS minification

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
   turbopack: {},
   typescript: { ignoreBuildErrors: true },
   eslint: { ignoreDuringBuilds: true },
+  swcMinify: true,
 
   /* —──────── Static-export image handling —──────── */
   images: {


### PR DESCRIPTION
## Summary
- set `swcMinify` in Next.js config to ensure production JavaScript is minimized

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428c2f37c0832da949dc2b220fb9fd