### PR TITLE
[i18n] Translate header labels

### DIFF
--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -29,6 +29,17 @@
     "loading": "Loading popular documents...",
     "exploreAll": "Explore All Categories"
   },
+  "directCategories": {
+    "agreements": "Agreements",
+    "letters": "Letters",
+    "forms": "Forms",
+    "family": "Family",
+    "business": "Business"
+  },
+  "aiFinder": "AI Finder",
+  "search": {
+    "placeholder": "Search documents..."
+  },
   "My Account": "My Account",
   "Logout": "Logout",
   "Sign Up": "Sign Up",

--- a/public/locales/es/header.json
+++ b/public/locales/es/header.json
@@ -29,6 +29,17 @@
     "loading": "Cargando documentos populares...",
     "exploreAll": "Explorar Todas las Categorías"
   },
+  "directCategories": {
+    "agreements": "Acuerdos",
+    "letters": "Cartas",
+    "forms": "Formularios",
+    "family": "Familia",
+    "business": "Negocios"
+  },
+  "aiFinder": "Buscador de IA",
+  "search": {
+    "placeholder": "Buscar documentos..."
+  },
   "My Account": "Mi Cuenta",
   "Logout": "Cerrar Sesión",
   "Sign Up": "Registrarse",

--- a/src/components/layout/Header/DirectCategoryNav.tsx
+++ b/src/components/layout/Header/DirectCategoryNav.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { 
@@ -23,27 +24,27 @@ interface DirectCategoryNavProps {
 const categories = [
   {
     id: 'agreements-contracts',
-    label: 'Agreements',
+    labelKey: 'agreements',
     icon: FileText,
   },
   {
     id: 'letters-notices',
-    label: 'Letters',
+    labelKey: 'letters',
     icon: Mail,
   },
   {
     id: 'forms-authorizations',
-    label: 'Forms',
+    labelKey: 'forms',
     icon: FileCheck,
   },
   {
     id: 'family-personal',
-    label: 'Family',
+    labelKey: 'family',
     icon: Users,
   },
   {
     id: 'business-commercial',
-    label: 'Business',
+    labelKey: 'business',
     icon: Building,
   }
 ];
@@ -54,6 +55,7 @@ export default function DirectCategoryNav({
   onCategorySelect,
   activeCategoryId
 }: DirectCategoryNavProps) {
+  const { t: tHeader } = useTranslation('header');
   if (!mounted) {
     return (
       <div className="flex items-center gap-1">
@@ -86,8 +88,12 @@ export default function DirectCategoryNav({
             aria-expanded={isActive}
           >
             <IconComponent className="h-4 w-4" />
-            <span className="hidden lg:inline">{category.label}</span>
-            <ChevronDown 
+            <span className="hidden lg:inline">
+              {tHeader(`directCategories.${category.labelKey}`, {
+                defaultValue: category.labelKey,
+              })}
+            </span>
+            <ChevronDown
               className={cn(
                 "h-3 w-3 transition-transform duration-200",
                 isActive && "rotate-180"

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -3,6 +3,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { Logo } from '@/components/layout/Logo';
 import LanguageSwitcher from '@/components/shared/navigation/LanguageSwitcher';
 import { useDiscoveryModal } from '@/contexts/DiscoveryModalContext';
@@ -22,6 +23,7 @@ const Header = React.memo(function Header() {
   };
   const clientLocale = params.locale ?? 'en';
   const { setShowDiscoveryModal } = useDiscoveryModal();
+  const { t: tHeader } = useTranslation('header');
 
   // Component state
   const [mounted, setMounted] = useState(false);
@@ -163,7 +165,9 @@ const Header = React.memo(function Header() {
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
               </svg>
-              <span className="hidden lg:inline">AI Finder</span>
+              <span className="hidden lg:inline">
+                {tHeader('aiFinder', { defaultValue: 'AI Finder' })}
+              </span>
               <div className="absolute -top-1 -right-1 w-2 h-2 bg-yellow-400 rounded-full animate-pulse"></div>
             </button>
             <LanguageSwitcher />


### PR DESCRIPTION
## Summary
- add AI Finder and nav category translations for ES
- wire header components to use translation keys

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run test` *(fails: 22 failed, 4 passed)*
- `npm run e2e` *(fails: accessibility tests fail)*
- `npm run build` *(fails: build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_685aff33d7a4832db424f039c534689f