### PR TITLE
[Docs] Load correct doc in view and wizard

### DIFF
--- a/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
+++ b/src/app/[locale]/docs/[docId]/start/StartWizardPageClient.tsx
@@ -120,7 +120,9 @@ export default function StartWizardPageClient() {
         setDraftLoaded(true);
       }
     }
-    loadDraft();
+    if (ready) {
+      void loadDraft();
+    }
   }, [
     authIsLoading,
     isLoadingConfig,

--- a/src/app/[locale]/docs/[docId]/view/page.tsx
+++ b/src/app/[locale]/docs/[docId]/view/page.tsx
@@ -21,8 +21,10 @@ interface ViewDocumentPageProps {
 
 export default function ViewDocumentPage({ params }: ViewDocumentPageProps) {
   const { locale, docId } = params;
-  const searchParams = useSearchParams();
-  const savedDocId = searchParams.get('docId');
+  const searchParams   = useSearchParams();
+  /* Dashboard passes ?docId=abc123, but direct navigation (or refresh)
+     gives you only the route param.  */
+  const savedDocId     = searchParams.get('docId') || docId;
   const { isLoggedIn, isLoading: authLoading, user } = useAuth();
   const router = useRouter();
 
@@ -31,8 +33,8 @@ export default function ViewDocumentPage({ params }: ViewDocumentPageProps) {
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
-    const uid = user?.uid; // TODO: use context/hook for userId
-    if (!uid || !savedDocId) return; // TODO: if not logged in, maybe show a different message/CTA
+    const uid = user?.uid;
+    if (!uid || !savedDocId) return;
     let cancelled = false;
     async function fetchContent() {
       setIsLoadingContent(true);


### PR DESCRIPTION
## Summary
- handle `docId` from URL or query string when viewing a document
- only load the draft once translations are ready

## Testing
- `npm run lint` *(fails: 43 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aa1857c60832d8f91aec207b04cf4