### PR TITLE
[Header] Remove extra desktop nav links

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -46,9 +46,6 @@ const Nav = React.memo(function Nav() {
   const navLinks = [
     { href: '/pricing', labelKey: 'nav.pricing', defaultLabel: 'Pricing' },
     { href: '/features', labelKey: 'nav.features', defaultLabel: 'Features' },
-    { href: '/blog', labelKey: 'nav.blog', defaultLabel: 'Blog' },
-    { href: '/faq', labelKey: 'nav.faq', defaultLabel: 'FAQ' },
-    { href: '/support', labelKey: 'nav.support', defaultLabel: 'Support' },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- simplify desktop nav by removing Blog/FAQ/Support links

## Testing
- `npm run lint` *(fails: unused vars & forbidden require imports in landing components)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844d893fa08832d9b6522e0c5688f0a