### PR TITLE
[Layout] Remove hero preload links

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,8 +71,6 @@ export default function RootLayout({
           : setup();
       `}
     </Script>,
-    <link key="preload-hero" rel="preload" href="/images/hero-homepage.png" as="image" />,
-    <link key="preload-signwell" rel="preload" href="/images/signwell-hero.svg" as="image" />,
     <link
       key="alt-en"
       rel="alternate"


### PR DESCRIPTION
## Summary
- clean up unused image preloads from the root layout

## Testing
- `npm run lint` *(fails: 37 errors, 6 warnings)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684909dd2e30832d8ca1e397509e860d