### PR TITLE
[Auth] Integrate real Firebase auth

### DIFF
--- a/src/app/[locale]/signin/page.tsx
+++ b/src/app/[locale]/signin/page.tsx
@@ -37,17 +37,26 @@ export default function SignInPage() {
     router.prefetch(`/${locale}/dashboard`);
   }, [router, locale]);
 
-  const handleSignIn = (e: React.FormEvent) => {
+  const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
-    // In a real app, you'd validate credentials against a backend
     if (email && password) {
       setIsSubmitting(true);
-      login(email);
-      toast({
-        title: t('Login Successful!'),
-        description: t('Redirecting to your dashboard...'),
-      });
-      router.push(`/${locale}/dashboard`);
+      try {
+        await login(email, password);
+        toast({
+          title: t('Login Successful!'),
+          description: t('Redirecting to your dashboard...'),
+        });
+        router.push(`/${locale}/dashboard`);
+      } catch (err: any) {
+        toast({
+          title: t('Login Failed'),
+          description: err?.message || 'Authentication error',
+          variant: 'destructive',
+        });
+      } finally {
+        setIsSubmitting(false);
+      }
     } else {
       toast({
         title: t('Login Failed'),

--- a/src/app/[locale]/signup/signup-client-content.tsx
+++ b/src/app/[locale]/signup/signup-client-content.tsx
@@ -29,14 +29,14 @@ export default function SignUpClientContent({
 }: SignUpClientContentProps) {
   const { t } = useTranslation('common');
   const router = useRouter();
-  const { login } = useAuth();
+  const { signUp } = useAuth();
   const { toast } = useToast();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  const handleSignUp = (e: React.FormEvent) => {
+  const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
     if (password !== confirmPassword) {
       toast({
@@ -47,12 +47,20 @@ export default function SignUpClientContent({
       return;
     }
     if (email && password) {
-      login(email);
-      toast({
-        title: t('Account Created!'),
-        description: t('Redirecting to your dashboard...'),
-      });
-      router.push(`/${locale}/dashboard`);
+      try {
+        await signUp(email, password);
+        toast({
+          title: t('Account Created!'),
+          description: t('Redirecting to your dashboard...'),
+        });
+        router.push(`/${locale}/dashboard`);
+      } catch (err: any) {
+        toast({
+          title: t('Signup Failed', { defaultValue: 'Signup Failed' }),
+          description: err?.message || 'Authentication error',
+          variant: 'destructive',
+        });
+      }
     } else {
       toast({
         title: t('Signup Failed', { defaultValue: 'Signup Failed' }),

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -140,6 +140,7 @@ export default function AuthModal({
       // update local auth context so the rest of the app knows the user
       await login(
         cred.user.email || '',
+        undefined,
         cred.user.uid,
         cred.user.displayName || undefined,
       );


### PR DESCRIPTION
## Summary
- integrate real Firebase Auth in `useAuth`
- update AuthModal to pass the new args
- switch sign-in and sign-up pages to use Firebase authentication
- wrap dashboard upload in try/catch for better feedback

## Testing
- `npm run lint` *(fails: 39 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848fbfa1e38832dad55ed42819e5df3