### PR TITLE
[i18n] Add missing browse documents translation

### DIFF
--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -9,6 +9,7 @@
     "faq": "FAQ",
     "support": "Support",
     "makeDocuments": "Make Documents",
+    "browseDocuments": "Browse Documents",
     "searchPlaceholder": "Search documents...",
     "openMenu": "Open menu",
     "closeMenu": "Close menu",

--- a/public/locales/es/header.json
+++ b/public/locales/es/header.json
@@ -9,6 +9,7 @@
     "faq": "Preguntas Frecuentes",
     "support": "Soporte",
     "makeDocuments": "Crear Documentos",
+    "browseDocuments": "Explorar Documentos",
     "searchPlaceholder": "Buscar documentos...",
     "openMenu": "Abrir menú",
     "closeMenu": "Cerrar menú",


### PR DESCRIPTION
## Summary
- ensure header navigation can translate "Browse Documents" in English and Spanish

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `npm run test` *(fails: TemplateDetailView.test.tsx errors)*
- `npm run e2e` *(fails: Accessibility test and blocked network requests)*
- `npm run build` *(fails: ESLint id-match errors)*

------
https://chatgpt.com/codex/tasks/task_e_685af9555e5c832d89a4f1dff546219e