### PR TITLE
[Utils] Add discovery results ranking

### DIFF
--- a/src/utils/__tests__/rankDiscoveryResults.test.ts
+++ b/src/utils/__tests__/rankDiscoveryResults.test.ts
@@ -1,0 +1,34 @@
+import { rank, type RawHit } from '../rankDiscoveryResults';
+
+describe('rankDiscoveryResults', () => {
+  it('orders results by descending score', () => {
+    const hits: RawHit[] = [
+      { id: 'doc1', keywordsHit: new Set(['a', 'b']), source: 'keyword' },
+      { id: 'doc1', keywordsHit: new Set(['c']), source: 'synonym' },
+      { id: 'doc2', keywordsHit: new Set(['a']), source: 'keyword' },
+      { id: 'doc3', keywordsHit: new Set(['d']), source: 'synonym' },
+      { id: 'doc4', keywordsHit: new Set(['a']), source: 'keyword' },
+      { id: 'doc4', keywordsHit: new Set(['e']), source: 'synonym' },
+    ];
+
+    const results = rank(hits);
+    expect(results.map(r => r.id)).toEqual(['doc1', 'doc4', 'doc2', 'doc3']);
+    const scores = Object.fromEntries(results.map(r => [r.id, r.score]));
+    expect(scores['doc1']).toBe(5);
+    expect(scores['doc4']).toBe(3);
+    expect(scores['doc2']).toBe(2);
+    expect(scores['doc3']).toBe(1);
+  });
+
+  it('breaks ties alphabetically by id', () => {
+    const hits: RawHit[] = [
+      { id: 'b', keywordsHit: new Set(['x', 'y']), source: 'synonym' },
+      { id: 'a', keywordsHit: new Set(['z']), source: 'keyword' },
+    ];
+
+    const results = rank(hits);
+    expect(results.map(r => r.id)).toEqual(['a', 'b']);
+    expect(results[0].score).toBe(2);
+    expect(results[1].score).toBe(2);
+  });
+});

--- a/src/utils/rankDiscoveryResults.ts
+++ b/src/utils/rankDiscoveryResults.ts
@@ -1,0 +1,36 @@
+export interface RawHit {
+  id: string;
+  keywordsHit: Set<string>;
+  source: 'keyword' | 'synonym';
+}
+
+export interface DiscoveryResult {
+  id: string;
+  score: number;
+  keywordsHit: string[];
+}
+
+export function rank(rawHits: RawHit[]): DiscoveryResult[] {
+  const grouped = new Map<string, { keywordHits: Set<string>; synonymHits: Set<string> }>();
+
+  for (const hit of rawHits) {
+    if (!grouped.has(hit.id)) {
+      grouped.set(hit.id, { keywordHits: new Set(), synonymHits: new Set() });
+    }
+    const entry = grouped.get(hit.id)!;
+    const targetSet = hit.source === 'keyword' ? entry.keywordHits : entry.synonymHits;
+    hit.keywordsHit.forEach(k => targetSet.add(k));
+  }
+
+  const results: DiscoveryResult[] = [];
+
+  for (const [id, { keywordHits, synonymHits }] of grouped) {
+    const hitsFromOriginalTokens = keywordHits.size;
+    const hitsFromSynonyms = synonymHits.size;
+    const score = hitsFromOriginalTokens * 2 + hitsFromSynonyms;
+    const allHits = new Set([...keywordHits, ...synonymHits]);
+    results.push({ id, score, keywordsHit: Array.from(allHits) });
+  }
+
+  return results.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+}


### PR DESCRIPTION
## Summary
- implement `rank` utility for discovery results
- add Jest tests for ranking order and tie-breaking

## Testing
- `npm run lint` *(fails: 6770 problems)*
- `npm run test` *(failed to finish)*
- `npm run e2e` *(failed: webserver exited early)*
- `npm run build` *(failed: invalid Next.js config)*

------
https://chatgpt.com/codex/tasks/task_e_685c392084b0832da0b929b94b6db3c7