### PR TITLE
[i18n] Localize AI Finder banner

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -483,6 +483,9 @@
   "Move": "Move",
   "selected": "selected",
   "duplicateNameError": "A document with that name already exists.",
+  "discoveryModal.title": "Find the Right Document for Your Needs",
+  "discoveryModal.quickNoteLabel": "Quick Note:",
+  "discoveryModal.quickNoteMessage": "Effortlessly create essential legal documents with our powerful templates. We provide tools, not legal advice – consult an attorney for personalized guidance.",
   "megaMenu": {
     "title": "Legal Documents",
     "subtitle": "Browse {{count}} professional legal documents",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -483,6 +483,9 @@
   "Move": "Mover",
   "selected": "seleccionados",
   "duplicateNameError": "Ya existe un documento con ese nombre.",
+  "discoveryModal.title": "Encuentra el documento adecuado para tus necesidades",
+  "discoveryModal.quickNoteLabel": "Nota rápida:",
+  "discoveryModal.quickNoteMessage": "Crea fácilmente documentos legales esenciales con nuestras potentes plantillas. Ofrecemos herramientas, no asesoramiento legal: consulta a un abogado para obtener orientación personalizada.",
   "megaMenu": {
     "title": "Documentos Legales",
     "subtitle": "Explora {{count}} documentos legales profesionales",

--- a/src/components/global/DocumentDiscoveryModal.tsx
+++ b/src/components/global/DocumentDiscoveryModal.tsx
@@ -416,7 +416,7 @@ export default function DocumentDiscoveryModal() {
         <DialogHeader>
           <DialogTitle className="text-xl font-bold text-gray-900 flex items-center gap-2">
             <MessageSquare className="h-6 w-6 text-blue-600" />
-            Find the Right Document for Your Needs
+            {t('discoveryModal.title')}
           </DialogTitle>
         </DialogHeader>
         
@@ -425,7 +425,7 @@ export default function DocumentDiscoveryModal() {
           <div className="flex items-center gap-2">
             <FileText className="h-4 w-4 text-blue-600 flex-shrink-0" />
             <p className="text-sm text-blue-800">
-              <span className="font-medium">Quick Note:</span> Effortlessly create essential legal documents with our powerful templates. We provide tools, not legal advice – consult an attorney for personalized guidance.
+              <span className="font-medium">{t('discoveryModal.quickNoteLabel')}</span> {t('discoveryModal.quickNoteMessage')}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add DiscoveryModal i18n keys
- translate Quick Note banner for AI Finder

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run test` *(fails: 22 failed, 4 passed)*
- `npm run e2e` *(fails: accessibility tests failed)*
- `npm run build` *(errors due to invalid next config)*

------
https://chatgpt.com/codex/tasks/task_e_685b0437ae90832d9a3ff6f37f001634