### PR TITLE
[Dashboard] Copy form data when duplicating

### DIFF
--- a/src/lib/firestore/documentActions.ts
+++ b/src/lib/firestore/documentActions.ts
@@ -39,9 +39,13 @@ export async function duplicateDocument(
   if (!snap.exists()) return null;
 
   const data = snap.data() as Record<string, unknown>;
+  const answers =
+    (data as Record<string, unknown>)['formData'] ??
+    (data as Record<string, unknown>)['data'];
   const newRef = doc(collection(db, 'users', userId, 'documents'));
   await setDoc(newRef, {
     ...data,
+    ...(answers ? { formData: answers, data: answers } : {}),
     name: `${(data.name as string) || docId} Copy`,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),


### PR DESCRIPTION
## Summary
- ensure duplicateDocument copies stored answers

## Testing
- `npm run lint` *(fails: 41 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a968cac90832d86c56e11d19ccfae