### PR TITLE
[Firebase] Initialize Firestore synchronously

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -5,7 +5,11 @@
 
 import { initializeApp, getApps, getApp, type FirebaseApp } from 'firebase/app';
 import type { Analytics } from 'firebase/analytics';
-import type { Firestore } from 'firebase/firestore';
+import {
+  initializeFirestore,
+  setLogLevel,
+  type Firestore,
+} from 'firebase/firestore';
 
 /* ------------------------------------------------------------------ */
 /* Fallback config (env vars override)                                */
@@ -70,12 +74,8 @@ export async function getAnalyticsInstance(): Promise<Analytics | null> {
 /* Firestore – optional HTTP long-polling and show only errors        */
 /* ------------------------------------------------------------------ */
 let dbInstance: Firestore | null = null;
-export async function getDb(): Promise<Firestore> {
+export function getDb(): Firestore {
   if (dbInstance) return dbInstance;
-
-  const { initializeFirestore, setLogLevel } = await import(
-    'firebase/firestore'
-  );
 
   const forcePolling =
     process.env.NEXT_PUBLIC_FIRESTORE_FORCE_POLLING === 'true';


### PR DESCRIPTION
## Summary
- export a fully initialized Firestore instance

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, etc.)*
- `npm run test` *(fails: TestingLibraryElementError, etc.)*
- `npm run e2e` *(fails: accessibility tests fail)*
- `npm run build` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6858dba9fcec832db85d79851a9696fa