### PR TITLE
[Dashboard] Improve duplicate action speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,15 @@ NEXT_PUBLIC_SITE_URL=https://example.com npm run build
 npm start
 ```
 
+
 The site will now be available on `https://localhost:<port>` (or your configured
 domain) and Lighthouse should no longer flag insecure requests.
+
+## Firestore Connectivity
+
+The Firestore client uses gRPC transport by default. If your network blocks
+gRPC, set `NEXT_PUBLIC_FIRESTORE_FORCE_POLLING=true` to fall back to HTTP long
+polling. Polling is slower and should be enabled only when required.
 
 ## Troubleshooting Lighthouse reports
 

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -76,6 +76,7 @@ export default function DashboardClientContent({
   const [sortBy, setSortBy] = useState<'name' | 'date' | 'status'>('name');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
   const [renameDoc, setRenameDoc] = useState<DashboardDocument | null>(null);
+  const [duplicatingDocId, setDuplicatingDocId] = useState<string | null>(null);
 
   const {
     documents,
@@ -349,13 +350,28 @@ export default function DashboardClientContent({
                             {t('Rename')}
                           </DropdownMenuItem>
                           <DropdownMenuItem
+                            disabled={duplicatingDocId === doc.id}
                             onSelect={async () => {
-                              await duplicateDocument(user!.uid, doc.id);
-                              toast({ title: t('Document duplicated') });
-                              queryClient.invalidateQueries({ queryKey: ['dashboardDocuments', user!.uid] });
+                              setDuplicatingDocId(doc.id);
+                              try {
+                                await duplicateDocument(user!.uid, doc.id);
+                                toast({ title: t('Document duplicated') });
+                              } catch {
+                                toast({
+                                  title: t('Error duplicating document'),
+                                  variant: 'destructive',
+                                });
+                              } finally {
+                                setDuplicatingDocId(null);
+                                queryClient.invalidateQueries({ queryKey: ['dashboardDocuments', user!.uid] });
+                              }
                             }}
                           >
-                            {t('Duplicate')}
+                            {duplicatingDocId === doc.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              t('Duplicate')
+                            )}
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             onSelect={async () => {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,6 @@
 // src/lib/firebase.ts
 // -----------------------------------------------------------------------------
-// Firebase bootstrap (client + server safe) with forced HTTP long-polling and error-only logging
+// Firebase bootstrap (client + server safe) with optional HTTP long-polling and error-only logging
 // -----------------------------------------------------------------------------
 
 import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
@@ -66,7 +66,7 @@ export async function getAnalyticsInstance(): Promise<Analytics | null> {
 }
 
 /* ------------------------------------------------------------------ */
-/* Firestore – force HTTP long-polling and show only errors           */
+/* Firestore – optional HTTP long-polling and show only errors        */
 /* ------------------------------------------------------------------ */
 let dbInstance: Firestore | null = null;
 export async function getDb(): Promise<Firestore> {
@@ -76,9 +76,13 @@ export async function getDb(): Promise<Firestore> {
     'firebase/firestore'
   );
 
-  dbInstance = initializeFirestore(app, {
-    experimentalForceLongPolling: true,
-  });
+  const forcePolling =
+    process.env.NEXT_PUBLIC_FIRESTORE_FORCE_POLLING === 'true';
+
+  dbInstance = initializeFirestore(
+    app,
+    forcePolling ? { experimentalForceLongPolling: true } : undefined,
+  );
 
   // Suppress all Firestore logs except errors
   setLogLevel('error');


### PR DESCRIPTION
## Summary
- configure Firestore to use gRPC by default and allow HTTP polling via `NEXT_PUBLIC_FIRESTORE_FORCE_POLLING`
- add docs on the new env var
- show a spinner while duplicating documents

## Testing
- `npm run lint` *(fails: 38 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68491495d0dc832db6cd2b65bbc3cb49