### PR TITLE
[Perf] Lazy load heavy libraries

### DIFF
--- a/src/components/DocPreview.tsx
+++ b/src/components/DocPreview.tsx
@@ -2,7 +2,8 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import dynamic from 'next/dynamic';
+const ReactMarkdown = dynamic(() => import('react-markdown'), { ssr: false });
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next';
 import Image from 'next/image';

--- a/src/components/DocumentPreview.tsx
+++ b/src/components/DocumentPreview.tsx
@@ -2,7 +2,8 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import dynamic from 'next/dynamic';
+const ReactMarkdown = dynamic(() => import('react-markdown'), { ssr: false });
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from 'react-i18next';
 import Image from 'next/image';

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { DayPicker } from 'react-day-picker';
+import dynamic from 'next/dynamic';
+
+const DayPicker = dynamic(
+  () => import('react-day-picker').then((m) => m.DayPicker),
+  { ssr: false },
+);
 
 import { cn } from '@/lib/utils';
 import { buttonVariants } from '@/components/ui/button';


### PR DESCRIPTION
## Summary
- dynamically load `DayPicker` from `react-day-picker`
- dynamically load `ReactMarkdown` in preview components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428b059598832d8d0c82f674b1683c