### PR TITLE
[Dashboard] Ensure folder modal closes on error

### DIFF
--- a/src/app/[locale]/dashboard/modals/FolderModal.tsx
+++ b/src/app/[locale]/dashboard/modals/FolderModal.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { createFolder } from '@/lib/firestore/folderActions';
+import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 
 interface FolderModalProps {
@@ -29,10 +30,26 @@ export default function FolderModal({ open, onClose }: FolderModalProps) {
     if (open) setName('');
   }, [open]);
 
+  const { toast } = useToast();
+
   const handleCreate = async () => {
     if (!user?.uid) return;
-    await createFolder(user.uid, name || t('UntitledFolder', 'Untitled Folder'));
-    onClose();
+    try {
+      await createFolder(
+        user.uid,
+        name || t('UntitledFolder', 'Untitled Folder'),
+      );
+      toast({ title: t('Folder created') });
+    } catch (err: any) {
+      console.error('[FolderModal] create folder failed', err);
+      toast({
+        title: t('Error creating folder'),
+        description: err?.message || String(err),
+        variant: 'destructive',
+      });
+    } finally {
+      onClose();
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- handle folder creation errors gracefully and close the modal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: playwright not found)*
- `npm run e2e` *(fails: playwright not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849155d57d4832dac3af945a311970c