### PR TITLE
[Auth] Forward UID to wizard

### DIFF
--- a/src/app/[locale]/signwell/signwell-client-content.tsx
+++ b/src/app/[locale]/signwell/signwell-client-content.tsx
@@ -339,13 +339,11 @@ export default function SignWellClientContent({
     }
   };
 
-  const onAuthSuccessModal = (mode: 'signin' | 'signup') => {
+  const onAuthSuccessModal = (_uid?: string) => {
     setShowAuthModal(false);
     toast({
       title: t('common:authModal.successTitle', {
-        context: mode,
-        defaultValue:
-          mode === 'signin' ? 'Sign In Successful!' : 'Account Created!',
+        defaultValue: 'Authentication Successful!',
       }),
       description: t('common:authModal.successDescription', {
         defaultValue: 'You can now proceed.',

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -29,7 +29,7 @@ import { app } from '@/lib/firebase'; // your initialized Firebase app
 interface AuthModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAuthSuccess: (_mode: 'signin' | 'signup', _uid: string) => void;
+  onAuthSuccess: (uid?: string) => void;
 }
 
 export default function AuthModal({
@@ -145,8 +145,12 @@ export default function AuthModal({
         cred.user.displayName || undefined,
       );
 
-      // notify parent (WizardForm)
-      onAuthSuccess(authMode, cred.user.uid);
+      // notify parent with UID immediately
+      if (cred.user?.uid) {
+        onAuthSuccess(cred.user.uid);
+      } else {
+        onAuthSuccess();
+      }
     } catch (err: any) {
       console.error('[AuthModal] Firebase Auth error:', err);
       toast({

--- a/src/lib/firestore/saveFormProgress.ts
+++ b/src/lib/firestore/saveFormProgress.ts
@@ -56,16 +56,23 @@ export async function saveFormProgress({
     progressDocId(docType, state || 'NA')
   );
 
-  await setDoc(
-    ref,
-    {
-      docType,
-      state: state || 'NA',
-      formData,
-      updatedAt: serverTimestamp(),
-    },
-    { merge: true }
-  );
+  const payload: Partial<FormProgressDoc> = {
+    docType,
+    state: state || 'NA',
+    updatedAt: serverTimestamp(),
+  };
+  if (Object.keys(formData || {}).length > 0) {
+    payload.formData = formData;
+  }
+
+  console.debug('saveFormProgress payload', {
+    userId,
+    docType,
+    state,
+    keys: Object.keys(formData),
+  });
+
+  await setDoc(ref, payload, { merge: true });
 }
 
 /* ---------- load -------------------------------------------------------- */
@@ -99,7 +106,7 @@ export async function loadFormProgress({
     const snap = await getDoc(ref);
     if (snap.exists()) {
       const data = snap.data() as FormProgressDoc;
-      return data.formData || {};
+      return (data?.formData as Record<string, unknown>) ?? {};
     }
 
     // Fallback to 'NA' if nothing for the specific state
@@ -114,7 +121,7 @@ export async function loadFormProgress({
       const fallbackSnap = await getDoc(fallbackRef);
       if (fallbackSnap.exists()) {
         const fallbackData = fallbackSnap.data() as FormProgressDoc;
-        return fallbackData.formData || {};
+        return (fallbackData?.formData as Record<string, unknown>) ?? {};
       }
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- return the authenticated user ID to calling components
- detach draft saving from redirect and simplify signwell auth modal
- write form draft in background and guard load logic
- log progress payload and merge `formData` when present

## Testing
- `npm run lint` *(fails: 41 errors, 7 warnings)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a8ae170a4832da5eab66413b10c16