### PR TITLE
[Dashboard] Avoid fetching offline

### DIFF
--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -8,7 +8,9 @@ export function useDashboardData(
   userId?: string,
   options?: { enabled?: boolean },
 ) {
-  const enabled = options?.enabled ?? !!userId;
+  const isOnline =
+    typeof navigator === 'undefined' ? true : navigator.onLine;
+  const enabled = (options?.enabled ?? !!userId) && isOnline;
 
   const docsQuery = useQuery({
     queryKey: ['dashboardDocuments', userId],


### PR DESCRIPTION
## Summary
- prevent dashboard queries when the browser has no internet connection

## Testing
- `npm run lint` *(fails: 43 errors, 8 warnings)*
- `npm run test`
- `npm run e2e`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684aa3b560b8832d909abc990e5c9f0d