### PR TITLE
[Blog] Translate search placeholder

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -124,6 +124,7 @@
   "No payment history.": "No payment history.",
   "Loading dashboard data...": "Loading dashboard data...",
   "Search all documents...": "Search all documents...",
+  "Search articles...": "Search articles...",
   "All States": "All States",
   "Please select a state from the filter bar above to see documents.": "Please select a state from the filter bar above to see documents.",
   "disclaimerStep.stepTitle": "Important Disclaimer",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -124,6 +124,7 @@
   "No payment history.": "No hay historial de pagos.",
   "Loading dashboard data...": "Cargando datos del panel...",
   "Search all documents...": "Buscar todos los documentos...",
+  "Search articles...": "Buscar artículos...",
   "All States": "Todos los Estados",
   "Please select a state from the filter bar above to see documents.": "Por favor, selecciona un estado de la barra de filtros de arriba para ver los documentos.",
   "disclaimerStep.stepTitle": "Descargo de Responsabilidad Importante",


### PR DESCRIPTION
## Summary
- add missing translation entry for blog search placeholder
- update Spanish placeholder text

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run test` *(fails: multiple unit test failures)*
- `npm run e2e` *(fails: 1 failing test)*
- `npm run build` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_685afae78dfc832da7a9c52c377c414b