### PR TITLE
[Search] Improve discovery search with synonyms

### DIFF
--- a/src/config/taxonomy.ts
+++ b/src/config/taxonomy.ts
@@ -870,6 +870,16 @@ export const taxonomy = {
     contract: ['agreement', 'document', 'form'],
     divorce: ['separation', 'dissolution'],
     freelance: ['independent-contractor', '1099', 'consultant'],
+    'buy car': ['vehicle-bill-of-sale'],
+    'buy a car': ['vehicle-bill-of-sale'],
+    'car purchase': ['vehicle-bill-of-sale'],
+    'vehicle purchase': ['vehicle-bill-of-sale'],
+    'buy house': ['real-estate-purchase-agreement', 'property-deed'],
+    'buy a house': ['real-estate-purchase-agreement', 'property-deed'],
+    'house purchase': ['real-estate-purchase-agreement', 'property-deed'],
+    'home purchase': ['real-estate-purchase-agreement'],
+    'buy home': ['real-estate-purchase-agreement'],
+    'get a divorce': ['divorce-settlement-agreement', 'marriage-separation-agreement'],
   },
   roles: {
     landlord: {


### PR DESCRIPTION
## Summary
- expand taxonomy synonyms for common queries
- upgrade `SemanticAnalysisEngine` to use all documents, synonym expansion and keyword paths

## Testing
- `npm run lint` *(fails: 6770 problems)*
- `npm run test` *(fails: TypeError: revenueSystem.setupCreatorAccount is not a function)*
- `npm run e2e` *(fails due to invalid next.config options and blocked network requests)*
- `npm run build` *(fails during tests)*

------
https://chatgpt.com/codex/tasks/task_e_685c2c303234832da86d4a316e0e576a