### PR TITLE
[Dashboard] Refresh folder list on creation

### DIFF
--- a/src/app/[locale]/dashboard/modals/FolderModal.tsx
+++ b/src/app/[locale]/dashboard/modals/FolderModal.tsx
@@ -44,8 +44,9 @@ export default function FolderModal({ open, onClose }: FolderModalProps) {
         user.uid,
         name || t('UntitledFolder', 'Untitled Folder'),
       );
+      // Refresh folder list so new folder appears immediately
       queryClient.invalidateQueries({
-        queryKey: ['dashboardDocuments', user.uid],
+        queryKey: ['dashboardFolders', user.uid],
       });
       toast({ title: t('Folder created') });
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- refresh folder query after creating a folder

## Testing
- `npm run lint` *(fails: 43 errors)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b71b13180832da1cc07ef577f4c24