### PR TITLE
[Dashboard] Add bulk document actions

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -423,5 +423,9 @@
   "docDetail.aiHighlightPre": "AI Highlight:",
   "docDetail.keyClauses": "Key clauses",
   "docDetail.aiHighlightPost": "will be automatically tailored.",
-  "docDetail.aiHighlightTitle": "AI Highlight: This section will be auto-customized based on your answers."
+  "docDetail.aiHighlightTitle": "AI Highlight: This section will be auto-customized based on your answers.",
+  "Select all": "Select all",
+  "Select document": "Select document",
+  "Move": "Move",
+  "selected": "selected"
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -423,5 +423,9 @@
   "docDetail.aiHighlightPre": "Resaltado de IA:",
   "docDetail.keyClauses": "Cláusulas clave",
   "docDetail.aiHighlightPost": "se personalizarán automáticamente.",
-  "docDetail.aiHighlightTitle": "Resaltado de IA: esta sección se personalizará automáticamente según tus respuestas."
+  "docDetail.aiHighlightTitle": "Resaltado de IA: esta sección se personalizará automáticamente según tus respuestas.",
+  "Select all": "Seleccionar todo",
+  "Select document": "Seleccionar documento",
+  "Move": "Mover",
+  "selected": "seleccionados"
 }

--- a/src/lib/firestore/documentActions.ts
+++ b/src/lib/firestore/documentActions.ts
@@ -78,3 +78,17 @@ export async function updateDocumentFolder(
   const ref = doc(db, 'users', userId, 'documents', docId);
   await updateDoc(ref, { folderId: folderId || null, updatedAt: serverTimestamp() });
 }
+
+export async function bulkMoveDocuments(
+  userId: string,
+  docIds: string[],
+  folderId: string | null,
+): Promise<void> {
+  const db = await getDb();
+  const batch = (await import('firebase/firestore')).writeBatch(db);
+  for (const id of docIds) {
+    const ref = doc(db, 'users', userId, 'documents', id);
+    batch.update(ref, { folderId: folderId || null, updatedAt: serverTimestamp() });
+  }
+  await batch.commit();
+}


### PR DESCRIPTION
## Summary
- enable batch selection in dashboard
- implement bulk move with Firestore batch
- surface move toolbar when docs are selected
- localize new strings for English and Spanish

## Testing
- `npm run lint` *(fails: 52 problems)*
- `npm run test`
- `npm run e2e`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b7ba653e8832d8f24ccb4aa4d61e4