### PR TITLE
[Dashboard] Add folder modal

### DIFF
--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import RenameModal from './modals/RenameModal';
+import FolderModal from './modals/FolderModal';
 import ProfileSettings from '@/components/ProfileSettings';
 import {
   FileText,
@@ -267,7 +268,10 @@ export default function DashboardClientContent({
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-            {/* TODO: Folder modal implementation */}
+              <FolderModal
+                open={showFolderModal}
+                onClose={() => setShowFolderModal(false)}
+              />
             </div>
 
             <Table>

--- a/src/app/[locale]/dashboard/modals/FolderModal.tsx
+++ b/src/app/[locale]/dashboard/modals/FolderModal.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { createFolder } from '@/lib/firestore/folderActions';
+import { useAuth } from '@/hooks/useAuth';
+
+interface FolderModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function FolderModal({ open, onClose }: FolderModalProps) {
+  const { t } = useTranslation('common');
+  const { user } = useAuth();
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    if (open) setName('');
+  }, [open]);
+
+  const handleCreate = async () => {
+    if (!user?.uid) return;
+    await createFolder(user.uid, name || t('UntitledFolder', 'Untitled Folder'));
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="sm:max-w-sm bg-card border-border p-6 rounded-lg shadow-xl">
+        <DialogHeader>
+          <DialogTitle>{t('newFolder', 'New Folder')}</DialogTitle>
+          <DialogDescription>
+            {t('enterFolderName', 'Enter a name for your new folder.')}
+          </DialogDescription>
+        </DialogHeader>
+        <Input value={name} onChange={(e) => setName(e.target.value)} />
+        <DialogFooter className="mt-4">
+          <Button variant="outline" onClick={onClose} type="button">
+            {t('cancel', 'Cancel')}
+          </Button>
+          <Button onClick={handleCreate} type="button">
+            {t('create', 'Create')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/firestore/folderActions.ts
+++ b/src/lib/firestore/folderActions.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { getDb } from '@/lib/firebase';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+
+export async function createFolder(userId: string, name: string): Promise<void> {
+  const db = await getDb();
+  await addDoc(collection(db, 'users', userId, 'folders'), {
+    name,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+}


### PR DESCRIPTION
## Summary
- implement FolderModal component
- create Firestore folder actions
- show FolderModal in dashboard when dropdown item is clicked

## Testing
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848fc051124832d911a603fc84ad077