### PR TITLE
[Dashboard] Stop duplicate spinner sooner

### DIFF
--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -357,6 +357,8 @@ export default function DashboardClientContent({
                                 ...old,
                                 { ...doc, id: tempId, name: `${doc.name} (Copy)` },
                               ]);
+                              // Hide spinner once optimistic update is applied
+                              setDuplicatingDocId(null);
                               try {
                                 await duplicateDocument(user!.uid, doc.id);
                                 toast({ title: t('Document duplicated') });
@@ -367,7 +369,6 @@ export default function DashboardClientContent({
                                   variant: 'destructive',
                                 });
                               } finally {
-                                setDuplicatingDocId(null);
                                 queryClient.invalidateQueries({ queryKey: key });
                               }
                             }}


### PR DESCRIPTION
## Summary
- show duplicate spinner only during optimistic update

## Testing
- `npm run lint` *(fails: 43 errors, 8 warnings)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b661e9c44832db3012683d86a2d33