### PR TITLE
[Dashboard] Await params and fix footer icons

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -13,6 +13,6 @@ interface DashboardPageProps {
 }
 
 export default async function DashboardPage({ params }: DashboardPageProps) {
-  const { locale } = params;
+  const { locale } = await params;
   return <DashboardClientContent locale={locale} />;
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -279,21 +279,21 @@ export const Footer = React.memo(function Footer() {
             alt="Stripe logo"
             width={80}
             height={24}
-            className="h-6 w-auto"
+            className="h-6 w-20"
           />
           <AutoImage
             src="https://cdn.simpleicons.org/firebase/ffca28"
             alt="Firebase logo"
             width={80}
             height={24}
-            className="h-6 w-auto"
+            className="h-6 w-20"
           />
           <AutoImage
             src="https://cdn.simpleicons.org/paypal/003087"
             alt="PayPal logo"
             width={80}
             height={24}
-            className="h-6 w-auto"
+            className="h-6 w-20"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- await `params` before use in the dashboard page to satisfy Next.js dynamic API requirements
- keep footer payment logos at matching width and height to silence image ratio warnings

## Testing
- `npm run lint` *(fails: 43 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684aa272244c832d93424ee88749fe86