### PR TITLE
[Docs] Redirect doc previews without locale

### DIFF
--- a/src/app/docs/[doc]/view/page.tsx
+++ b/src/app/docs/[doc]/view/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-static';
+
+export default function LegacyDocViewRedirect({
+  params,
+}: {
+  params: { doc: string };
+}) {
+  redirect(`/en/docs/${params.doc}/view`);
+}
+


### PR DESCRIPTION
## Summary
- ensure `/docs/:doc/view` redirects to English path

## Testing
- `npm run lint` *(fails: '@typescript-eslint' errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849110a1da0832da6b3e456c813a7a3