### PR TITLE
[Dashboard] Prefetch view pages and lazy load remark-gfm

### DIFF
--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -84,6 +84,13 @@ export default function DashboardClientContent({
     enabled: isHydrated && isLoggedIn && !!user?.uid,
   });
 
+  // Prefetch document view pages after documents load
+  useEffect(() => {
+    documents.forEach((doc) => {
+      router.prefetch(`/${locale}/docs/${doc.docType}/view?docId=${doc.id}`);
+    });
+  }, [documents, router, locale]);
+
   useEffect(() => {
     setIsHydrated(true);
   }, []);

--- a/src/components/DocumentDetail.tsx
+++ b/src/components/DocumentDetail.tsx
@@ -54,12 +54,14 @@ const DocumentDetail = React.memo(function DocumentDetail({
     setIsHydrated(true);
   }, []);
 
-  // Dynamically load remark-gfm so it's only loaded when this component mounts
+  // Dynamically load remark-gfm only when markdown is provided
   useEffect(() => {
-    import('remark-gfm').then((mod) => {
-      setRemarkGfmPlugin(() => mod.default ?? mod);
-    });
-  }, []);
+    if (initialMarkdown) {
+      import('remark-gfm').then((mod) => {
+        setRemarkGfmPlugin(() => mod.default ?? mod);
+      });
+    }
+  }, [initialMarkdown]);
 
   // New useEffect to process initialMarkdown (e.g., title replacement, placeholder replacement)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prefetch document view pages in dashboard for faster loads
- only import remark-gfm when markdown content is provided

## Testing
- `npm run lint` *(fails: no-unused-vars and import style errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68490a901d84832db7bdc7227b6fab24