### PR TITLE
[UI] Translate top docs categories

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -322,6 +322,24 @@
   "TopDocsChips.badge.updated": "Updated",
   "TopDocsChips.tooltip.new": "Recently added",
   "TopDocsChips.tooltip.updated": "Recently refreshed",
+  "TopDocsChips.categories": {
+    "realEstateProperty": "Real Estate & Property",
+    "employmentHR": "Employment & HR",
+    "personalFamily": "Personal & Family",
+    "healthCare": "Health & Care",
+    "financeLending": "Finance & Lending",
+    "businessStartups": "Business & Start-ups",
+    "ipCreative": "IP & Creative Works",
+    "legalProcessDisputes": "Legal Process & Disputes",
+    "estatePlanning": "Estate Planning",
+    "constructionTrades": "Construction & Trades",
+    "technologyDigital": "Technology & Digital",
+    "agricultureEnergy": "Agriculture & Energy",
+    "vehiclesEquipment": "Vehicles & Equipment",
+    "generalForms": "General Forms",
+    "ipCreativeWorks": "IP & Creative Works (Media)",
+    "assetsGear": "Assets & Gear"
+  },
   "useCases": {
     "freelancers": {
       "title": "For Freelancers",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -322,6 +322,24 @@
   "TopDocsChips.badge.updated": "Actualizado",
   "TopDocsChips.tooltip.new": "Agregado recientemente",
   "TopDocsChips.tooltip.updated": "Actualizado recientemente",
+  "TopDocsChips.categories": {
+    "realEstateProperty": "Bienes Raíces y Propiedad",
+    "employmentHR": "Empleo y RRHH",
+    "personalFamily": "Personal y Familia",
+    "healthCare": "Salud y Cuidado",
+    "financeLending": "Finanzas y Préstamos",
+    "businessStartups": "Negocios y Startups",
+    "ipCreative": "PI y Obras Creativas",
+    "legalProcessDisputes": "Proceso Legal y Disputas",
+    "estatePlanning": "Planificación Patrimonial",
+    "constructionTrades": "Construcción y Oficios",
+    "technologyDigital": "Tecnología y Digital",
+    "agricultureEnergy": "Agricultura y Energía",
+    "vehiclesEquipment": "Vehículos y Equipos",
+    "generalForms": "Formularios Generales",
+    "ipCreativeWorks": "PI y Obras Creativas (Medios)",
+    "assetsGear": "Bienes y Equipos"
+  },
   "useCases": {
     "freelancers": {
       "title": "Para Freelancers",

--- a/src/components/shared/TopDocsChips.tsx
+++ b/src/components/shared/TopDocsChips.tsx
@@ -57,23 +57,71 @@ const TopDocsChips = React.memo(function TopDocsChips() {
   const allCategories = Object.keys(taxonomy.categories);
   
   // Category display names and icons - using all your categories
-  const categoryMeta: Record<string, { label: string; icon: LucideIcon }> = {
-    'real-estate-property': { label: 'Real Estate & Property', icon: Home },
-    'employment-hr': { label: 'Employment & HR', icon: Users },
-    'personal-family': { label: 'Personal & Family', icon: Users },
-    'health-care': { label: 'Health & Care', icon: Users },
-    'finance-lending': { label: 'Finance & Lending', icon: Folder },
-    'business-startups': { label: 'Business & Start-ups', icon: Folder },
-    'ip-creative': { label: 'IP & Creative Works', icon: FileText },
-    'legal-process-disputes': { label: 'Legal Process & Disputes', icon: FileText },
-    'estate-planning': { label: 'Estate Planning', icon: FileText },
-    'construction-trades': { label: 'Construction & Trades', icon: FileText },
-    'technology-digital': { label: 'Technology & Digital', icon: FileText },
-    'agriculture-energy': { label: 'Agriculture & Energy', icon: FileText },
-    'vehicles-equipment': { label: 'Vehicles & Equipment', icon: FileText },
-    'general-forms': { label: 'General Forms', icon: FileText },
-    'ip-creative-works': { label: 'IP & Creative Works (Media)', icon: FileText },
-    'assets-gear': { label: 'Assets & Gear', icon: FileText },
+  const categoryMeta: Record<string, { labelKey: string; icon: LucideIcon }> = {
+    'real-estate-property': {
+      labelKey: 'TopDocsChips.categories.realEstateProperty',
+      icon: Home,
+    },
+    'employment-hr': {
+      labelKey: 'TopDocsChips.categories.employmentHR',
+      icon: Users,
+    },
+    'personal-family': {
+      labelKey: 'TopDocsChips.categories.personalFamily',
+      icon: Users,
+    },
+    'health-care': {
+      labelKey: 'TopDocsChips.categories.healthCare',
+      icon: Users,
+    },
+    'finance-lending': {
+      labelKey: 'TopDocsChips.categories.financeLending',
+      icon: Folder,
+    },
+    'business-startups': {
+      labelKey: 'TopDocsChips.categories.businessStartups',
+      icon: Folder,
+    },
+    'ip-creative': {
+      labelKey: 'TopDocsChips.categories.ipCreative',
+      icon: FileText,
+    },
+    'legal-process-disputes': {
+      labelKey: 'TopDocsChips.categories.legalProcessDisputes',
+      icon: FileText,
+    },
+    'estate-planning': {
+      labelKey: 'TopDocsChips.categories.estatePlanning',
+      icon: FileText,
+    },
+    'construction-trades': {
+      labelKey: 'TopDocsChips.categories.constructionTrades',
+      icon: FileText,
+    },
+    'technology-digital': {
+      labelKey: 'TopDocsChips.categories.technologyDigital',
+      icon: FileText,
+    },
+    'agriculture-energy': {
+      labelKey: 'TopDocsChips.categories.agricultureEnergy',
+      icon: FileText,
+    },
+    'vehicles-equipment': {
+      labelKey: 'TopDocsChips.categories.vehiclesEquipment',
+      icon: FileText,
+    },
+    'general-forms': {
+      labelKey: 'TopDocsChips.categories.generalForms',
+      icon: FileText,
+    },
+    'ip-creative-works': {
+      labelKey: 'TopDocsChips.categories.ipCreativeWorks',
+      icon: FileText,
+    },
+    'assets-gear': {
+      labelKey: 'TopDocsChips.categories.assetsGear',
+      icon: FileText,
+    },
   };
 
   useEffect(() => {
@@ -89,7 +137,7 @@ const TopDocsChips = React.memo(function TopDocsChips() {
   }, [isHydrated]);
 
   const categories = React.useMemo(
-    () => allCategories.filter(cat => categoryMeta[cat]),
+    () => allCategories.filter((cat) => categoryMeta[cat]),
     [allCategories],
   );
   const isMobile = useIsMobile();
@@ -174,7 +222,9 @@ const TopDocsChips = React.memo(function TopDocsChips() {
                 variant={selectedCategory === cat ? 'default' : 'outline'}
                 onClick={() => setSelectedCategory(cat)}
               >
-                {categoryMeta[cat]?.label || cat}
+                {tCommon(categoryMeta[cat]?.labelKey ?? cat, {
+                  defaultValue: categoryMeta[cat]?.labelKey ?? cat,
+                })}
               </Button>
             ))}
             {isMobile && moreCategories.length > 0 && (
@@ -190,7 +240,9 @@ const TopDocsChips = React.memo(function TopDocsChips() {
                       key={cat}
                       onSelect={() => setSelectedCategory(cat)}
                     >
-                      {categoryMeta[cat]?.label || cat}
+                      {tCommon(categoryMeta[cat]?.labelKey ?? cat, {
+                        defaultValue: categoryMeta[cat]?.labelKey ?? cat,
+                      })}
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuContent>
@@ -201,7 +253,9 @@ const TopDocsChips = React.memo(function TopDocsChips() {
 
         {/* Selected Category Name */}
         <h3 className="text-lg font-medium text-center mb-4 text-foreground">
-          {categoryMeta[selectedCategory]?.label || selectedCategory}
+          {tCommon(categoryMeta[selectedCategory]?.labelKey ?? selectedCategory, {
+            defaultValue: categoryMeta[selectedCategory]?.labelKey ?? selectedCategory,
+          })}
         </h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {filteredDocs.map((doc) => {


### PR DESCRIPTION
## Summary
- add TopDocsChips category translations for English and Spanish
- use translation keys when rendering top document category labels

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm run test` *(fails: test suite errors)*
- `npm run e2e` *(fails: test execution errors)*
- `npm run build` *(fails: build failed)*

------
https://chatgpt.com/codex/tasks/task_e_685affa72bd0832d895f1ce2d8e4aac6