### PR TITLE
[Dashboard] Fix folder creation UI update

### DIFF
--- a/src/app/[locale]/dashboard/modals/FolderModal.tsx
+++ b/src/app/[locale]/dashboard/modals/FolderModal.tsx
@@ -39,12 +39,16 @@ export default function FolderModal({ open, onClose }: FolderModalProps) {
     const key = ['dashboardFolders', user.uid] as const;
     const tmpId = `tmp-${Date.now()}`;
     const prev = queryClient.getQueryData(key);
+    const folderName = name || t('UntitledFolder', 'Untitled Folder');
     queryClient.setQueryData(key, (old: any = []) => [
       ...old,
-      { id: tmpId, name: name || t('UntitledFolder', 'Untitled Folder') },
+      { id: tmpId, name: folderName },
     ]);
     try {
-      await createFolder(user.uid, name || t('UntitledFolder', 'Untitled Folder'));
+      const newId = await createFolder(user.uid, folderName);
+      queryClient.setQueryData(key, (old: any = []) =>
+        old.map((f: any) => (f.id === tmpId ? { id: newId, name: folderName } : f)),
+      );
       queryClient.invalidateQueries({ queryKey: key });
       toast({ title: t('Folder created') });
     } catch (err: any) {

--- a/src/lib/firestore/folderActions.ts
+++ b/src/lib/firestore/folderActions.ts
@@ -10,13 +10,17 @@ import {
   serverTimestamp,
 } from 'firebase/firestore';
 
-export async function createFolder(userId: string, name: string): Promise<void> {
+export async function createFolder(
+  userId: string,
+  name: string,
+): Promise<string> {
   const db = await getDb();
-  await addDoc(collection(db, 'users', userId, 'folders'), {
+  const docRef = await addDoc(collection(db, 'users', userId, 'folders'), {
     name,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   });
+  return docRef.id;
 }
 
 export interface UserFolder {


### PR DESCRIPTION
## Summary
- return new folder ID from `createFolder`
- update `FolderModal` to optimistically use new folder ID and close dialog

## Testing
- `npm run lint` *(fails: unused vars in unrelated files)*
- `npm run test`
- `npm run e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b9ba2c70c832da920e22acd6e26ab