### PR TITLE
[Docs] Run build and fix duplicate import

### DIFF
--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -39,7 +39,6 @@ import AutoImage from '@/components/AutoImage';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { useToast } from '@/hooks/use-toast';
-import dynamic from 'next/dynamic';
 
 const AuthModal = dynamic(() => import('@/components/AuthModal'));
 import { useAuth } from '@/hooks/useAuth'; // Import useAuth


### PR DESCRIPTION
## Summary
- remove duplicate dynamic import in SignWell client content
- run lint, test, e2e, and build

## Testing
- `npm run lint` *(fails: 36 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842ae54f47c832d9e31a4e92b5a47df