### PR TITLE
[PDF] Enable coordinate overlay fallback

### DIFF
--- a/src/lib/pdf/pdf-overlay-service.ts
+++ b/src/lib/pdf/pdf-overlay-service.ts
@@ -40,16 +40,15 @@ export async function overlayFormData(
       fields.forEach(field => {
         console.log(`📋 Available field: "${field.getName()}" (${field.constructor.name})`);
       });
-      
+
       return await smartFormFieldMapping(pdfDoc, formData, state);
-    } else {
-      // FALLBACK: No form fields - this is a scanned PDF
-      console.log('⚠️ FALLBACK MODE: No form fields detected - PDF appears to be scanned');
-      console.log('💡 Recommendation: Contact state DMV for fillable version');
-      
-      // Return original PDF with a warning overlay
-      return await addWarningOverlay(pdfDoc, 'Form fields not detected - please fill manually');
     }
+
+    // FALLBACK: No form fields - apply coordinate-based overlay
+    console.log('⚠️ FALLBACK MODE: No form fields detected - attempting coordinate overlay');
+    const overlaid = await coordinateBasedOverlayWithStateMapping(pdfDoc, formData, state);
+
+    return overlaid;
     
   } catch (error) {
     console.error('❌ PDF Overlay Error:', error);


### PR DESCRIPTION
## Summary
- fix overlay service to draw coordinates when PDF lacks form fields

## Testing
- `npm run lint` *(fails: unexpected any and other lint errors)*
- `npm run test` *(fails: tests could not run)*
- `npm run e2e` *(fails: unhandled exceptions during tests)*
- `npm run build` *(fails: test failures in build step)*

------
https://chatgpt.com/codex/tasks/task_e_6858cce0f9cc832da7f03eff22c8deb2