### PR TITLE
[Dashboard] Fix locale param handling

### DIFF
--- a/src/app/[locale]/(app)/dashboard/page.tsx
+++ b/src/app/[locale]/(app)/dashboard/page.tsx
@@ -73,7 +73,7 @@ interface DashboardPageProps {
   };
 }
 
-export default async function DashboardPage({ params }: DashboardPageProps) {
-  const { locale } = await params;
+export default function DashboardPage({ params }: DashboardPageProps) {
+  const { locale } = params;
   return <DashboardClientContent locale={locale} />;
 }


### PR DESCRIPTION
## Summary
- avoid awaiting params in DashboardPage

## Testing
- `npm run lint`
- `npm run test` *(fails: useCommandPalette must be used within a CommandPaletteProvider)*
- `npm run e2e` *(fails: TemplateDetailView tests fail; AddressField place picker not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858dabe7754832db88204ab5e86f995