### PR TITLE
[Dashboard] Fix new folder modal closing

### DIFF
--- a/src/app/[locale]/dashboard/modals/FolderModal.tsx
+++ b/src/app/[locale]/dashboard/modals/FolderModal.tsx
@@ -33,7 +33,10 @@ export default function FolderModal({ open, onClose }: FolderModalProps) {
   const { toast } = useToast();
 
   const handleCreate = async () => {
-    if (!user?.uid) return;
+    if (!user?.uid) {
+      onClose();
+      return;
+    }
     try {
       await createFolder(
         user.uid,


### PR DESCRIPTION
## Summary
- close the FolderModal if no user is present before attempting creation

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a96f5f130832dba8d6cc31fa91fc1