### PR TITLE
[Docs] Fix view page preview

### DIFF
--- a/functions/gen-preview.ts
+++ b/functions/gen-preview.ts
@@ -14,7 +14,7 @@ export const onDraftWrite = functions.firestore
     const markdown = await renderMarkdown(
       after.docType,
       after.formData,
-      after.state || 'NA'
+      after.locale || 'en'
     );
 
     return change.after.ref.set(

--- a/src/app/[locale]/docs/[docId]/view/page.tsx
+++ b/src/app/[locale]/docs/[docId]/view/page.tsx
@@ -48,6 +48,8 @@ export default function ViewDocumentPage({ params }: ViewDocumentPageProps) {
         }
         const data = snap.data() as Record<string, any>;
         let markdown = data.contentMarkdown as string | undefined;
+        const formData = data.formData ?? data.data;
+        const effectiveDocType = data.docType || data.originalDocId || docId;
 
         // Check for other sources (legacy or alternative storage)
         if (typeof data.markdown === 'string' && !markdown) {
@@ -64,11 +66,11 @@ export default function ViewDocumentPage({ params }: ViewDocumentPageProps) {
         }
 
         // ---------- Fallback: generate from formData on‑the‑fly ----------
-        if (!markdown && data.formData) {
+        if (!markdown && formData) {
           markdown = await renderMarkdown(
-            data.docType,
-            data.formData,
-            data.state ?? 'NA',
+            effectiveDocType,
+            formData,
+            data.state ?? locale,
           );
 
           /*  Optional but highly recommended: write it back so subsequent

--- a/src/lib/markdown-renderer.ts
+++ b/src/lib/markdown-renderer.ts
@@ -6,8 +6,9 @@
 export async function renderMarkdown(
   docType: string,
   formData: Record<string, unknown>,
+  locale: 'en' | 'es' = 'en',
 ): Promise<string> {
-  const templateUrl = `/templates/en/${docType}.md`;
+  const templateUrl = `/templates/${locale}/${docType}.md`;
   let template = '';
   try {
     const res = await fetch(templateUrl);


### PR DESCRIPTION
## Summary
- correctly load saved data on the document view page
- allow renderMarkdown to fetch locale-based templates
- adjust Cloud Function preview generator for locale

## Testing
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b6671b518832db5f539cf77544beb