### PR TITLE
[Dashboard] Prevent duplicate document names

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -427,5 +427,6 @@
   "Select all": "Select all",
   "Select document": "Select document",
   "Move": "Move",
-  "selected": "selected"
+  "selected": "selected",
+  "duplicateNameError": "A document with that name already exists."
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -427,5 +427,6 @@
   "Select all": "Seleccionar todo",
   "Select document": "Seleccionar documento",
   "Move": "Mover",
-  "selected": "seleccionados"
+  "selected": "seleccionados",
+  "duplicateNameError": "Ya existe un documento con ese nombre."
 }

--- a/src/app/[locale]/dashboard/dashboard-client-content.tsx
+++ b/src/app/[locale]/dashboard/dashboard-client-content.tsx
@@ -184,13 +184,14 @@ const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
       });
       toast({ title: t('Document uploaded') });
     setUploadProgress(100);
-  } catch (err: any) {
-    console.error('[dashboard] upload failed', err);
-    toast({
-      title: t('Upload failed'),
-      description: err?.message || String(err),
-      variant: 'destructive',
-    });
+    } catch (err: unknown) {
+      console.error('[dashboard] upload failed', err);
+      const desc = err instanceof Error ? err.message : String(err);
+      toast({
+        title: t('Upload failed'),
+        description: desc,
+        variant: 'destructive',
+      });
   } finally {
     setIsUploading(false);
     if (fileInputRef.current) fileInputRef.current.value = '';
@@ -312,10 +313,10 @@ const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
           } else {
             const dA = (typeof a.date === 'object' && 'toDate' in a.date)
               ? a.date.toDate()
-              : new Date(a.date as any);
+              : new Date(a.date as string);
             const dB = (typeof b.date === 'object' && 'toDate' in b.date)
               ? b.date.toDate()
-              : new Date(b.date as any);
+              : new Date(b.date as string);
             valA = dA.getTime();
             valB = dB.getTime();
           }
@@ -571,9 +572,13 @@ const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
                 try {
                   await renameDocument(user!.uid, renameDoc.id, name);
                   toast({ title: t('Document renamed') });
-                } catch {
+                } catch (err: unknown) {
                   if (previous) queryClient.setQueryData(key, previous);
-                  toast({ title: t('Error renaming document'), variant: 'destructive' });
+                  const message =
+                    err instanceof Error && err.message === 'duplicate-name'
+                      ? t('duplicateNameError')
+                      : t('Error renaming document');
+                  toast({ title: message, variant: 'destructive' });
                 } finally {
                   queryClient.invalidateQueries({ queryKey: key });
                 }

--- a/src/lib/firestore/documentActions.ts
+++ b/src/lib/firestore/documentActions.ts
@@ -8,6 +8,9 @@ import {
   collection,
   doc,
   getDoc,
+  getDocs,
+  query,
+  where,
   setDoc,
   updateDoc,
   serverTimestamp,
@@ -22,6 +25,13 @@ export async function renameDocument(
   name: string,
 ): Promise<void> {
   const db = await getDb();
+  const colRef = collection(db, 'users', userId, 'documents');
+  const q = query(colRef, where('name', '==', name));
+  const snap = await getDocs(q);
+  const exists = snap.docs.some((d) => d.id !== docId && !d.data().deletedAt);
+  if (exists) {
+    throw new Error('duplicate-name');
+  }
   const ref = doc(db, 'users', userId, 'documents', docId);
   await updateDoc(ref, { name, updatedAt: serverTimestamp() });
 }


### PR DESCRIPTION
## Summary
- validate uniqueness in `renameDocument` API
- surface duplicate error in dashboard toast
- add `duplicateNameError` translation

## Testing
- `npm run lint` *(fails: 52 problems)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b8b30528c832d95def0a9eb64b4f8