### PR TITLE
[Lib] Enhance semantic search indexing

### DIFF
--- a/src/lib/__tests__/semantic-analysis-engine.test.ts
+++ b/src/lib/__tests__/semantic-analysis-engine.test.ts
@@ -1,0 +1,17 @@
+import { SemanticAnalysisEngine } from '../semantic-analysis-engine';
+
+describe('SemanticAnalysisEngine', () => {
+  const engine = new SemanticAnalysisEngine();
+
+  it('finds divorce settlement agreement for "divorce" query', () => {
+    const results = engine.analyze('divorce', { locale: 'en', maxResults: 5 });
+    const ids = results.map(r => r.doc.id);
+    expect(ids).toContain('divorce-settlement-agreement');
+  });
+
+  it('finds vehicle bill of sale for "buy a car" query', () => {
+    const results = engine.analyze('buy a car', { locale: 'en', maxResults: 5 });
+    const ids = results.map(r => r.doc.id);
+    expect(ids).toContain('vehicle-bill-of-sale');
+  });
+});


### PR DESCRIPTION
## Summary
- improve Fuse.js index to allow localized text search
- add unit tests for common queries

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm run test` *(fails: 23 failed, 4 passed)*
- `npm run e2e` *(fails due to blocked network requests)*
- `npm run build` *(incomplete; build warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685c2af68f88832d8397d5bf9d13dee1