### PR TITLE
[Dashboard] Remove unnecessary await

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -13,6 +13,6 @@ interface DashboardPageProps {
 }
 
 export default async function DashboardPage({ params }: DashboardPageProps) {
-  const { locale } = await params;
+  const { locale } = params;
   return <DashboardClientContent locale={locale} />;
 }


### PR DESCRIPTION
## Summary
- remove `await` from dashboard page params

## Testing
- `npm run lint` *(fails: @typescript-eslint issues)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845155ac214832d8d218aa6609a4082