### PR TITLE
[Dashboard] Improve data UX

### DIFF
--- a/src/app/[locale]/dashboard/modals/FolderModal.tsx
+++ b/src/app/[locale]/dashboard/modals/FolderModal.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { createFolder } from '@/lib/firestore/folderActions';
+import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -31,6 +32,7 @@ export default function FolderModal({ open, onClose }: FolderModalProps) {
   }, [open]);
 
   const { toast } = useToast();
+  const queryClient = useQueryClient();
 
   const handleCreate = async () => {
     if (!user?.uid) {
@@ -42,6 +44,9 @@ export default function FolderModal({ open, onClose }: FolderModalProps) {
         user.uid,
         name || t('UntitledFolder', 'Untitled Folder'),
       );
+      queryClient.invalidateQueries({
+        queryKey: ['dashboardDocuments', user.uid],
+      });
       toast({ title: t('Folder created') });
     } catch (err: any) {
       console.error('[FolderModal] create folder failed', err);

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -28,6 +28,7 @@ export function useDashboardData(
     documents: docsQuery.data || [],
     payments: paymentsQuery.data || [],
     isLoading: docsQuery.isLoading || paymentsQuery.isLoading,
+    isFetching: docsQuery.isFetching || paymentsQuery.isFetching,
     error: docsQuery.error || paymentsQuery.error,
   };
 }


### PR DESCRIPTION
## Summary
- add isFetching to `useDashboardData`
- tweak loading states in DashboardClientContent
- invalidate dashboard document queries when creating folders
- optimistically update dashboard data when duplicating or deleting docs

## Testing
- `npm run lint` *(fails: 43 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b38732324832d86eef88bb4122cc6