### PR TITLE
[Firebase] Auto-detect long polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ domain) and Lighthouse should no longer flag insecure requests.
 
 ## Firestore Connectivity
 
-The Firestore client uses gRPC transport by default. If your network blocks
-gRPC, set `NEXT_PUBLIC_FIRESTORE_FORCE_POLLING=true` to fall back to HTTP long
-polling. Polling is slower and should be enabled only when required.
+The Firestore client now auto‑detects whether your network supports gRPC. If
+gRPC is blocked, it automatically falls back to HTTP long polling.
+You can still force polling by setting
+`NEXT_PUBLIC_FIRESTORE_FORCE_POLLING=true`, but polling is slower and should be
+enabled only when required.
 
 ## Troubleshooting Lighthouse reports
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -84,9 +84,11 @@ export async function getDb(): Promise<Firestore> {
         If we omit it (i.e. pass `undefined`) the SDK dereferences
         `settings.cacheSizeBytes` and crashes.
      ------------------------------------------------------------- */
+  // Auto-detect whether the network requires long polling. Allow forcing
+  // polling via environment variable when gRPC is blocked.
   const settings = forcePolling
     ? { experimentalForceLongPolling: true }
-    : {};
+    : { experimentalAutoDetectLongPolling: true };
 
   dbInstance = initializeFirestore(app, settings);
 


### PR DESCRIPTION
## Summary
- auto-detect gRPC support when initializing Firestore
- document the automatic fallback in README

## Testing
- `npm run lint` *(fails: 'StepOneExplanation.tsx' unused vars)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aa374b00c832d85d3e4e735f06afe