### PR TITLE
[i18n] Translate homepage categories

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -509,6 +509,18 @@
     "riskLiability": "Risk & Liability",
     "family": "Family & Personal",
     "construction": "Construction & Home Improvement",
-    "disputeResolution": "Dispute Resolution"
+    "disputeResolution": "Dispute Resolution",
+    "personalFamily": "Personal & Family",
+    "healthCare": "Health & Care",
+    "businessStartups": "Business & Start-ups",
+    "ipCreative": "IP & Creative Works",
+    "legalProcessDisputes": "Legal Process & Disputes",
+    "constructionTrades": "Construction & Trades",
+    "technologyDigital": "Technology & Digital",
+    "agricultureEnergy": "Agriculture & Energy",
+    "vehiclesEquipment": "Vehicles & Equipment",
+    "generalForms": "General Forms",
+    "ipCreativeWorksMedia": "IP & Creative Works (Media)",
+    "assetsGear": "Assets & Gear"
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -509,6 +509,18 @@
     "riskLiability": "Riesgo y Responsabilidad",
     "family": "Familia y Personal",
     "construction": "Construcción y Mejoras del Hogar",
-    "disputeResolution": "Resolución de Disputas"
+    "disputeResolution": "Resolución de Disputas",
+    "personalFamily": "Personal y Familia",
+    "healthCare": "Salud y Cuidado",
+    "businessStartups": "Negocios y Start-ups",
+    "ipCreative": "PI y Obras Creativas",
+    "legalProcessDisputes": "Proceso Legal y Disputas",
+    "constructionTrades": "Construcción y Oficios",
+    "technologyDigital": "Tecnología y Digital",
+    "agricultureEnergy": "Agricultura y Energía",
+    "vehiclesEquipment": "Vehículos y Equipos",
+    "generalForms": "Formularios Generales",
+    "ipCreativeWorksMedia": "PI y Obras Creativas (Medios)",
+    "assetsGear": "Activos y Equipos"
   }
 }

--- a/src/components/shared/TopDocsChips.tsx
+++ b/src/components/shared/TopDocsChips.tsx
@@ -58,22 +58,102 @@ const TopDocsChips = React.memo(function TopDocsChips() {
   
   // Category display names and icons - using all your categories
   const categoryMeta: Record<string, { label: string; icon: LucideIcon }> = {
-    'real-estate-property': { label: 'Real Estate & Property', icon: Home },
-    'employment-hr': { label: 'Employment & HR', icon: Users },
-    'personal-family': { label: 'Personal & Family', icon: Users },
-    'health-care': { label: 'Health & Care', icon: Users },
-    'finance-lending': { label: 'Finance & Lending', icon: Folder },
-    'business-startups': { label: 'Business & Start-ups', icon: Folder },
-    'ip-creative': { label: 'IP & Creative Works', icon: FileText },
-    'legal-process-disputes': { label: 'Legal Process & Disputes', icon: FileText },
-    'estate-planning': { label: 'Estate Planning', icon: FileText },
-    'construction-trades': { label: 'Construction & Trades', icon: FileText },
-    'technology-digital': { label: 'Technology & Digital', icon: FileText },
-    'agriculture-energy': { label: 'Agriculture & Energy', icon: FileText },
-    'vehicles-equipment': { label: 'Vehicles & Equipment', icon: FileText },
-    'general-forms': { label: 'General Forms', icon: FileText },
-    'ip-creative-works': { label: 'IP & Creative Works (Media)', icon: FileText },
-    'assets-gear': { label: 'Assets & Gear', icon: FileText },
+    'real-estate-property': {
+      label: tCommon('categories.realEstate', {
+        defaultValue: 'Real Estate & Property',
+      }),
+      icon: Home,
+    },
+    'employment-hr': {
+      label: tCommon('categories.employment', {
+        defaultValue: 'Employment & HR',
+      }),
+      icon: Users,
+    },
+    'personal-family': {
+      label: tCommon('categories.personalFamily', {
+        defaultValue: 'Personal & Family',
+      }),
+      icon: Users,
+    },
+    'health-care': {
+      label: tCommon('categories.healthCare', {
+        defaultValue: 'Health & Care',
+      }),
+      icon: Users,
+    },
+    'finance-lending': {
+      label: tCommon('categories.finance', {
+        defaultValue: 'Finance & Lending',
+      }),
+      icon: Folder,
+    },
+    'business-startups': {
+      label: tCommon('categories.businessStartups', {
+        defaultValue: 'Business & Start-ups',
+      }),
+      icon: Folder,
+    },
+    'ip-creative': {
+      label: tCommon('categories.ipCreative', {
+        defaultValue: 'IP & Creative Works',
+      }),
+      icon: FileText,
+    },
+    'legal-process-disputes': {
+      label: tCommon('categories.legalProcessDisputes', {
+        defaultValue: 'Legal Process & Disputes',
+      }),
+      icon: FileText,
+    },
+    'estate-planning': {
+      label: tCommon('categories.estatePlanning', {
+        defaultValue: 'Estate Planning',
+      }),
+      icon: FileText,
+    },
+    'construction-trades': {
+      label: tCommon('categories.constructionTrades', {
+        defaultValue: 'Construction & Trades',
+      }),
+      icon: FileText,
+    },
+    'technology-digital': {
+      label: tCommon('categories.technologyDigital', {
+        defaultValue: 'Technology & Digital',
+      }),
+      icon: FileText,
+    },
+    'agriculture-energy': {
+      label: tCommon('categories.agricultureEnergy', {
+        defaultValue: 'Agriculture & Energy',
+      }),
+      icon: FileText,
+    },
+    'vehicles-equipment': {
+      label: tCommon('categories.vehiclesEquipment', {
+        defaultValue: 'Vehicles & Equipment',
+      }),
+      icon: FileText,
+    },
+    'general-forms': {
+      label: tCommon('categories.generalForms', {
+        defaultValue: 'General Forms',
+      }),
+      icon: FileText,
+    },
+    'ip-creative-works': {
+      label: tCommon('categories.ipCreativeWorksMedia', {
+        defaultValue: 'IP & Creative Works (Media)',
+      }),
+      icon: FileText,
+    },
+    'assets-gear': {
+      label: tCommon('categories.assetsGear', {
+        defaultValue: 'Assets & Gear',
+      }),
+      icon: FileText,
+    },
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- hook up translation keys for categories in TopDocsChips
- add missing category strings in English and Spanish translations

## Testing
- `npm run lint` *(fails: no-implicit-any and other lint errors)*
- `npm run test` *(fails: TestingLibraryElementError)*
- `npm run e2e` *(fails: network errors and aborted)*
- `npm run build` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685afec61b24832db92049a67adc9b38