### PR TITLE
[Dashboard] Improve loading UX

### DIFF
--- a/src/app/[locale]/dashboard/DocumentsSkeleton.tsx
+++ b/src/app/[locale]/dashboard/DocumentsSkeleton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function DocumentsSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Last Modified</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: rows }).map((_, i) => (
+          <TableRow key={i}>
+            <TableCell>
+              <Skeleton className="h-4 w-40" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-24" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-20" />
+            </TableCell>
+            <TableCell></TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -53,6 +53,7 @@ import { getFirestore, doc as firestoreDoc, setDoc, serverTimestamp } from 'fire
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { useDashboardData } from '@/hooks/useDashboardData';
+import { DocumentsSkeleton } from './DocumentsSkeleton';
 import {
   renameDocument,
   duplicateDocument,
@@ -252,8 +253,8 @@ const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
   const renderContent = () => {
     if (!documents.length && isFetchingData) {
       return (
-        <div className="p-6 text-muted-foreground">
-          {t('Loading documents...')}
+        <div className="p-6">
+          <DocumentsSkeleton />
         </div>
       );
     }

--- a/src/lib/firestore/dashboardData.ts
+++ b/src/lib/firestore/dashboardData.ts
@@ -27,11 +27,15 @@ export async function getUserDocuments(
   userId: string,
   max = 20,
 ): Promise<DashboardDocument[]> {
+  const start = Date.now();
   const db = await getDb();
   const col = collection(db, 'users', userId, 'documents');
   // Changed orderBy from 'createdAt' to 'updatedAt'
   const q = query(col, orderBy('updatedAt', 'desc'), limit(max));
   const snap = await getDocs(q);
+  console.info(
+    `[dashboardData] fetched ${snap.size} docs for ${userId} in ${Date.now() - start}ms`,
+  );
   return snap.docs
     .filter((d) => {
       const data = d.data() as { deletedAt?: unknown };
@@ -77,19 +81,27 @@ export async function getUserPayments(
   userId: string,
   max = 20,
 ): Promise<DashboardPayment[]> {
+  const start = Date.now();
   const db = await getDb();
   const col = collection(db, 'users', userId, 'payments');
   const q = query(col, orderBy('date', 'desc'), limit(max));
   const snap = await getDocs(q);
+  console.info(
+    `[dashboardData] fetched ${snap.size} payments for ${userId} in ${Date.now() - start}ms`,
+  );
   return snap.docs.map((d) => d.data() as DashboardPayment);
 }
 
 export async function getUserFolders(
   userId: string,
 ): Promise<DashboardFolder[]> {
+  const start = Date.now();
   const db = await getDb();
   const col = collection(db, 'users', userId, 'folders');
   const q = query(col, orderBy('createdAt', 'asc'));
   const snap = await getDocs(q);
+  console.info(
+    `[dashboardData] fetched ${snap.size} folders for ${userId} in ${Date.now() - start}ms`,
+  );
   return snap.docs.map((d) => ({ id: d.id, name: (d.data().name as string) || d.id }));
 }


### PR DESCRIPTION
## Summary
- add a reusable `DocumentsSkeleton` table
- show skeleton while dashboard documents load
- log Firestore fetch times for dashboard data

## Testing
- `npm run lint` *(fails: 43 errors, 9 warnings)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b7191d6d4832da49346f978695d85