### PR TITLE
[UI] Prevent nav overlap in Spanish

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -226,7 +226,7 @@ const Header = React.memo(function Header() {
         {/* Centered Desktop Nav & Actions */}
         <div
           className={cn(
-            'hidden md:flex items-center absolute inset-x-0 justify-center gap-3 md:gap-4 transition-opacity duration-200 ease-in-out',
+            'hidden md:flex items-center flex-1 justify-center gap-3 md:gap-4 transition-opacity duration-200 ease-in-out',
             scrolled && 'opacity-60',
           )}
         >


### PR DESCRIPTION
## Summary
- use flex container for nav group instead of absolute positioning

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844e607f520832d97ab2380ac47d161