### PR TITLE
[App] Preload hero images on relevant pages

### DIFF
--- a/src/app/[locale]/signwell/head.tsx
+++ b/src/app/[locale]/signwell/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <link rel="preload" href="/images/signwell-hero.svg" as="image" />
+    </>
+  );
+}

--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -726,6 +726,7 @@ export default function SignWellClientContent({
               alt={t('security.imageAlt')}
               width={400}
               height={300}
+              priority
               className="rounded-lg shadow-xl"
               data-ai-hint="security shield padlock"
             />

--- a/src/app/[locale]/templates/head.tsx
+++ b/src/app/[locale]/templates/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <link rel="preload" href="/images/hero-homepage.png" as="image" />
+    </>
+  );
+}

--- a/src/app/[locale]/templates/templates-client-content.tsx
+++ b/src/app/[locale]/templates/templates-client-content.tsx
@@ -66,6 +66,7 @@ export default function TemplatesClientContent({ locale }: Props) {
           alt="Happy customer"
           width={400}
           height={240}
+          priority
           className="rounded-lg"
         />
       </div>


### PR DESCRIPTION
## Summary
- add page-level `<Head>` to preload the signwell hero image
- add page-level `<Head>` to preload the templates hero image
- mark hero images with `priority` so Next.js preloads them

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68490da45c08832d8bfe2c15597e4562